### PR TITLE
feat: add support for batching transactions in a userop

### DIFF
--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -15,6 +15,7 @@ import type {
   SupportedTransports,
 } from "../client/types.js";
 import type { ISmartContractAccount } from "./types.js";
+import type { BatchUserOperationCallData } from "../types.js";
 
 export interface BaseSmartAccountParams<
   TTransport extends SupportedTransports = Transport
@@ -68,6 +69,12 @@ export abstract class BaseSmartContractAccount<
   ): Promise<`0x${string}`>;
   abstract signMessage(msg: string | Uint8Array): Promise<`0x${string}`>;
   protected abstract getAccountInitCode(): Promise<`0x${string}`>;
+
+  async encodeBatchExecute(
+    _txs: BatchUserOperationCallData
+  ): Promise<`0x${string}`> {
+    throw new Error("encodeBatchExecute not supported");
+  }
 
   async getNonce(): Promise<bigint> {
     if (!this.isDeployed) {

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -9,6 +9,7 @@ import {
 } from "viem";
 import { SimpleAccountAbi } from "../abis/SimpleAccountAbi.js";
 import { SimpleAccountFactoryAbi } from "../abis/SimpleAccountFactoryAbi.js";
+import type { BatchUserOperationCallData } from "../types.js";
 import {
   BaseSmartContractAccount,
   type BaseSmartAccountParams,
@@ -55,6 +56,26 @@ export class SimpleSmartContractAccount<
       abi: SimpleAccountAbi,
       functionName: "execute",
       args: [target, value, data],
+    });
+  }
+
+  override async encodeBatchExecute(
+    _txs: BatchUserOperationCallData
+  ): Promise<`0x${string}`> {
+    const [targets, datas] = _txs.reduce(
+      (accum, curr) => {
+        accum[0].push(curr.target);
+        accum[1].push(curr.data);
+
+        return accum;
+      },
+      [[], []] as [Address[], Hex[]]
+    );
+
+    return encodeFunctionData({
+      abi: SimpleAccountAbi,
+      functionName: "executeBatch",
+      args: [targets, datas],
     });
   }
 

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -1,5 +1,6 @@
 import type { Address } from "abitype";
 import type { Hex } from "viem";
+import type { BatchUserOperationCallData } from "../types";
 
 export interface ISmartContractAccount {
   /**
@@ -23,6 +24,14 @@ export interface ISmartContractAccount {
    * @param data - the call data or "0x" if empty
    */
   encodeExecute(target: string, value: bigint, data: string): Promise<Hex>;
+
+  /**
+   * Encodes a batch of transactions to the account's batch execute function.
+   * NOTE: not all accounts support batching.
+   * @param txs - An Array of objects containing the target, value, and data for each transaction
+   * @returns the encoded callData for a UserOperation
+   */
+  encodeBatchExecute(txs: BatchUserOperationCallData): Promise<Hex>;
 
   /**
    * @returns the nonce of the account

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -5,7 +5,12 @@ import type {
   PublicErc4337Client,
   SupportedTransports,
 } from "../client/types.js";
-import type { UserOperationRequest, UserOperationStruct } from "../types.js";
+import type {
+  BatchUserOperationCallData,
+  UserOperationCallData,
+  UserOperationRequest,
+  UserOperationStruct,
+} from "../types.js";
 
 export type SendUserOperationResult = {
   hash: string;
@@ -53,15 +58,11 @@ export interface ISmartAccountProvider<
    * 3. feeDataGetter -- sets maxfeePerGas and maxPriorityFeePerGas
    * 4. paymasterMiddleware -- used to set paymasterAndData. (default: "0x")
    *
-   * @param target - the address receiving the call data
-   * @param data - the call data or "0x" if empty
-   * @param value - optionally the amount of native token to send
+   * @param data - either {@link UserOperationCallData} or {@link BatchUserOperationCallData}
    * @returns - {@link SendUserOperationResult} containing the hash and request
    */
   sendUserOperation: (
-    target: string,
-    data: string,
-    value?: bigint
+    data: UserOperationCallData | BatchUserOperationCallData
   ) => Promise<SendUserOperationResult>;
 
   /**
@@ -73,6 +74,18 @@ export interface ISmartAccountProvider<
    * @returns the transaction hash
    */
   sendTransaction: (request: RpcTransactionRequest) => Promise<Hash>;
+
+  /**
+   * This takes a set of  ethereum transactions and converts them into one UserOperation, sends the UserOperation, and waits
+   * on the receipt of that UserOperation (ie. has it been mined). If you don't want to wait for the UserOperation
+   * to mine, it's recommended to user {@link sendUserOperation} instead.
+   *
+   * NOTE: the account you're sending the transactions to MUST support batch transactions.
+   *
+   * @param request - a {@link RpcTransactionRequest} Array representing a traditional ethereum transaction
+   * @returns the transaction hash
+   */
+  sendTransactions: (request: RpcTransactionRequest[]) => Promise<Hash>;
 
   /**
    * EIP-1193 compliant request method

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,17 @@ export type PromiseOrValue<T> = T | Promise<T>;
 export type BigNumberish = string | bigint | number;
 export type BytesLike = Uint8Array | string;
 
+export interface UserOperationCallData {
+  /* the target of the call */
+  target: Address;
+  /* the data passed to the target */
+  data: Hex;
+  /* the amount of native token to send to the target (default: 0) */
+  value?: bigint;
+}
+
+export type BatchUserOperationCallData = UserOperationCallData[];
+
 // represents the request as it needs to be formatted for RPC requests
 export interface UserOperationRequest {
   /* the origin of the request */

--- a/packages/ethers/src/__tests__/simple-account.test.ts
+++ b/packages/ethers/src/__tests__/simple-account.test.ts
@@ -43,11 +43,10 @@ describe("Simple Account Tests", async () => {
   });
 
   it("should execute successfully", async () => {
-    const result = signer.sendUserOperation(
-      await signer.getAddress(),
-      "0x",
-      0n
-    );
+    const result = signer.sendUserOperation({
+      target: (await signer.getAddress()) as `0x${string}`,
+      data: "0x",
+    });
 
     await expect(result).resolves.not.toThrowError();
   });
@@ -79,11 +78,10 @@ describe("Simple Account Tests", async () => {
         })
     );
 
-    const result = signer.sendUserOperation(
-      await signer.getAddress(),
-      "0x",
-      0n
-    );
+    const result = signer.sendUserOperation({
+      target: (await signer.getAddress()) as `0x${string}`,
+      data: "0x",
+    });
 
     await expect(result).rejects.toThrowError();
   });
@@ -101,11 +99,10 @@ describe("Simple Account Tests", async () => {
       })
     );
 
-    const result = signer.sendUserOperation(
-      await signer.getAddress(),
-      "0x",
-      0n
-    );
+    const result = signer.sendUserOperation({
+      target: (await signer.getAddress()) as `0x${string}`,
+      data: "0x",
+    });
 
     await expect(result).resolves.not.toThrowError();
   }, 10000);

--- a/packages/ethers/src/account-signer.ts
+++ b/packages/ethers/src/account-signer.ts
@@ -1,7 +1,9 @@
 import {
   BaseSmartContractAccount,
   resolveProperties,
-  type AccountMiddlewareFn,
+  type FeeDataMiddleware,
+  type GasEstimatorMiddleware,
+  type PaymasterAndDataMiddleware,
   type PublicErc4337Client,
 } from "@alchemy/aa-core";
 import { Signer } from "@ethersproject/abstract-signer";
@@ -54,20 +56,20 @@ export class AccountSigner extends Signer {
     return this.account.signMessage(message);
   }
 
-  withPaymasterMiddleware: (overrides: {
-    dummyPaymasterMiddleware: AccountMiddlewareFn;
-    getPaymasterAndDataMiddleware: AccountMiddlewareFn;
-  }) => this = (overrides) => {
+  withPaymasterMiddleware = (overrides: {
+    dummyPaymasterDataMiddleware?: PaymasterAndDataMiddleware;
+    paymasterDataMiddleware?: PaymasterAndDataMiddleware;
+  }): this => {
     this.provider.withPaymasterMiddleware(overrides);
     return this;
   };
 
-  withGasEstimator: (override: AccountMiddlewareFn) => this = (override) => {
+  withGasEstimator = (override: GasEstimatorMiddleware): this => {
     this.provider.withGasEstimator(override);
     return this;
   };
 
-  withFeeDataGetter: (override: AccountMiddlewareFn) => this = (override) => {
+  withFeeDataGetter = (override: FeeDataMiddleware): this => {
     this.provider.withFeeDataGetter(override);
     return this;
   };

--- a/packages/ethers/src/provider-adapter.ts
+++ b/packages/ethers/src/provider-adapter.ts
@@ -2,10 +2,12 @@ import {
   BaseSmartContractAccount,
   SmartAccountProvider,
   getChain,
-  type AccountMiddlewareFn,
   type Address,
   type HttpTransport,
   type PublicErc4337Client,
+  type PaymasterAndDataMiddleware,
+  type FeeDataMiddleware,
+  type GasEstimatorMiddleware,
 } from "@alchemy/aa-core";
 import { defineReadOnly } from "@ethersproject/properties";
 import { JsonRpcProvider } from "@ethersproject/providers";
@@ -56,20 +58,20 @@ export class EthersProviderAdapter extends JsonRpcProvider {
     return new AccountSigner(this);
   }
 
-  withPaymasterMiddleware: (overrides: {
-    dummyPaymasterMiddleware: AccountMiddlewareFn;
-    getPaymasterAndDataMiddleware: AccountMiddlewareFn;
-  }) => this = (overrides) => {
+  withPaymasterMiddleware = (overrides: {
+    dummyPaymasterDataMiddleware?: PaymasterAndDataMiddleware;
+    paymasterDataMiddleware?: PaymasterAndDataMiddleware;
+  }): this => {
     this.accountProvider.withPaymasterMiddleware(overrides);
     return this;
   };
 
-  withGasEstimator: (override: AccountMiddlewareFn) => this = (override) => {
+  withGasEstimator = (override: GasEstimatorMiddleware): this => {
     this.accountProvider.withGasEstimator(override);
     return this;
   };
 
-  withFeeDataGetter: (override: AccountMiddlewareFn) => this = (override) => {
+  withFeeDataGetter = (override: FeeDataMiddleware): this => {
     this.accountProvider.withFeeDataGetter(override);
     return this;
   };


### PR DESCRIPTION
This PR adds support for batching TXs in a UserOp.

This is a breaking change for existing users because it changes the typing on `sendUserOperation` to accept a typed object for the callData or an Array of that object.
Also adds a method for `sendTransactions` similar to the `sendTransaction` method which accepts a Transaction object instead of a UO.

In the next PR (once the rest of this stack is approved), I'll update the README to include the new usage.

addresses: https://github.com/alchemyplatform/aa-sdk/issues/5
