### PR TITLE
chore: update to latest version of viem and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Alchemy's Account Abstraction Kit is an SDK that enables easy interactions with 
 via `yarn`:
 
 ```bash
-yarn add @alchemy/aa-core
+yarn add @alchemy/aa-core viem
 ```
 
 via `npm`:
 
 ```bash
-npm i -s @alchemy/aa-core
+npm i -s @alchemy/aa-core viem
 ```
 
-If you are using `ethers` and want to use an `ethers` compatible `Provider` and `Signer` you can also add the the `@alchemy/aa-ethers` library.
+If you are using `ethers` and want to use an `ethers` compatible `Provider` and `Signer` you can also add the the `@alchemy/aa-ethers` library (the above packages are required still).
 
 via `yarn`:
 
@@ -82,11 +82,11 @@ const provider = new SmartAccountProvider(
 );
 
 // 3. send a UserOperation
-const { hash } = provider.sendUserOperation(
-  "0xTargetAddress",
-  "0xcallData",
-  0n // value: bigint or undefined
-);
+const { hash } = provider.sendUserOperation({
+  target: "0xTargetAddress",
+  data: "0xcallData",
+  value: 0n, // value: bigint or undefined
+});
 ```
 
 ### via `aa-ethers`
@@ -132,11 +132,11 @@ const signer = EthersProviderAdapter.fromEthersProvider(
 );
 
 // 3. send a user op
-const { hash } = signer.sendUserOperation(
-  "0xTargetAddress",
-  "0xcallData",
-  0n // value: bigint or undefined
-);
+const { hash } = signer.sendUserOperation({
+  target: "0xTargetAddress",
+  data: "0xcallData",
+  value: 0n, // value: bigint or undefined
+});
 ```
 
 ## Components

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,11 +46,14 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
     "typescript-template": "*",
+    "viem": "^0.3.50",
     "vitest": "^0.31.0"
   },
   "dependencies": {
-    "abitype": "^0.8.3",
-    "viem": "0.3.17"
+    "abitype": "^0.8.3"
+  },
+  "peerDependencies": {
+    "viem": "^0.3.50"
   },
   "repository": {
     "type": "git",

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -41,14 +41,17 @@
     "test:run": "vitest run"
   },
   "devDependencies": {
+    "@alchemy/aa-core": "^0.1.0-alpha.1",
     "alchemy-sdk": "^2.8.3",
     "dotenv": "^16.0.3",
     "typescript": "^5.0.4",
     "typescript-template": "*",
     "vitest": "^0.31.0"
   },
+  "peerDependencies": {
+    "@alchemy/aa-core": "^0.1.0-alpha.1"
+  },
   "dependencies": {
-    "@alchemy/aa-core": "^0.1.0-alpha.1",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,17 +1897,10 @@
   dependencies:
     eslint-scope "5.1.1"
 
-"@noble/curves@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-0.9.0.tgz#d59713ecbb6a77381de84fb8969381fa85a7380b"
-  integrity sha512-OAdtHMXBp7Chl2lcTn/i7vnFX/q+hhTwDnek5NfYfZsY4LyaUuHCcoq2JlLY3BTFTLT+ZhYZalhF6ejlV7KnJQ==
-  dependencies:
-    "@noble/hashes" "1.3.0"
-
-"@noble/curves@~0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-0.8.3.tgz#ad6d48baf2599cf1d58dcb734c14d5225c8996e0"
-  integrity sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==
+"@noble/curves@1.0.0", "@noble/curves@~1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.0.0.tgz#e40be8c7daf088aaf291887cbc73f43464a92932"
+  integrity sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==
   dependencies:
     "@noble/hashes" "1.3.0"
 
@@ -2332,12 +2325,12 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
   integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
-"@scure/bip32@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.2.0.tgz#35692d8f8cc3207200239fc119f9e038e5f465df"
-  integrity sha512-O+vT/hBVk+ag2i6j2CDemwd1E1MtGt+7O1KzrPNsaNvSsiEK55MyPIxJIMI2PS8Ijj464B2VbQlpRoQXxw1uHg==
+"@scure/bip32@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.0.tgz#6c8d980ef3f290987736acd0ee2e0f0d50068d87"
+  integrity sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==
   dependencies:
-    "@noble/curves" "~0.8.3"
+    "@noble/curves" "~1.0.0"
     "@noble/hashes" "~1.3.0"
     "@scure/base" "~1.1.0"
 
@@ -2584,10 +2577,10 @@
     loupe "^2.3.6"
     pretty-format "^27.5.1"
 
-"@wagmi/chains@0.2.16":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-0.2.16.tgz#a726716e4619ec1c192b312e23f9c38407617aa0"
-  integrity sha512-rkWaI2PxCnbD8G07ZZff5QXftnSkYL0h5f4DkHCG3fGYYr/ZDvmCL4bMae7j7A9sAif1csPPBmbCzHp3R5ogCQ==
+"@wagmi/chains@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-1.0.0.tgz#41710941f2c2a699a246c4e3a6112b4efd996171"
+  integrity sha512-eNbqRWyHbivcMNq5tbXJks4NaOzVLHnNQauHPeE/EDT9AlpqzcrMc+v2T1/2Iw8zN4zgqB86NCsxeJHJs7+xng==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -2627,10 +2620,10 @@ abbrev@^2.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
   integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
 
-abitype@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.7.1.tgz#16db20abe67de80f6183cf75f3de1ff86453b745"
-  integrity sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==
+abitype@0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.8.7.tgz#e4b3f051febd08111f486c0cc6a98fa72d033622"
+  integrity sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==
 
 abitype@^0.8.3:
   version "0.8.3"
@@ -8611,18 +8604,18 @@ validate-npm-package-name@^5.0.0:
   dependencies:
     builtins "^5.0.0"
 
-viem@0.3.17:
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-0.3.17.tgz#2f4d01c5988f2a90ef52acb84a0dc9f7c2822538"
-  integrity sha512-WGJQ3rV2gMiHgwxLqeAZQ3HetSfsrkF//WezdJPnwUNXuic/c2jjB3MBk4XfYvuRUMccPfc37ORi03AmQxjscg==
+viem@^0.3.50:
+  version "0.3.50"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-0.3.50.tgz#999a7682eda7eabc48c923f4b9923c3f098fc1ab"
+  integrity sha512-s+LxCYZTR9F/qPk1/n1YDVAX9vSeVz7GraqBZWGrDuenCJxo9ArCoIceJ6ksI0WwSeNzcZ0VVbD/kWRzTxkipw==
   dependencies:
     "@adraffy/ens-normalize" "1.9.0"
-    "@noble/curves" "0.9.0"
+    "@noble/curves" "1.0.0"
     "@noble/hashes" "1.3.0"
-    "@scure/bip32" "1.2.0"
+    "@scure/bip32" "1.3.0"
     "@scure/bip39" "1.2.0"
-    "@wagmi/chains" "0.2.16"
-    abitype "0.7.1"
+    "@wagmi/chains" "1.0.0"
+    abitype "0.8.7"
     isomorphic-ws "5.0.0"
     ws "8.12.0"
 


### PR DESCRIPTION
This updates to the latest version of viem and updates the README to fix an error in the `sendUserOperation` example call.

- A breaking change was introduced in the last merge and was not reflected in the README properly. (See https://github.com/alchemyplatform/aa-sdk/issues/15)

- I made viem a peerDependency so that the library can use the users local viem. This way, users don't need to wait for us to merge changes if they want to use the latest viem version
