### PR TITLE
fix: arbitrum min fee per bid needs to be a 1/10th the default on other chains

### DIFF
--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -6,6 +6,7 @@ import {
   type RpcTransactionRequest,
   type Transport,
 } from "viem";
+import { arbitrum, arbitrumGoerli } from "viem/chains";
 import { BaseSmartContractAccount } from "../account/base.js";
 import { createPublicErc4337Client } from "../client/create-client.js";
 import type {
@@ -68,6 +69,11 @@ export interface SmartAccountProviderOpts {
   minPriorityFeePerBid?: bigint;
 }
 
+const minPriorityFeePerBidDefaults = new Map<number, bigint>([
+  [arbitrum.id, 10_000_000n],
+  [arbitrumGoerli.id, 10_000_000n],
+]);
+
 export class SmartAccountProvider<
   TTransport extends SupportedTransports = Transport
 > implements ISmartAccountProvider<TTransport>
@@ -86,7 +92,11 @@ export class SmartAccountProvider<
   ) {
     this.txMaxRetries = opts?.txMaxRetries ?? 5;
     this.txRetryIntervalMs = opts?.txRetryIntervalMs ?? 2000;
-    this.minPriorityFeePerBid = opts?.minPriorityFeePerBid ?? 1000000000n;
+    this.minPriorityFeePerBid =
+      opts?.minPriorityFeePerBid ??
+      minPriorityFeePerBidDefaults.get(chain.id) ??
+      100_000_000n;
+
     this.rpcClient =
       typeof rpcProvider === "string"
         ? createPublicErc4337Client({


### PR DESCRIPTION
This addresses and issue with how arbitrum handles gas. The min fee per bid needs to be 1/10th the bid on other chains. 

This also fixes an issue where the minimum was 10x higher than it was supposed to be (rundler only requires .1 wei, it was set to 1 wei)
