### PR TITLE
feat: expose more user op methods on the provider

### DIFF
--- a/packages/alchemy/src/middleware/gas-fees.ts
+++ b/packages/alchemy/src/middleware/gas-fees.ts
@@ -14,7 +14,8 @@ export interface GasFeeMode {
 
 export const withAlchemyGasFeeEstimator = (
   provider: AlchemyProvider,
-  feeMode: GasFeeMode
+  feeMode: GasFeeMode,
+  maxPriorityFeeBufferPercent: bigint
 ): AlchemyProvider => {
   if (feeMode.strategy === GasFeeStrategy.DEFAULT) {
     return provider;
@@ -26,9 +27,11 @@ export const withAlchemyGasFeeEstimator = (
     if (baseFeePerGas == null) {
       throw new Error("baseFeePerGas is null");
     }
-    const maxPriorityFeePerGas = BigInt(
-      await provider.rpcClient.getMaxPriorityFeePerGas()
-    );
+    // add a buffer here to account for potential spikes in priority fee
+    const maxPriorityFeePerGas =
+      (BigInt(await provider.rpcClient.getMaxPriorityFeePerGas()) *
+        (100n + maxPriorityFeeBufferPercent)) /
+      100n;
     // add 25% overhead to ensure mine
     const baseFeeScaled = (baseFeePerGas * 5n) / 4n;
 

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -29,6 +29,10 @@ export type AlchemyProviderConfig = {
   entryPointAddress: Address;
   account?: BaseSmartContractAccount;
   opts?: SmartAccountProviderOpts;
+  feeOpts?: {
+    /** this adds a percent buffer on top of the fee estimated (default 5%)*/
+    maxPriorityFeeBufferPercent?: bigint;
+  };
 };
 
 export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
@@ -38,6 +42,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
     entryPointAddress,
     account,
     opts,
+    feeOpts,
   }: AlchemyProviderConfig) {
     const _chain =
       typeof chain === "number" ? SupportedChains.get(chain) : chain;
@@ -53,7 +58,8 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
       ChainFeeStrategies.get(_chain.id) ?? {
         strategy: GasFeeStrategy.DEFAULT,
         value: 0n,
-      }
+      },
+      feeOpts?.maxPriorityFeeBufferPercent ?? 5n
     );
   }
 

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -17,6 +17,8 @@ import {
   isValidRequest,
   type BatchUserOperationCallData,
   type UserOperationCallData,
+  type UserOperationReceipt,
+  type UserOperationResponse,
   type UserOperationStruct,
 } from "../types.js";
 import {
@@ -187,7 +189,7 @@ export class SmartAccountProvider<
     return await this.waitForUserOperationTransaction(hash as Hash);
   };
 
-  private async waitForUserOperationTransaction(hash: Hash): Promise<Hash> {
+  waitForUserOperationTransaction = async (hash: Hash): Promise<Hash> => {
     for (let i = 0; i < this.txMaxRetries; i++) {
       await new Promise((resolve) =>
         setTimeout(resolve, this.txRetryIntervalMs)
@@ -204,7 +206,15 @@ export class SmartAccountProvider<
     }
 
     throw new Error("Failed to find transaction for User Operation");
-  }
+  };
+
+  getUserOperationByHash = (hash: Hash): Promise<UserOperationResponse> => {
+    return this.rpcClient.getUserOperationByHash(hash);
+  };
+
+  getUserOperationReceipt = (hash: Hash): Promise<UserOperationReceipt> => {
+    return this.rpcClient.getUserOperationReceipt(hash);
+  };
 
   sendUserOperation = async (
     data: UserOperationCallData | BatchUserOperationCallData

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -8,7 +8,9 @@ import type {
 import type {
   BatchUserOperationCallData,
   UserOperationCallData,
+  UserOperationReceipt,
   UserOperationRequest,
+  UserOperationResponse,
   UserOperationStruct,
 } from "../types.js";
 
@@ -78,6 +80,31 @@ export interface ISmartAccountProvider<
   sendUserOperation: (
     data: UserOperationCallData | BatchUserOperationCallData
   ) => Promise<SendUserOperationResult>;
+
+  /**
+   * This will wait for the user operation to be included in a transaction that's been mined.
+   * The default retry and wait logic is configured on the Provider itself
+   *
+   * @param hash the user operation hash you want to wait for
+   * @returns the tx hash that included this user operation
+   */
+  waitForUserOperationTransaction: (hash: Hash) => Promise<Hash>;
+
+  /**
+   * calls `eth_getUserOperationByHash` and returns the {@link UserOperationResponse}
+   *
+   * @param hash - the hash of the UserOperation to get the receipt for
+   * @returns - {@link UserOperationResponse}
+   */
+  getUserOperationByHash: (hash: Hash) => Promise<UserOperationResponse>;
+
+  /**
+   * calls `eth_getUserOperationReceipt` and returns the {@link UserOperationReceipt}
+   *
+   * @param hash - the hash of the UserOperation to get the receipt for
+   * @returns - {@link UserOperationResponse}
+   */
+  getUserOperationReceipt: (hash: Hash) => Promise<UserOperationReceipt>;
 
   /**
    * This takes an ethereum transaction and converts it into a UserOperation, sends the UserOperation, and waits


### PR DESCRIPTION
This adds some utility methods to the provider

- getUserOperationByHash -- pass through to the underlying rpc client
- getUserOperationReceipt -- pass through to the underlying rpc client
- waitForUserOperationTransaction -- waits for the user op to be included in a transaction and returns the tx hash. This is used by sendTransaction, but found myself wanting this utility at some point so just exposing it as public instead of keeping it private

Edit also was lazy and added a buffer to the fee estimates we generate
