### PR TITLE
feat: add a logger and some debug statements

### DIFF
--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -14,6 +14,7 @@ import type {
   PublicErc4337Client,
   SupportedTransports,
 } from "../client/types.js";
+import { Logger } from "../logger.js";
 import type { BatchUserOperationCallData } from "../types.js";
 import type { ISmartContractAccount } from "./types.js";
 
@@ -111,9 +112,17 @@ export abstract class BaseSmartContractAccount<
   async getAddress(): Promise<Address> {
     if (!this.accountAddress) {
       const initCode = await this.getAccountInitCode();
+      Logger.debug(
+        "[BaseSmartContractAccount](getAddress) initCode: ",
+        initCode
+      );
       try {
         await this.entryPoint.simulate.getSenderAddress([initCode]);
       } catch (err: any) {
+        Logger.debug(
+          "[BaseSmartContractAccount](getAddress) entrypoint.getSenderAddress result: ",
+          err
+        );
         if (err.cause?.data?.errorName === "SenderAddressResult") {
           this.accountAddress = err.cause.data.args[0] as Address;
           return this.accountAddress;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,9 +14,9 @@ export type {
   SimpleSmartAccountParams,
 } from "./account/simple.js";
 export type * from "./account/types.js";
-export type { SmartAccountSigner } from "./signer/types.js";
-export { PrivateKeySigner } from "./signer/private-key.js";
 export { HdAccountSigner } from "./signer/hd-account.js";
+export { PrivateKeySigner } from "./signer/private-key.js";
+export type { SmartAccountSigner } from "./signer/types.js";
 
 export {
   createPublicErc4337Client,
@@ -35,8 +35,10 @@ export type * from "./types.js";
 export {
   asyncPipe,
   deepHexlify,
+  defineReadOnly,
   getChain,
   getUserOperationHash,
   resolveProperties,
-  defineReadOnly,
 } from "./utils.js";
+
+export { Logger, type LogLevel } from "./logger.js";

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,51 @@
+export enum LogLevel {
+  DEBUG = 4,
+  INFO = 3,
+  WARN = 2,
+  ERROR = 1,
+  NONE = 0,
+}
+
+export class Logger {
+  static logLevel: LogLevel = LogLevel.NONE;
+  static logFilter?: string;
+
+  static setLogLevel(logLevel: LogLevel) {
+    this.logLevel = logLevel;
+  }
+
+  static setLogFilter(pattern: string) {
+    this.logFilter = pattern;
+  }
+
+  static error(msg: string, ...args: any[]) {
+    if (!this.shouldLog(msg, LogLevel.ERROR)) return;
+
+    console.error(msg, ...args);
+  }
+
+  static warn(msg: string, ...args: any[]) {
+    if (!this.shouldLog(msg, LogLevel.WARN)) return;
+
+    console.warn(msg, ...args);
+  }
+
+  static debug(msg: string, ...args: any[]) {
+    if (!this.shouldLog(msg, LogLevel.DEBUG)) return;
+
+    console.debug(msg, ...args);
+  }
+
+  static info(msg: string, ...args: any[]) {
+    if (!this.shouldLog(msg, LogLevel.INFO)) return;
+
+    console.info(msg, ...args);
+  }
+
+  private static shouldLog(msg: string, level: LogLevel) {
+    if (this.logLevel < level) return false;
+    if (this.logFilter && !msg.includes(this.logFilter)) return false;
+
+    return true;
+  }
+}


### PR DESCRIPTION
This adds a logger that can be used in side of the SDK to log things to consumers.

It's configurable by users to set log level + add a filter on messages (to remove noise)

Right now I'm adding just a couple specific debug logs for an issue a customer is facing where the getCounterFactual is failing for them
