### PR TITLE
chore: add publish package CI action

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -5,6 +5,24 @@ on:
       - main
 
 jobs:
+  enforce_title:
+    name: Enforce PR Title Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.20"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Use commitlint to check PR title
+        run: echo "${{ github.event.pull_request.title }}" | yarn commitlint
+
   build_and_lint:
     name: Lint and Build
     runs-on: ubuntu-latest
@@ -14,7 +32,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: "16.20"
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,7 +1,10 @@
 name: Publish new Package
 
 # workflow dispatch requires a maintainer to go to the Actions tab and manually trigger the workflow
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    branches:
+      - main
 
 # If we ever migrate this to not be manual, we HAVE to check that the commit
 # it is running against DOES NOT contain [skip-ci] in the commit message

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,37 @@
+name: Publish new Package
+
+# workflow dispatch requires a maintainer to go to the Actions tab and manually trigger the workflow
+on: workflow_dispatch
+
+# If we ever migrate this to not be manual, we HAVE to check that the commit
+# it is running against DOES NOT contain [skip-ci] in the commit message
+jobs:
+  build_test_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ALCHEMY_BOT_PAT }}
+
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.20"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+      # TODO: we still need to make the tests work in CI environments
+      # will come back to this
+      # - name: Test
+      #   run: yarn test
+
+      # Lerna publish will, compute the new version, update files, run precommit hooks, tag, publish, and push change log
+      - name: Publish using Lerna
+        run: yarn lerna publish --no-private --yes
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,7 @@
 name: Publish new Package
 
 # workflow dispatch requires a maintainer to go to the Actions tab and manually trigger the workflow
-on:
-  workflow_dispatch:
-    branches:
-      - main
+on: workflow_dispatch
 
 # If we ever migrate this to not be manual, we HAVE to check that the commit
 # it is running against DOES NOT contain [skip-ci] in the commit message

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
   "changelog": true,
   "command": {
     "version": {
-      "message": "chore(release): publish %s"
+      "message": "chore(release): publish %s [skip-ci]"
     }
   },
   "granularPathspec": false


### PR DESCRIPTION
This sets up a github action that can be manually triggered to run the publish steps

The following secrets have already been added to the repo
`NPM_TOKEN` -> this is an automation token that enables publishing without OTP
`ALCHEMY_BOT_PAT` -> PAT generated for alchemy-bot user which is an admin on the repo. This enables us to use branch protection, but still push the changelog and other generated files by the publish process to main
