### PR TITLE
ci: add unit tests to on-pull-request action

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Test
+        run: yarn test:unit

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -43,4 +43,4 @@ jobs:
         run: yarn build
 
       - name: Unit Test
-        run: yarn test:unit
+        run: yarn test

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Test
+      - name: Unit Test
         run: yarn test:unit

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,8 +1,6 @@
 name: Run checks on Pull Requests
 on:
   pull_request:
-    # branches:
-    #   - main
 
 jobs:
   enforce_title:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Use commitlint to check PR title
         run: echo "${{ github.event.pull_request.title }}" | yarn commitlint
 
-  build_and_lint:
-    name: Lint and Build
+  build_and_lint_and_test:
+    name: Lint and Build and Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,8 +1,8 @@
 name: Run checks on Pull Requests
 on:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   enforce_title:


### PR DESCRIPTION
Requirements
- add unit tests to on-pull-request action
- enforce running on-pull-request on PRs merging to any branch, to account for stacked PRs

Tests: see output of CI below (which passes)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow file `on-pull-request.yml`. 

### Detailed summary:
- Renamed the job `build_and_lint` to `build_and_lint_and_test`
- Added a new job `Unit Test` to run the `yarn test` command

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->