### PR TITLE
test: change zerodev e2e tests to use .env wallet

### DIFF
--- a/packages/accounts/src/kernel-zerodev/e2e-tests/constants.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/constants.ts
@@ -1,0 +1,2 @@
+export const API_KEY = process.env.API_KEY!;
+export const OWNER_MNEMONIC = process.env.OWNER_MNEMONIC!;

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
@@ -8,6 +8,7 @@ import {
   toHex,
   type Address,
   type Hex,
+  type Hash,
 } from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
@@ -152,16 +153,19 @@ describe("Kernel Account Tests", () => {
   it("sendUserOperation should execute properly", async () => {
     let signerWithProvider = connect(0n, owner);
 
-    const result = signerWithProvider.sendUserOperation({
+    const result = await signerWithProvider.sendUserOperation({
       target: await signerWithProvider.getAddress(),
       data: "0x",
       value: 0n,
     });
-    await expect(result).resolves.not.toThrowError();
-  }, 10000);
+    const txnHash = signerWithProvider.waitForUserOperationTransaction(
+      result.hash as Hash
+    );
+
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 50000);
 
   it("sendUserOperation batch should execute properly", async () => {
-    await new Promise((resolve) => setTimeout(resolve, 10000));
     let signerWithProvider = connect(0n, owner);
     const request: KernelUserOperationCallData = {
       target: await signerWithProvider.getAddress(),
@@ -174,9 +178,13 @@ describe("Kernel Account Tests", () => {
       value: 200000000n,
     };
     const requests: BatchUserOperationCallData = [request, request2];
-    const result = signerWithProvider.sendUserOperation(requests);
-    await expect(result).resolves.not.toThrowError();
-  }, 20000);
+    const result = await signerWithProvider.sendUserOperation(requests);
+    const txnHash = signerWithProvider.waitForUserOperationTransaction(
+      result.hash as Hash
+    );
+
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 50000);
 
   //non core functions
   it("should correctly identify whether account is deployed", async () => {

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -2,7 +2,7 @@ import {
   SimpleSmartContractAccount,
   type SimpleSmartAccountOwner,
 } from "@alchemy/aa-core";
-import { toHex } from "viem";
+import { toHex, type Hash } from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
 import { AlchemyProvider } from "../src/provider.js";
@@ -44,14 +44,14 @@ describe("Simple Account Tests", () => {
   });
 
   it("should execute successfully", async () => {
-    await new Promise((resolve) => setTimeout(resolve, 7500));
-    const result = signer.sendUserOperation({
+    const result = await signer.sendUserOperation({
       target: await signer.getAddress(),
       data: "0x",
     });
+    const txnHash = signer.waitForUserOperationTransaction(result.hash as Hash);
 
-    await expect(result).resolves.not.toThrowError();
-  }, 10000);
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 50000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
@@ -80,21 +80,18 @@ describe("Simple Account Tests", () => {
   });
 
   it("should successfully execute with alchemy paymaster info", async () => {
-    // TODO: this is super hacky right now
-    // we have to wait for the test above to run and be confirmed so that this one submits successfully using the correct nonce
-    // one way we could do this is by batching the two UOs together
-    await new Promise((resolve) => setTimeout(resolve, 10000));
     const newSigner = signer.withAlchemyGasManager({
       provider: signer.rpcClient,
       policyId: PAYMASTER_POLICY_ID,
       entryPoint: ENTRYPOINT_ADDRESS,
     });
 
-    const result = newSigner.sendUserOperation({
+    const result = await newSigner.sendUserOperation({
       target: await newSigner.getAddress(),
       data: "0x",
     });
+    const txnHash = signer.waitForUserOperationTransaction(result.hash as Hash);
 
-    await expect(result).resolves.not.toThrowError();
-  }, 20000);
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 50000);
 });

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -44,13 +44,14 @@ describe("Simple Account Tests", () => {
   });
 
   it("should execute successfully", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 7500));
     const result = signer.sendUserOperation({
       target: await signer.getAddress(),
       data: "0x",
     });
 
     await expect(result).resolves.not.toThrowError();
-  });
+  }, 10000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
@@ -82,7 +83,7 @@ describe("Simple Account Tests", () => {
     // TODO: this is super hacky right now
     // we have to wait for the test above to run and be confirmed so that this one submits successfully using the correct nonce
     // one way we could do this is by batching the two UOs together
-    await new Promise((resolve) => setTimeout(resolve, 7500));
+    await new Promise((resolve) => setTimeout(resolve, 10000));
     const newSigner = signer.withAlchemyGasManager({
       provider: signer.rpcClient,
       policyId: PAYMASTER_POLICY_ID,
@@ -95,5 +96,5 @@ describe("Simple Account Tests", () => {
     });
 
     await expect(result).resolves.not.toThrowError();
-  }, 10000);
+  }, 20000);
 });

--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -39,13 +39,14 @@ describe("Simple Account Tests", () => {
   });
 
   it("should execute successfully", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 7500));
     const result = signer.sendUserOperation({
       target: await signer.getAddress(),
       data: "0x",
     });
 
     await expect(result).resolves.not.toThrowError();
-  });
+  }, 20000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";

--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -1,4 +1,4 @@
-import { isAddress } from "viem";
+import { isAddress, type Hash } from "viem";
 import { generatePrivateKey } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
 import {
@@ -39,14 +39,14 @@ describe("Simple Account Tests", () => {
   });
 
   it("should execute successfully", async () => {
-    await new Promise((resolve) => setTimeout(resolve, 7500));
-    const result = signer.sendUserOperation({
+    const result = await signer.sendUserOperation({
       target: await signer.getAddress(),
       data: "0x",
     });
+    const txnHash = signer.waitForUserOperationTransaction(result.hash as Hash);
 
-    await expect(result).resolves.not.toThrowError();
-  }, 20000);
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 50000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -37,15 +37,17 @@ describe("Simple Account Tests", async () => {
   });
 
   it("should execute successfully", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 7500));
     const result = signer.sendUserOperation({
       target: (await signer.getAddress()) as `0x${string}`,
       data: "0x",
     });
 
     await expect(result).resolves.not.toThrowError();
-  });
+  }, 20000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 7500));
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const signer = EthersProviderAdapter.fromEthersProvider(
       alchemyProvider,
@@ -68,5 +70,5 @@ describe("Simple Account Tests", async () => {
     });
 
     await expect(result).rejects.toThrowError();
-  });
+  }, 20000);
 });

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -37,17 +37,16 @@ describe("Simple Account Tests", async () => {
   });
 
   it("should execute successfully", async () => {
-    // TODO: this is super hacky right now for Ethers
-    // we have to wait for the test above to run and be confirmed so that this one submits successfully using the correct nonce
-    // one way we could do this is by batching the two UOs together
-    await new Promise((resolve) => setTimeout(resolve, 7500));
-    const result = signer.sendUserOperation({
+    const result = await signer.sendUserOperation({
       target: (await signer.getAddress()) as `0x${string}`,
       data: "0x",
     });
+    const txnHash = signer.waitForUserOperationTransaction(
+      result.hash as `0x${string}`
+    );
 
-    await expect(result).resolves.not.toThrowError();
-  }, 20000);
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 50000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -37,6 +37,9 @@ describe("Simple Account Tests", async () => {
   });
 
   it("should execute successfully", async () => {
+    // TODO: this is super hacky right now for Ethers
+    // we have to wait for the test above to run and be confirmed so that this one submits successfully using the correct nonce
+    // one way we could do this is by batching the two UOs together
     await new Promise((resolve) => setTimeout(resolve, 7500));
     const result = signer.sendUserOperation({
       target: (await signer.getAddress()) as `0x${string}`,
@@ -47,7 +50,6 @@ describe("Simple Account Tests", async () => {
   }, 20000);
 
   it("should fail to execute if account address is not deployed and not correct", async () => {
-    await new Promise((resolve) => setTimeout(resolve, 7500));
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const signer = EthersProviderAdapter.fromEthersProvider(
       alchemyProvider,

--- a/packages/ethers/src/account-signer.ts
+++ b/packages/ethers/src/account-signer.ts
@@ -24,15 +24,64 @@ const hexlifyOptional = (value: any): `0x${string}` | undefined => {
   return hexlify(value) as `0x${string}`;
 };
 
+export interface SmartAccountProviderOpts {
+  /**
+   * The maximum number of times to try fetching a transaction receipt before giving up (default: 5)
+   */
+  txMaxRetries?: number;
+
+  /**
+   * The interval in milliseconds to wait between retries while waiting for tx receipts (default: 2_000n)
+   */
+  txRetryIntervalMs?: number;
+
+  /**
+   * The mulitplier on interval length to wait between retries while waiting for tx receipts (default: 1.5)
+   */
+  txRetryMulitplier?: number;
+
+  /**
+   * used when computing the fees for a user operation (default: 100_000_000n)
+   */
+  minPriorityFeePerBid?: bigint;
+}
+
 export class AccountSigner extends Signer {
   private account?: BaseSmartContractAccount;
-  sendUserOperation;
 
-  constructor(readonly provider: EthersProviderAdapter) {
+  private txMaxRetries: number;
+  private txRetryIntervalMs: number;
+  private txRetryMulitplier: number;
+
+  sendUserOperation;
+  getTransaction;
+  getUserOperationByHash;
+  getUserOperationReceipt;
+
+  constructor(
+    readonly provider: EthersProviderAdapter,
+    opts?: SmartAccountProviderOpts
+  ) {
     super();
     this.account = this.provider.accountProvider.account;
+
+    this.txMaxRetries = opts?.txMaxRetries ?? 5;
+    this.txRetryIntervalMs = opts?.txRetryIntervalMs ?? 2000;
+    this.txRetryMulitplier = opts?.txRetryMulitplier ?? 1.5;
+
     this.sendUserOperation =
       this.provider.accountProvider.sendUserOperation.bind(
+        this.provider.accountProvider
+      );
+    this.getTransaction = this.provider.accountProvider.getTransaction.bind(
+      this.provider.accountProvider
+    );
+    this.getUserOperationByHash =
+      this.provider.accountProvider.getUserOperationByHash.bind(
+        this.provider.accountProvider
+      );
+    this.getUserOperationReceipt =
+      this.provider.accountProvider.getUserOperationReceipt.bind(
         this.provider.accountProvider
       );
   }
@@ -101,6 +150,30 @@ export class AccountSigner extends Signer {
       "Transaction signing is not supported, use sendUserOperation instead"
     );
   }
+
+  waitForUserOperationTransaction = async (
+    hash: `0x${string}`
+  ): Promise<`0x${string}`> => {
+    for (let i = 0; i < this.txMaxRetries; i++) {
+      const txRetryIntervalWithJitterMs =
+        this.txRetryIntervalMs * Math.pow(this.txRetryMulitplier, i) +
+        Math.random() * 100;
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, txRetryIntervalWithJitterMs)
+      );
+      const receipt = await this.getUserOperationReceipt(hash as `0x${string}`)
+        // TODO: should maybe log the error?
+        .catch(() => null);
+      if (receipt) {
+        return this.getTransaction(receipt.receipt.transactionHash).then(
+          (x) => x.hash
+        );
+      }
+    }
+
+    throw new Error("Failed to find transaction for User Operation");
+  };
 
   getPublicErc4337Client(): PublicErc4337Client {
     return this.provider.getPublicErc4337Client();

--- a/packages/ethers/src/account-signer.ts
+++ b/packages/ethers/src/account-signer.ts
@@ -73,9 +73,7 @@ export class AccountSigner extends Signer {
       this.provider.accountProvider.sendUserOperation.bind(
         this.provider.accountProvider
       );
-    this.getTransaction = this.provider.accountProvider.getTransaction.bind(
-      this.provider.accountProvider
-    );
+    this.getTransaction = this.provider.getTransaction.bind(this.provider);
     this.getUserOperationByHash =
       this.provider.accountProvider.getUserOperationByHash.bind(
         this.provider.accountProvider
@@ -167,7 +165,7 @@ export class AccountSigner extends Signer {
         .catch(() => null);
       if (receipt) {
         return this.getTransaction(receipt.receipt.transactionHash).then(
-          (x) => x.hash
+          (x) => x.hash as `0x${string}`
         );
       }
     }


### PR DESCRIPTION
Requirements
- change zerodev e2e tests to use .env wallet
- use `waitForUserOperationTxn` and update test timeouts to 50 seconds for tests to account for "replacement underpriced" errors from not waiting enough time for prev. tests' sendUserOperations.

Tests: 
<img width="966" alt="image" src="https://github.com/alchemyplatform/aa-sdk/assets/43521356/b562ff43-9fc2-4d96-b013-49a6c1fec111">

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `API_KEY` and `OWNER_MNEMONIC` constants to `constants.ts` in `packages/accounts/src/kernel-zerodev/e2e-tests`
- Modified `AccountSigner` class in `packages/ethers/src/account-signer.ts` to include `waitForUserOperationTransaction` property
- Modified `simple-account.test.ts` in `packages/ethers/e2e-tests`, `packages/core/e2e-tests`, `packages/alchemy/e2e-tests`, and `packages/accounts/src/kernel-zerodev/e2e-tests` to use `await` with `sendUserOperation` and `waitForUserOperationTransaction` methods

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->