### PR TITLE
feat: support passing fee overrides to the send user op method

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -19,6 +19,11 @@ export interface UserOperationCallData {
 
 export type BatchUserOperationCallData = UserOperationCallData[];
 
+export type UserOperationOverrides = Pick<
+  UserOperationStruct,
+  "maxFeePerGas" | "maxPriorityFeePerGas"
+>;
+
 // represents the request as it needs to be formatted for RPC requests
 export interface UserOperationRequest {
   /* the origin of the request */


### PR DESCRIPTION
This adds the ability to override the gas fees of a user op

useful if you need to replace a user operation


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new type `UserOperationOverrides` to represent gas price overrides in user operation requests.
- Modified the `sendUserOperation` method to accept an optional `overrides` parameter.
- Updated the `sendUserOperation` method to apply the overrides if they are passed in.
- Updated the `SmartAccountProvider` class to use the `overrides` parameter when calling `sendUserOperation` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->