### PR TITLE
chore: add more detail to readmes about contract addresses, and add breadcrumb

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ npm i -s @alchemy/aa-ethers
 
 ## Example Usage to Interact with [Simple Accounts](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/SimpleAccount.sol)
 
+**Note 🗒️:** We've also included an [E2E example here](https://github.com/alchemyplatform/aa-sdk/tree/main/examples/alchemy-daapp). This example DApp creates a simple account wallet and mints an NFT in one flow.
+
 ### via `aa-core`
 
 ```ts

--- a/examples/alchemy-daapp/README.md
+++ b/examples/alchemy-daapp/README.md
@@ -34,11 +34,15 @@ export const serverConfigs: Record<number, ServerConfiguration> = {
     nftContractAddress: "<your-nft-contract-address>",
     simpleAccountFactoryAddress: "<your-simple-account-factory-address>",
     gasManagerPolicyId: "<your-gas-manager-policy-id>",
-    chain: polygon,
+    chain: polygonMumbai,
   },
   // Repeat for other chains as needed
 };
 ```
+### **🗒️ Notes:** for `nftContractAddress` and `simpleAccountFactoryAddress` 
+- There are already contract addresses deployed for them across [various chains here](https://github.com/alchemyplatform/aa-sdk/blob/main/examples/alchemy-daapp/src/configs/clientConfigs.ts).
+- We used eth-infinitism's [simpleAccountFactory here](https://github.com/eth-infinitism/account-abstraction/blob/main/contracts/samples/SimpleAccountFactory.sol).
+- Finally, the contracts sibling package has the copy of the [NFT contract](https://github.com/alchemyplatform/aa-sdk/tree/main/examples/contracts/DAAppNFT/src) along instructions on [how to deploy it](https://github.com/alchemyplatform/aa-sdk/blob/main/examples/contracts/README.md).
 
 4. Update the serverConfigs.ts file with your alchemy API keys:
 ```typescript


### PR DESCRIPTION
TSIA

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the Polygon Mumbai chain and includes additional notes and instructions for contract addresses and deployment. 

### Detailed summary
- Added support for the Polygon Mumbai chain
- Updated the `chain` value in the `aa-core` example
- Added notes for `nftContractAddress` and `simpleAccountFactoryAddress`
- Provided links to pre-deployed contract addresses and contract deployment instructions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->