### PR TITLE
feat: add event emitter to the provider so that we can listen to connected events in dapps

### DIFF
--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -24,16 +24,21 @@ describe("Alchemy Provider Tests", () => {
     apiKey: "test",
     chain,
     entryPointAddress: "0xENTRYPOINT_ADDRESS",
-  }).connect(
-    (provider) =>
-      new SimpleSmartContractAccount({
-        entryPointAddress: "0xENTRYPOINT_ADDRESS",
-        chain,
-        owner,
-        factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
-        rpcClient: provider,
-      })
-  );
+  }).connect((provider) => {
+    const account = new SimpleSmartContractAccount({
+      entryPointAddress: "0xENTRYPOINT_ADDRESS",
+      chain,
+      owner,
+      factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
+      rpcClient: provider,
+    });
+
+    account.getAddress = vi.fn(
+      async () => "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"
+    );
+
+    return account;
+  });
 
   it("should correctly sign the message", async () => {
     expect(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,8 @@
     "vitest": "^0.31.0"
   },
   "dependencies": {
-    "abitype": "^0.8.3"
+    "abitype": "^0.8.3",
+    "eventemitter3": "^5.0.1"
   },
   "peerDependencies": {
     "viem": "^1.1.7"

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -1,4 +1,4 @@
-import type { Transaction } from "viem";
+import { type Transaction } from "viem";
 import { polygonMumbai } from "viem/chains";
 import {
   afterEach,
@@ -8,8 +8,8 @@ import {
   vi,
   type SpyInstance,
 } from "vitest";
-import { SmartAccountProvider } from "../base.js";
 import type { UserOperationReceipt } from "../../types.js";
+import { SmartAccountProvider } from "../base.js";
 
 describe("Base Tests", () => {
   let retryMsDelays: number[] = [];
@@ -94,5 +94,53 @@ describe("Base Tests", () => {
       3,
       getUserOperationReceiptMock
     );
+  });
+
+  it("should emit connected event on connected", async () => {
+    const spy = vi.spyOn(providerMock, "emit");
+    const account = {
+      chain: polygonMumbai,
+      entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+      rpcClient: providerMock.rpcClient,
+      getAddress: async () => "0xMOCK_ADDRESS",
+    } as any;
+
+    // This says the await is not important... it is. the method is not marked sync because we don't need it to be,
+    // but the address is emited from an async method so we want to await that
+    await providerMock.connect(() => account);
+
+    expect(spy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "connect",
+          {
+            "chainId": "0x13881",
+          },
+        ],
+        [
+          "accountsChanged",
+          [
+            "0xMOCK_ADDRESS",
+          ],
+        ],
+      ]
+    `);
+  });
+
+  it("should emit disconnected event on disconnect", async () => {
+    const spy = vi.spyOn(providerMock, "emit");
+    providerMock.disconnect();
+
+    expect(spy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "disconnect",
+        ],
+        [
+          "accountsChanged",
+          [],
+        ],
+      ]
+    `);
   });
 });

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -1,5 +1,5 @@
 import type { Address } from "abitype";
-import type { Hash, RpcTransactionRequest, Transport } from "viem";
+import type { Hash, Hex, RpcTransactionRequest, Transport } from "viem";
 import type { BaseSmartContractAccount } from "../account/base.js";
 import type {
   PublicErc4337Client,
@@ -16,6 +16,19 @@ import type {
 
 type WithRequired<T, K extends keyof T> = Required<Pick<T, K>>;
 type WithOptional<T, K extends keyof T> = Pick<Partial<T>, K>;
+
+export type ConnectorData = {
+  chainId?: Hex;
+};
+
+export interface ProviderEvents {
+  chainChanged(chainId: Hex): void;
+  accountsChanged(accounts: Address[]): void;
+  connect(data: ConnectorData): void;
+  message({ type, data }: { type: string; data?: unknown }): void;
+  disconnect(): void;
+  error(error: Error): void;
+}
 
 export type SendUserOperationResult = {
   hash: string;
@@ -204,4 +217,11 @@ export interface ISmartAccountProvider<
   connect(
     fn: (provider: PublicErc4337Client<TTransport>) => BaseSmartContractAccount
   ): this & { account: BaseSmartContractAccount };
+
+  /**
+   * Allows for disconnecting the account from the provider so you can connect the provider to another account instance
+   *
+   * @returns the provider with the account disconnected
+   */
+  disconnect(): this & { account: undefined };
 }

--- a/packages/ethers/src/__tests__/provider-adapter.test.ts
+++ b/packages/ethers/src/__tests__/provider-adapter.test.ts
@@ -17,16 +17,21 @@ describe("Simple Account Tests", async () => {
   const signer = EthersProviderAdapter.fromEthersProvider(
     alchemyProvider,
     "0xENTRYPOINT_ADDRESS"
-  ).connectToAccount(
-    (rpcClient) =>
-      new SimpleSmartContractAccount({
-        entryPointAddress: "0xENTRYPOINT_ADDRESS",
-        chain: getChain(alchemyProvider.network.chainId),
-        owner: convertWalletToAccountSigner(owner),
-        factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
-        rpcClient,
-      })
-  );
+  ).connectToAccount((rpcClient) => {
+    const account = new SimpleSmartContractAccount({
+      entryPointAddress: "0xENTRYPOINT_ADDRESS",
+      chain: getChain(alchemyProvider.network.chainId),
+      owner: convertWalletToAccountSigner(owner),
+      factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
+      rpcClient,
+    });
+
+    account.getAddress = vi.fn(
+      async () => "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"
+    );
+
+    return account;
+  });
 
   it("should correctly sign the message", async () => {
     expect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   integrity sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==
 
 "@alchemy/aa-core@file:packages/core":
-  version "0.1.0-alpha.17"
+  version "0.1.0-alpha.18"
   dependencies:
     abitype "^0.8.3"
 
@@ -6804,6 +6804,11 @@ eventemitter3@^4.0.4, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 events@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `eventemitter3` as a dependency in `core/package.json`
- Modified `provider.test.ts` and `provider-adapter.test.ts` files to connect and disconnect the account from the provider
- Modified `base.test.ts` file to emit `connect` and `disconnect` events on connection and disconnection
- Modified `base.ts` file to add `disconnect` method and emit appropriate events
- Modified `simple.test.ts` file to connect the provider to the account and added test cases for signing and encoding batch transaction data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->