### PR TITLE
feat: minor nit in alchemy provider constructor

### DIFF
--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -26,9 +26,9 @@ import {
 type ConnectionConfig =
   | {
       apiKey: string;
-      rpcUrl: undefined;
+      rpcUrl?: undefined;
     }
-  | { rpcUrl: string; apiKey: undefined };
+  | { rpcUrl: string; apiKey?: undefined };
 
 export type AlchemyProviderConfig = {
   chain: Chain | number;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the `AlchemyProviderConfig` type in `provider.ts` to make the `rpcUrl` and `apiKey` properties optional.

### Detailed summary:
- Updated the `rpcUrl` property in `AlchemyProviderConfig` to be optional.
- Updated the `apiKey` property in `AlchemyProviderConfig` to be optional.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->