### PR TITLE
chore(ci): allow for URL override in e2e tests

### DIFF
--- a/packages/accounts/src/kernel-zerodev/e2e-tests/constants.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/constants.ts
@@ -1,2 +1,3 @@
-export const API_KEY = process.env.API_KEY!;
+export const RPC_URL = process.env.RPC_URL;
+export const API_KEY = process.env.API_KEY;
 export const OWNER_MNEMONIC = process.env.OWNER_MNEMONIC!;

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
@@ -19,14 +19,17 @@ import {
 import { KernelAccountProvider } from "../provider.js";
 import type { KernelUserOperationCallData } from "../types.js";
 import { KernelBaseValidator, ValidatorMode } from "../validator/base.js";
-import { API_KEY, OWNER_MNEMONIC } from "./constants.js";
+import { RPC_URL, API_KEY, OWNER_MNEMONIC } from "./constants.js";
 import { MockSigner } from "./mocks/mock-signer.js";
 
 describe("Kernel Account Tests", () => {
   //any wallet should work
   const config = {
     chain: polygonMumbai,
-    rpcProvider: `${polygonMumbai.rpcUrls.alchemy.http[0]}/${API_KEY}`,
+    rpcProvider:
+      RPC_URL != null
+        ? RPC_URL
+        : `${polygonMumbai.rpcUrls.alchemy.http[0]}/${API_KEY}`,
     validatorAddress: "0x180D6465F921C7E0DEA0040107D342c87455fFF5" as Address,
     accountFactoryAddress:
       "0x5D006d3880645ec6e254E18C1F879DAC9Dd71A39" as Address,

--- a/packages/alchemy/e2e-tests/constants.ts
+++ b/packages/alchemy/e2e-tests/constants.ts
@@ -1,3 +1,4 @@
-export const API_KEY = process.env.API_KEY!;
+export const RPC_URL = process.env.RPC_URL;
+export const API_KEY = process.env.API_KEY;
 export const OWNER_MNEMONIC = process.env.OWNER_MNEMONIC!;
 export const PAYMASTER_POLICY_ID = process.env.PAYMASTER_POLICY_ID!;

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -6,7 +6,12 @@ import { toHex, type Hash } from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
 import { AlchemyProvider } from "../src/provider.js";
-import { API_KEY, OWNER_MNEMONIC, PAYMASTER_POLICY_ID } from "./constants.js";
+import {
+  RPC_URL,
+  API_KEY,
+  OWNER_MNEMONIC,
+  PAYMASTER_POLICY_ID,
+} from "./constants.js";
 
 const ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
 const SIMPLE_ACCOUNT_FACTORY_ADDRESS =
@@ -24,6 +29,7 @@ describe("Simple Account Tests", () => {
   const chain = polygonMumbai;
   const signer = new AlchemyProvider({
     apiKey: API_KEY,
+    rpcUrl: RPC_URL,
     chain,
     entryPointAddress: ENTRYPOINT_ADDRESS,
   }).connect(
@@ -57,6 +63,7 @@ describe("Simple Account Tests", () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const newSigner = new AlchemyProvider({
       apiKey: API_KEY,
+      rpcUrl: RPC_URL,
       chain,
       entryPointAddress: ENTRYPOINT_ADDRESS,
     }).connect(

--- a/packages/core/e2e-tests/constants.ts
+++ b/packages/core/e2e-tests/constants.ts
@@ -1,2 +1,3 @@
-export const API_KEY = process.env.API_KEY!;
+export const RPC_URL = process.env.RPC_URL;
+export const API_KEY = process.env.API_KEY;
 export const OWNER_MNEMONIC = process.env.OWNER_MNEMONIC!;

--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/account/simple.js";
 import { SmartAccountProvider } from "../src/provider/base.js";
 import { LocalAccountSigner } from "../src/signer/local-account.js";
-import { API_KEY, OWNER_MNEMONIC } from "./constants.js";
+import { RPC_URL, API_KEY, OWNER_MNEMONIC } from "./constants.js";
 
 const ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
 const SIMPLE_ACCOUNT_FACTORY_ADDRESS =
@@ -18,7 +18,7 @@ describe("Simple Account Tests", () => {
     LocalAccountSigner.mnemonicToAccountSigner(OWNER_MNEMONIC);
   const chain = polygonMumbai;
   const signer = new SmartAccountProvider(
-    `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
+    RPC_URL != null ? RPC_URL : `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
     ENTRYPOINT_ADDRESS,
     chain
   ).connect(
@@ -51,7 +51,7 @@ describe("Simple Account Tests", () => {
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const newSigner = new SmartAccountProvider(
-      `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
+      RPC_URL != null ? RPC_URL : `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
       ENTRYPOINT_ADDRESS,
       chain
     ).connect(
@@ -79,7 +79,7 @@ describe("Simple Account Tests", () => {
       generatePrivateKey()
     );
     const provider = new SmartAccountProvider(
-      `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
+      RPC_URL != null ? RPC_URL : `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
       ENTRYPOINT_ADDRESS,
       chain
     ).connect(

--- a/packages/ethers/e2e-tests/constants.ts
+++ b/packages/ethers/e2e-tests/constants.ts
@@ -1,2 +1,3 @@
-export const API_KEY = process.env.API_KEY!;
+export const RPC_URL = process.env.RPC_URL;
+export const API_KEY = process.env.API_KEY;
 export const OWNER_MNEMONIC = process.env.OWNER_MNEMONIC!;

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -3,7 +3,7 @@ import { Wallet } from "@ethersproject/wallet";
 import { Alchemy, Network } from "alchemy-sdk";
 import { EthersProviderAdapter } from "../src/provider-adapter.js";
 import { convertWalletToAccountSigner } from "../src/utils.js";
-import { API_KEY, OWNER_MNEMONIC } from "./constants.js";
+import { RPC_URL, API_KEY, OWNER_MNEMONIC } from "./constants.js";
 
 const ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
 const SIMPLE_ACCOUNT_FACTORY_ADDRESS =
@@ -12,6 +12,7 @@ const SIMPLE_ACCOUNT_FACTORY_ADDRESS =
 describe("Simple Account Tests", async () => {
   const alchemy = new Alchemy({
     apiKey: API_KEY,
+    url: RPC_URL,
     network: Network.MATIC_MUMBAI,
   });
   const alchemyProvider = await alchemy.config.getProvider();


### PR DESCRIPTION
Enable overriding the RPC URL used during e2e tests with a `RPC_URL` environment variable. Useful for when trying to run the e2e tests against an environment other than Alchemy production.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the code to use the `RPC_URL` constant instead of directly accessing the `API_KEY` in multiple files. 

### Detailed summary
- Updated code to import `RPC_URL` constant in multiple files
- Removed direct access to `API_KEY` in multiple files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->