### PR TITLE
feat(alchemy): use rundler_maxPriorityFeePerGas for fee estimate

### DIFF
--- a/examples/alchemy-daapp/src/configs/clientConfigs.ts
+++ b/examples/alchemy-daapp/src/configs/clientConfigs.ts
@@ -35,7 +35,7 @@ export const daappConfigurations: Record<number, DAAppConfiguration> = {
   },
   [sepolia.id]: {
     nftContractAddress: "0x5679b0de84bba361d31b2e7152ab20f0f8565245",
-    simpleAccountFactoryAddress: "0xc8c5736988F4Ea76B9f620dc678c23d5cBf3C83c",
+    simpleAccountFactoryAddress: "0x9406cc6185a346906296840746125a0e44976454",
     gasManagerPolicyId: env.NEXT_PUBLIC_SEPOLIA_POLICY_ID,
     rpcUrl: `/api/rpc/proxy?chainId=${sepolia.id}`,
     chain: sepolia,

--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
@@ -23,18 +23,6 @@ import {
   metaForStepIdentifier,
 } from "./OnboardingDataModels";
 
-export enum GasFeeStrategy {
-  DEFAULT = "DEFAULT",
-  FIXED = "FIXED",
-  BASE_FEE_PERCENTAGE = "BASE_FEE_PERCENTAGE",
-  PRIORITY_FEE_PERCENTAGE = "PRIORITY_FEE_PERCENTAGE",
-}
-
-export interface GasFeeMode {
-  strategy: GasFeeStrategy;
-  value: bigint;
-}
-
 async function pollForLambdaForComplete(
   lambda: () => Promise<boolean>,
   txnMaxDurationSeconds: number = 20

--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
@@ -100,7 +100,11 @@ const onboardingStepHandlers: Record<
     let baseSigner = new SmartAccountProvider(
       appConfig.rpcUrl,
       context.entrypointAddress!,
-      context.chain!
+      context.chain!,
+      undefined,
+      {
+        txMaxRetries: 60,
+      }
     ).connect((provider: any) => {
       if (!context.owner) {
         throw new Error("No owner for account was found");

--- a/packages/alchemy/src/chains.ts
+++ b/packages/alchemy/src/chains.ts
@@ -10,7 +10,6 @@ import {
   polygonMumbai,
   sepolia,
 } from "viem/chains";
-import { GasFeeStrategy, type GasFeeMode } from "./middleware/gas-fees.js";
 
 export const SupportedChains = new Map<number, Chain>([
   [polygonMumbai.id, polygonMumbai],
@@ -22,57 +21,4 @@ export const SupportedChains = new Map<number, Chain>([
   [arbitrum.id, arbitrum],
   [optimism.id, optimism],
   [optimismGoerli.id, optimismGoerli],
-]);
-
-const defineChainStrategy = (
-  chainId: number,
-  strategy: GasFeeStrategy,
-  value: GasFeeMode["value"]
-): [number, GasFeeMode] => {
-  return [chainId, { strategy, value }];
-};
-
-export const ChainFeeStrategies: Map<number, GasFeeMode> = new Map<
-  number,
-  GasFeeMode
->([
-  // testnets
-  defineChainStrategy(
-    goerli.id,
-    GasFeeStrategy.PRIORITY_FEE_INCREASE_PERCENT,
-    0n
-  ),
-  defineChainStrategy(
-    sepolia.id,
-    GasFeeStrategy.PRIORITY_FEE_INCREASE_PERCENT,
-    0n
-  ),
-  defineChainStrategy(
-    polygonMumbai.id,
-    GasFeeStrategy.PRIORITY_FEE_INCREASE_PERCENT,
-    0n
-  ),
-  defineChainStrategy(
-    optimismGoerli.id,
-    GasFeeStrategy.PERCENT_OF_BASE_FEE,
-    0n
-  ),
-  defineChainStrategy(
-    arbitrumGoerli.id,
-    GasFeeStrategy.PERCENT_OF_BASE_FEE,
-    0n
-  ),
-  // mainnets
-  defineChainStrategy(
-    mainnet.id,
-    GasFeeStrategy.PRIORITY_FEE_INCREASE_PERCENT,
-    57n
-  ),
-  defineChainStrategy(
-    polygon.id,
-    GasFeeStrategy.PRIORITY_FEE_INCREASE_PERCENT,
-    25n
-  ),
-  defineChainStrategy(optimism.id, GasFeeStrategy.PERCENT_OF_BASE_FEE, 5n),
-  defineChainStrategy(arbitrum.id, GasFeeStrategy.PERCENT_OF_BASE_FEE, 5n),
 ]);

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -1,8 +1,4 @@
-export {
-  GasFeeStrategy,
-  withAlchemyGasFeeEstimator,
-} from "./middleware/gas-fees.js";
-export type { GasFeeMode } from "./middleware/gas-fees.js";
+export { withAlchemyGasFeeEstimator } from "./middleware/gas-fees.js";
 
 export {
   withAlchemyGasManager,

--- a/packages/alchemy/src/middleware/client.ts
+++ b/packages/alchemy/src/middleware/client.ts
@@ -1,0 +1,45 @@
+import {
+  type PublicErc4337Client,
+  type UserOperationRequest,
+} from "@alchemy/aa-core";
+import type { Address, Hex } from "viem";
+
+export type ClientWithAlchemyMethods = PublicErc4337Client & {
+  request: PublicErc4337Client["request"] &
+    {
+      request(args: {
+        method: "alchemy_requestPaymasterAndData";
+        params: [
+          {
+            policyId: string;
+            entryPoint: Address;
+            userOperation: UserOperationRequest;
+          }
+        ];
+      }): Promise<{ paymasterAndData: Hex }>;
+
+      request(args: {
+        method: "alchemy_requestGasAndPaymasterAndData";
+        params: [
+          {
+            policyId: string;
+            entryPoint: Address;
+            userOperation: UserOperationRequest;
+            dummySignature: Hex;
+          }
+        ];
+      }): Promise<{
+        paymasterAndData: Hex;
+        callGasLimit: Hex;
+        verificationGasLimit: Hex;
+        preVerificationGas: Hex;
+        maxFeePerGas: Hex;
+        maxPriorityFeePerGas: Hex;
+      }>;
+
+      request(args: {
+        method: "rundler_maxPriorityFeePerGas";
+        params: [];
+      }): Promise<Hex>;
+    }["request"];
+};

--- a/packages/alchemy/src/middleware/client.ts
+++ b/packages/alchemy/src/middleware/client.ts
@@ -26,6 +26,10 @@ export type ClientWithAlchemyMethods = PublicErc4337Client & {
             entryPoint: Address;
             userOperation: UserOperationRequest;
             dummySignature: Hex;
+            feeOverride?: {
+              maxFeePerGas: Hex;
+              maxPriorityFeePerGas: Hex;
+            };
           }
         ];
       }): Promise<{

--- a/packages/alchemy/src/middleware/gas-fees.ts
+++ b/packages/alchemy/src/middleware/gas-fees.ts
@@ -1,54 +1,31 @@
 import type { AlchemyProvider } from "../provider.js";
 
-export enum GasFeeStrategy {
-  DEFAULT = "DEFAULT",
-  PERCENT_OF_BASE_FEE = "PERCENT_OF_BASE_FEE",
-  PRIORITY_FEE_INCREASE_PERCENT = "PRIORITY_FEE_INCREASE_PERCENT",
-}
-
-export interface GasFeeMode {
-  strategy: GasFeeStrategy;
-  value: bigint;
-}
-
 export const withAlchemyGasFeeEstimator = (
   provider: AlchemyProvider,
-  feeMode: GasFeeMode,
+  baseFeeBufferPercent: bigint,
   maxPriorityFeeBufferPercent: bigint
 ): AlchemyProvider => {
-  if (feeMode.strategy === GasFeeStrategy.DEFAULT) {
-    return provider;
-  }
-
   provider.withFeeDataGetter(async () => {
     const block = await provider.rpcClient.getBlock({ blockTag: "latest" });
     const baseFeePerGas = block.baseFeePerGas;
     if (baseFeePerGas == null) {
       throw new Error("baseFeePerGas is null");
     }
-    // add a buffer here to account for potential spikes in priority fee
-    const maxPriorityFeePerGas =
-      (BigInt(await provider.rpcClient.getMaxPriorityFeePerGas()) *
-        (100n + maxPriorityFeeBufferPercent)) /
-      100n;
-    // add 25% overhead to ensure mine
-    const baseFeeScaled = (baseFeePerGas * 5n) / 4n;
+    const priorityFeePerGas = BigInt(
+      await provider.alchemyClient.request({
+        method: "rundler_maxPriorityFeePerGas",
+        params: [],
+      })
+    );
 
-    const prioFee = ((): bigint => {
-      switch (feeMode.strategy) {
-        case GasFeeStrategy.PERCENT_OF_BASE_FEE:
-          return (baseFeeScaled * feeMode.value) / 100n;
-        case GasFeeStrategy.PRIORITY_FEE_INCREASE_PERCENT:
-          // add 10% to required priority fee to ensure mine
-          return (maxPriorityFeePerGas * (100n + feeMode.value)) / 100n;
-        default:
-          throw new Error("fee mode not supported");
-      }
-    })();
+    const baseFeeIncrease =
+      (baseFeePerGas * (100n + baseFeeBufferPercent)) / 100n;
+    const prioFeeIncrease =
+      (priorityFeePerGas * (100n + maxPriorityFeeBufferPercent)) / 100n;
 
     return {
-      maxPriorityFeePerGas: prioFee,
-      maxFeePerGas: baseFeeScaled + prioFee,
+      maxFeePerGas: baseFeeIncrease + prioFeeIncrease,
+      maxPriorityFeePerGas: prioFeeIncrease,
     };
   });
   return provider;

--- a/packages/alchemy/src/middleware/gas-manager.ts
+++ b/packages/alchemy/src/middleware/gas-manager.ts
@@ -3,43 +3,9 @@ import {
   resolveProperties,
   type ConnectedSmartAccountProvider,
   type PublicErc4337Client,
-  type UserOperationRequest,
 } from "@alchemy/aa-core";
-import type { Address, Hex, Transport } from "viem";
-
-type ClientWithAlchemyMethods = PublicErc4337Client & {
-  request: PublicErc4337Client["request"] &
-    {
-      request(args: {
-        method: "alchemy_requestPaymasterAndData";
-        params: [
-          {
-            policyId: string;
-            entryPoint: Address;
-            userOperation: UserOperationRequest;
-          }
-        ];
-      }): Promise<{ paymasterAndData: Hex }>;
-      request(args: {
-        method: "alchemy_requestGasAndPaymasterAndData";
-        params: [
-          {
-            policyId: string;
-            entryPoint: Address;
-            userOperation: UserOperationRequest;
-            dummySignature: Hex;
-          }
-        ];
-      }): Promise<{
-        paymasterAndData: Hex;
-        callGasLimit: Hex;
-        verificationGasLimit: Hex;
-        preVerificationGas: Hex;
-        maxFeePerGas: Hex;
-        maxPriorityFeePerGas: Hex;
-      }>;
-    }["request"];
-};
+import type { Address, Transport } from "viem";
+import type { ClientWithAlchemyMethods } from "./client.js";
 
 export interface AlchemyGasManagerConfig {
   policyId: string;

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -303,8 +303,8 @@ export class SmartAccountProvider<
     const initCode = await this.account.getInitCode();
     const uoStruct = await asyncPipe(
       this.dummyPaymasterDataMiddleware,
-      this.gasEstimator,
       this.feeDataGetter,
+      this.gasEstimator,
       this.paymasterDataMiddleware,
       this.customMiddleware ?? noOpMiddleware,
       // This applies the overrides if they've been passed in


### PR DESCRIPTION
Use the new `rundler_maxPriorityFeePerGas` instead of hardcoded fee modes during Alchemy provider fee estimation.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on refactoring and improving the gas fee handling and estimation logic in the Alchemy package.

### Detailed summary:
- The `GasFeeStrategy` enum and `GasFeeMode` interface have been removed from the `gas-fees.ts` file.
- The `GasFeeStrategy` enum and `GasFeeMode` interface have been removed from the `OnboardingController.ts` file.
- The `withAlchemyGasFeeEstimator` function in the `gas-fees.ts` file has been updated to accept `baseFeeBufferPercent` and `maxPriorityFeeBufferPercent` as parameters instead of `feeMode`.
- The `withAlchemyGasFeeEstimator` function in the `gas-fees.ts` file now uses the `alchemyClient.request` method to fetch the `maxPriorityFeePerGas` value.
- The `withAlchemyGasFeeEstimator` function in the `gas-fees.ts` file now calculates the `baseFeeIncrease` and `prioFeeIncrease` values based on the `baseFeeBufferPercent` and `maxPriorityFeeBufferPercent` parameters.
- The `withAlchemyGasManager` function in the `gas-manager.ts` file now uses the `provider.rpcClient` property instead of `config.provider` to access the RPC client.
- The `withAlchemyGasManager` function in the `gas-manager.ts` file now accepts `baseFeeBufferPercent` and `maxPriorityFeeBufferPercent` as parameters instead of `provider`.
- The `alchemyPaymasterAndDataMiddleware` function in the `gas-manager.ts` file now uses the `provider.rpcClient` property instead of `config.provider` to access the RPC client.

> The following files were skipped due to too many changes: `packages/alchemy/src/middleware/gas-manager.ts`, `packages/alchemy/src/provider.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->