### PR TITLE
refactor: add support for converting ethers wallet and ethers signer to SmartAccountOwner

### DIFF
--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -1,3 +1,6 @@
 export { AccountSigner } from "./account-signer.js";
 export { EthersProviderAdapter } from "./provider-adapter.js";
-export { convertWalletToAccountSigner } from "./utils.js";
+export {
+  convertEthersSignerToAccountSigner,
+  convertWalletToAccountSigner,
+} from "./utils.js";

--- a/packages/ethers/src/utils.ts
+++ b/packages/ethers/src/utils.ts
@@ -1,10 +1,11 @@
-import type { SimpleSmartAccountOwner } from "@alchemy/aa-core";
+import type { Address, SmartAccountSigner } from "@alchemy/aa-core";
+import type { Signer } from "@ethersproject/abstract-signer";
 import { Wallet } from "@ethersproject/wallet";
 import type { SignTypedDataParameters } from "viem/accounts";
 
 export const convertWalletToAccountSigner = (
   wallet: Wallet
-): SimpleSmartAccountOwner => {
+): SmartAccountSigner => {
   return {
     getAddress: async () => Promise.resolve(wallet.address as `0x${string}`),
     signMessage: async (msg: Uint8Array | string) =>
@@ -18,6 +19,23 @@ export const convertWalletToAccountSigner = (
         params.types,
         params.message
       )) as `0x${string}`;
+    },
+  };
+};
+
+export const convertEthersSignerToAccountSigner = (
+  signer: Signer
+): SmartAccountSigner => {
+  return {
+    getAddress: async () => signer.getAddress() as Promise<Address>,
+    signMessage: async (msg: Uint8Array | string) =>
+      (await signer.signMessage(msg)) as `0x${string}`,
+    signTypedData: async (
+      _params: Omit<SignTypedDataParameters, "privateKey">
+    ) => {
+      throw new Error(
+        "signTypedData is not supported for ethers signers; use Wallet"
+      );
     },
   };
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new function `convertEthersSignerToAccountSigner` to the `utils.ts` file in the `ethers` package.

### Detailed summary:
- Added `convertEthersSignerToAccountSigner` function to `utils.ts`.
- Imported `Address` and `SmartAccountSigner` types from `@alchemy/aa-core`.
- Imported `Signer` type from `@ethersproject/abstract-signer`.
- Updated `convertWalletToAccountSigner` function in `utils.ts` to return `SmartAccountSigner` instead of `SimpleSmartAccountOwner`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->