### PR TITLE
fix: send transaction clobbers fee (fixes #67)

### DIFF
--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -159,16 +159,21 @@ export class SmartAccountProvider<
       throw new Error("transaction is missing to address");
     }
 
+    const overrides: UserOperationOverrides = {};
+    if (request.maxFeePerGas) {
+      overrides.maxFeePerGas = request.maxFeePerGas;
+    }
+    if (request.maxPriorityFeePerGas) {
+      overrides.maxPriorityFeePerGas = request.maxPriorityFeePerGas;
+    }
+
     const { hash } = await this.sendUserOperation(
       {
         target: request.to,
         data: request.data ?? "0x",
         value: request.value ? fromHex(request.value, "bigint") : 0n,
       },
-      {
-        maxFeePerGas: request.maxFeePerGas,
-        maxPriorityFeePerGas: request.maxPriorityFeePerGas,
-      }
+      overrides
     );
 
     return await this.waitForUserOperationTransaction(hash as Hash);
@@ -239,11 +244,16 @@ export class SmartAccountProvider<
         .filter((x) => x.maxPriorityFeePerGas != null)
         .map((x) => fromHex(x.maxPriorityFeePerGas!, "bigint"))
     );
+    const overrides: UserOperationOverrides = {};
+    if (maxFeePerGas != null) {
+      overrides.maxFeePerGas = maxFeePerGas;
+    }
 
-    const { hash } = await this.sendUserOperation(batch, {
-      maxFeePerGas,
-      maxPriorityFeePerGas,
-    });
+    if (maxPriorityFeePerGas != null) {
+      overrides.maxPriorityFeePerGas = maxPriorityFeePerGas;
+    }
+
+    const { hash } = await this.sendUserOperation(batch, overrides);
 
     return await this.waitForUserOperationTransaction(hash as Hash);
   };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the code to use overrides for maxFeePerGas and maxPriorityFeePerGas in the SmartAccountProvider class.

### Detailed summary
- Introduces a new `overrides` object to store the overrides for maxFeePerGas and maxPriorityFeePerGas.
- If the request includes maxFeePerGas, it is added to the overrides object.
- If the request includes maxPriorityFeePerGas, it is added to the overrides object.
- The `sendUserOperation` function is called with the `overrides` object instead of separate maxFeePerGas and maxPriorityFeePerGas arguments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->