### PR TITLE
feat: add jwt support for Alchemy providers

### DIFF
--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -1,3 +1,4 @@
+import * as AACoreModule from "@alchemy/aa-core";
 import {
   SimpleSmartContractAccount,
   type BatchUserOperationCallData,
@@ -21,7 +22,8 @@ describe("Alchemy Provider Tests", () => {
   };
   const chain = polygonMumbai;
   const signer = new AlchemyProvider({
-    apiKey: "test",
+    rpcUrl: "https://eth-mainnet.g.alchemy.com/v2",
+    jwtToken: "test",
     chain,
     entryPointAddress: "0xENTRYPOINT_ADDRESS",
   }).connect((provider) => {
@@ -38,6 +40,23 @@ describe("Alchemy Provider Tests", () => {
     );
 
     return account;
+  });
+
+  it("should have a JWT propety", async () => {
+    const spy = vi.spyOn(AACoreModule, "createPublicErc4337Client");
+    new AlchemyProvider({
+      rpcUrl: "https://eth-mainnet.g.alchemy.com/v2",
+      jwtToken: "test",
+      chain,
+      entryPointAddress: "0xENTRYPOINT_ADDRESS",
+    });
+    expect(spy.mock.calls[0][0].fetchOptions).toMatchInlineSnapshot(`
+      {
+        "headers": {
+          "Authorization": "bearer test",
+        },
+      }
+    `);
   });
 
   it("should correctly sign the message", async () => {

--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -53,7 +53,7 @@ describe("Alchemy Provider Tests", () => {
     expect(spy.mock.calls[0][0].fetchOptions).toMatchInlineSnapshot(`
       {
         "headers": {
-          "Authorization": "bearer test",
+          "Authorization": "Bearer test",
         },
       }
     `);

--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -23,7 +23,7 @@ describe("Alchemy Provider Tests", () => {
   const chain = polygonMumbai;
   const signer = new AlchemyProvider({
     rpcUrl: "https://eth-mainnet.g.alchemy.com/v2",
-    jwtToken: "test",
+    jwt: "test",
     chain,
     entryPointAddress: "0xENTRYPOINT_ADDRESS",
   }).connect((provider) => {
@@ -46,7 +46,7 @@ describe("Alchemy Provider Tests", () => {
     const spy = vi.spyOn(AACoreModule, "createPublicErc4337Client");
     new AlchemyProvider({
       rpcUrl: "https://eth-mainnet.g.alchemy.com/v2",
-      jwtToken: "test",
+      jwt: "test",
       chain,
       entryPointAddress: "0xENTRYPOINT_ADDRESS",
     });

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -7,4 +7,4 @@ export {
 
 export { SupportedChains } from "./chains.js";
 export { AlchemyProvider } from "./provider.js";
-export type { AlchemyProviderConfig } from "./provider.js";
+export type { AlchemyProviderConfig, ConnectionConfig } from "./provider.js";

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -1,12 +1,13 @@
 import {
   BaseSmartContractAccount,
   SmartAccountProvider,
+  createPublicErc4337Client,
   deepHexlify,
   resolveProperties,
   type AccountMiddlewareFn,
   type SmartAccountProviderOpts,
 } from "@alchemy/aa-core";
-import type { Address, Chain, HttpTransport } from "viem";
+import { type Address, type Chain, type HttpTransport } from "viem";
 import {
   arbitrum,
   arbitrumGoerli,
@@ -14,20 +15,21 @@ import {
   optimismGoerli,
 } from "viem/chains";
 import { SupportedChains } from "./chains.js";
+import type { ClientWithAlchemyMethods } from "./middleware/client.js";
+import { withAlchemyGasFeeEstimator } from "./middleware/gas-fees.js";
 import {
+  alchemyPaymasterAndDataMiddleware,
   withAlchemyGasManager,
   type AlchemyGasManagerConfig,
-  alchemyPaymasterAndDataMiddleware,
 } from "./middleware/gas-manager.js";
-import { withAlchemyGasFeeEstimator } from "./middleware/gas-fees.js";
-import type { ClientWithAlchemyMethods } from "./middleware/client.js";
 
 type ConnectionConfig =
   | {
       apiKey: string;
       rpcUrl?: undefined;
     }
-  | { rpcUrl: string; apiKey?: undefined };
+  | { rpcUrl: string; apiKey?: undefined }
+  | { rpcUrl: string; apiKey?: undefined; jwtToken: string };
 
 export type AlchemyProviderConfig = {
   chain: Chain | number;
@@ -82,7 +84,19 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
         ? `${_chain.rpcUrls.alchemy.http[0]}/${connectionConfig.apiKey}`
         : connectionConfig.rpcUrl;
 
-    super(rpcUrl, entryPointAddress, _chain, account, opts);
+    const client = createPublicErc4337Client({
+      chain: _chain,
+      rpcUrl,
+      ...("jwtToken" in connectionConfig && {
+        fetchOptions: {
+          headers: {
+            Authorization: `bearer ${connectionConfig.jwtToken}`,
+          },
+        },
+      }),
+    });
+
+    super(client, entryPointAddress, _chain, account, opts);
 
     this.alchemyClient = this.rpcClient as ClientWithAlchemyMethods;
     withAlchemyGasFeeEstimator(

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -23,12 +23,9 @@ import {
   type AlchemyGasManagerConfig,
 } from "./middleware/gas-manager.js";
 
-type ConnectionConfig =
-  | {
-      apiKey: string;
-      rpcUrl?: never;
-    }
-  | { rpcUrl: string; apiKey?: never }
+export type ConnectionConfig =
+  | { rpcUrl?: never; apiKey: string; jwt?: never }
+  | { rpcUrl: string; apiKey?: never; jwt?: never }
   | { rpcUrl: string; apiKey?: never; jwt: string };
 
 export type AlchemyProviderConfig = {
@@ -87,7 +84,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
     const client = createPublicErc4337Client({
       chain: _chain,
       rpcUrl,
-      ...("jwt" in connectionConfig && {
+      ...(connectionConfig.jwt != null && {
         fetchOptions: {
           headers: {
             Authorization: `Bearer ${connectionConfig.jwt}`,

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -29,7 +29,7 @@ type ConnectionConfig =
       rpcUrl?: undefined;
     }
   | { rpcUrl: string; apiKey?: undefined }
-  | { rpcUrl: string; apiKey?: undefined; jwtToken: string };
+  | { rpcUrl: string; apiKey?: undefined; jwt: string };
 
 export type AlchemyProviderConfig = {
   chain: Chain | number;
@@ -87,10 +87,10 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
     const client = createPublicErc4337Client({
       chain: _chain,
       rpcUrl,
-      ...("jwtToken" in connectionConfig && {
+      ...("jwt" in connectionConfig && {
         fetchOptions: {
           headers: {
-            Authorization: `Bearer ${connectionConfig.jwtToken}`,
+            Authorization: `Bearer ${connectionConfig.jwt}`,
           },
         },
       }),

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -26,10 +26,10 @@ import {
 type ConnectionConfig =
   | {
       apiKey: string;
-      rpcUrl?: undefined;
+      rpcUrl?: never;
     }
-  | { rpcUrl: string; apiKey?: undefined }
-  | { rpcUrl: string; apiKey?: undefined; jwt: string };
+  | { rpcUrl: string; apiKey?: never }
+  | { rpcUrl: string; apiKey?: never; jwt: string };
 
 export type AlchemyProviderConfig = {
   chain: Chain | number;

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -90,7 +90,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
       ...("jwtToken" in connectionConfig && {
         fetchOptions: {
           headers: {
-            Authorization: `bearer ${connectionConfig.jwtToken}`,
+            Authorization: `Bearer ${connectionConfig.jwtToken}`,
           },
         },
       }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a JWT (JSON Web Token) property to the `AlchemyProviderConfig` and `ConnectionConfig` types in order to support authentication with Alchemy API.

### Detailed summary:
- Added `ConnectionConfig` type to support different connection configurations.
- Added `jwt` property to the `ConnectionConfig` type to store the JSON Web Token.
- Updated `AlchemyProviderConfig` type to include `jwt` property.
- Updated `AlchemyProvider` constructor to accept `jwt` property in the connection configuration.
- Added a test to ensure the JWT property is correctly passed to the `createPublicErc4337Client` function.
- Updated imports and removed unused imports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->