### PR TITLE
fix: update the typing for alchemy provider to support an additional JWT case

### DIFF
--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -25,6 +25,7 @@ import {
 
 export type ConnectionConfig =
   | { rpcUrl?: never; apiKey: string; jwt?: never }
+  | { rpcUrl?: never; apiKey?: never; jwt: string }
   | { rpcUrl: string; apiKey?: never; jwt?: never }
   | { rpcUrl: string; apiKey?: never; jwt: string };
 
@@ -77,8 +78,8 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
     }
 
     const rpcUrl =
-      connectionConfig.apiKey !== undefined
-        ? `${_chain.rpcUrls.alchemy.http[0]}/${connectionConfig.apiKey}`
+      connectionConfig.rpcUrl == null
+        ? `${_chain.rpcUrls.alchemy.http[0]}/${connectionConfig.apiKey ?? ""}`
         : connectionConfig.rpcUrl;
 
     const client = createPublicErc4337Client({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the `ConnectionConfig` type and modifying the `rpcUrl` assignment in the `AlchemyProvider` class.

### Detailed summary:
- Updated the `ConnectionConfig` type to allow for different combinations of `rpcUrl`, `apiKey`, and `jwt` properties.
- Modified the `rpcUrl` assignment in the `AlchemyProvider` class to handle the updated `ConnectionConfig` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->