### PR TITLE
fix: pass overrides from tx to user op

### DIFF
--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -221,11 +221,14 @@ export class SmartAccountProvider<
       overrides.maxPriorityFeePerGas = request.maxPriorityFeePerGas;
     }
 
-    return this.buildUserOperation({
-      target: request.to,
-      data: request.data ?? "0x",
-      value: request.value ? fromHex(request.value, "bigint") : 0n,
-    });
+    return this.buildUserOperation(
+      {
+        target: request.to,
+        data: request.data ?? "0x",
+        value: request.value ? fromHex(request.value, "bigint") : 0n,
+      },
+      overrides
+    );
   };
 
   sendTransactions = async (requests: RpcTransactionRequest[]) => {


### PR DESCRIPTION
The PR makes sure TX overrides to be passed into user op.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to update the `buildUserOperation` function in the `base.ts` file.
- Notable changes include:
  - The `buildUserOperation` function now accepts an additional `overrides` parameter.
  - The `overrides` parameter is passed as an argument when calling the `buildUserOperation` function in the `sendTransactions` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->