### PR TITLE
fix(core): add missing `null` return type of `eth_getUserOperation*` methods

### DIFF
--- a/packages/core/src/client/create-client.ts
+++ b/packages/core/src/client/create-client.ts
@@ -62,14 +62,14 @@ export const createPublicErc4337FromClient: <
       });
     },
 
-    getUserOperationByHash(hash: Hash): Promise<UserOperationResponse> {
+    getUserOperationByHash(hash: Hash): Promise<UserOperationResponse | null> {
       return clientAdapter.request({
         method: "eth_getUserOperationByHash",
         params: [hash],
       });
     },
 
-    getUserOperationReceipt(hash: Hash): Promise<UserOperationReceipt> {
+    getUserOperationReceipt(hash: Hash): Promise<UserOperationReceipt | null> {
       return clientAdapter.request({
         method: "eth_getUserOperationReceipt",
         params: [hash],

--- a/packages/core/src/client/types.ts
+++ b/packages/core/src/client/types.ts
@@ -36,12 +36,12 @@ export type Erc337RpcSchema = [
   {
     Method: "eth_getUserOperationReceipt";
     Parameters: [Hash];
-    ReturnType: UserOperationReceipt;
+    ReturnType: UserOperationReceipt | null;
   },
   {
     Method: "eth_getUserOperationByHash";
     Parameters: [Hash];
-    ReturnType: UserOperationResponse;
+    ReturnType: UserOperationResponse | null;
   },
   {
     Method: "eth_supportedEntryPoints";
@@ -86,7 +86,7 @@ export interface Erc4337Actions {
    * @param hash - the hash of the UserOperation to get the receipt for
    * @returns - {@link UserOperationResponse}
    */
-  getUserOperationByHash(hash: Hash): Promise<UserOperationResponse>;
+  getUserOperationByHash(hash: Hash): Promise<UserOperationResponse | null>;
 
   /**
    * calls `eth_getUserOperationReceipt` and returns the {@link UserOperationReceipt}
@@ -94,7 +94,7 @@ export interface Erc4337Actions {
    * @param hash - the hash of the UserOperation to get the receipt for
    * @returns - {@link UserOperationResponse}
    */
-  getUserOperationReceipt(hash: Hash): Promise<UserOperationReceipt>;
+  getUserOperationReceipt(hash: Hash): Promise<UserOperationReceipt | null>;
 
   /**
    * calls `eth_supportedEntryPoints` and returns the entrypoints the RPC

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -301,11 +301,15 @@ export class SmartAccountProvider<
     throw new Error("Failed to find transaction for User Operation");
   };
 
-  getUserOperationByHash = (hash: Hash): Promise<UserOperationResponse> => {
+  getUserOperationByHash = (
+    hash: Hash
+  ): Promise<UserOperationResponse | null> => {
     return this.rpcClient.getUserOperationByHash(hash);
   };
 
-  getUserOperationReceipt = (hash: Hash): Promise<UserOperationReceipt> => {
+  getUserOperationReceipt = (
+    hash: Hash
+  ): Promise<UserOperationReceipt | null> => {
     return this.rpcClient.getUserOperationReceipt(hash);
   };
 

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -133,7 +133,7 @@ export interface ISmartAccountProvider<
    * @param hash - the hash of the UserOperation to get the receipt for
    * @returns - {@link UserOperationResponse}
    */
-  getUserOperationByHash: (hash: Hash) => Promise<UserOperationResponse>;
+  getUserOperationByHash: (hash: Hash) => Promise<UserOperationResponse | null>;
 
   /**
    * calls `eth_getUserOperationReceipt` and returns the {@link UserOperationReceipt}
@@ -141,7 +141,7 @@ export interface ISmartAccountProvider<
    * @param hash - the hash of the UserOperation to get the receipt for
    * @returns - {@link UserOperationResponse}
    */
-  getUserOperationReceipt: (hash: Hash) => Promise<UserOperationReceipt>;
+  getUserOperationReceipt: (hash: Hash) => Promise<UserOperationReceipt | null>;
 
   /**
    * This takes an ethereum transaction and converts it into a UserOperation, sends the UserOperation, and waits


### PR DESCRIPTION
Fixes #92.

This PR fixes the missing `null` in the return type of `eth_getUserOperationReceipt` outlined in #92. Additionally, it adds a `null` return type for `eth_getUserOperationByHash`, which has a similar type bug.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a nullable return type to the `getUserOperationByHash` and `getUserOperationReceipt` functions. 

### Detailed summary
- Modified the `getUserOperationByHash` function in `base.ts` to return `UserOperationResponse | null`.
- Modified the `getUserOperationReceipt` function in `base.ts` to return `UserOperationReceipt | null`.
- Updated the `getUserOperationByHash` function in `create-client.ts` to return `UserOperationResponse | null`.
- Updated the `getUserOperationReceipt` function in `create-client.ts` to return `UserOperationReceipt | null`.
- Added `| null` to the return type of `getUserOperationByHash` in `types.ts`.
- Added `| null` to the return type of `getUserOperationReceipt` in `types.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->