### PR TITLE
fix: wrong param in readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ let provider = new AlchemyProvider({
 
 // [OPTIONAL] Use Alchemy Gas Manager
 provider = provider.withAlchemyGasManager({
-  provider: provider.rpcClient,
   policyId: PAYMASTER_POLICY_ID,
   entryPoint: ENTRYPOINT_ADDRESS,
 });


### PR DESCRIPTION
Noticed that `provider.withAlchemyGasManager()` only accepts `policyId` and `entryPoint` as you can verify here: 

https://github.com/alchemyplatform/aa-sdk/blob/main/packages/alchemy/src/middleware/gas-manager.ts#L10-L13

So removed the `provider` param which is not required.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
This PR focuses on using Alchemy Gas Manager for the provider with specific policy and entry point addresses.

- The `provider` is being updated with Alchemy Gas Manager.
- The `policyId` and `entryPoint` addresses are specified for the Alchemy Gas Manager.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->