### PR TITLE
fix: remove type `SimpleSmartAccountOwner`

### DIFF
--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -1,98 +1,98 @@
 import type { Address } from "abitype";
 import {
-    concatHex,
-    encodeFunctionData,
-    hexToBytes,
-    type FallbackTransport,
-    type Hex,
-    type Transport,
+  concatHex,
+  encodeFunctionData,
+  hexToBytes,
+  type FallbackTransport,
+  type Hex,
+  type Transport,
 } from "viem";
 import { SimpleAccountAbi } from "../abis/SimpleAccountAbi.js";
 import { SimpleAccountFactoryAbi } from "../abis/SimpleAccountFactoryAbi.js";
 import type { BatchUserOperationCallData } from "../types.js";
 import {
-    BaseSmartContractAccount,
-    type BaseSmartAccountParams,
+  BaseSmartContractAccount,
+  type BaseSmartAccountParams,
 } from "./base.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 
 export interface SimpleSmartAccountParams<
-    TTransport extends Transport | FallbackTransport = Transport
+  TTransport extends Transport | FallbackTransport = Transport
 > extends BaseSmartAccountParams<TTransport> {
-    owner: SmartAccountSigner;
-    factoryAddress: Address;
-    index?: bigint;
+  owner: SmartAccountSigner;
+  factoryAddress: Address;
+  index?: bigint;
 }
 
 export class SimpleSmartContractAccount<
-    TTransport extends Transport | FallbackTransport = Transport
+  TTransport extends Transport | FallbackTransport = Transport
 > extends BaseSmartContractAccount<TTransport> {
-    protected owner: SmartAccountSigner;
-    protected factoryAddress: Address;
-    protected index: bigint;
+  protected owner: SmartAccountSigner;
+  protected factoryAddress: Address;
+  protected index: bigint;
 
-    constructor(params: SimpleSmartAccountParams) {
-        super(params);
+  constructor(params: SimpleSmartAccountParams) {
+    super(params);
 
-        this.index = params.index ?? 0n;
-        this.owner = params.owner;
-        this.factoryAddress = params.factoryAddress;
+    this.index = params.index ?? 0n;
+    this.owner = params.owner;
+    this.factoryAddress = params.factoryAddress;
+  }
+
+  getDummySignature(): `0x${string}` {
+    return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+  }
+
+  async encodeExecute(
+    target: Hex,
+    value: bigint,
+    data: Hex
+  ): Promise<`0x${string}`> {
+    return encodeFunctionData({
+      abi: SimpleAccountAbi,
+      functionName: "execute",
+      args: [target, value, data],
+    });
+  }
+
+  override async encodeBatchExecute(
+    _txs: BatchUserOperationCallData
+  ): Promise<`0x${string}`> {
+    const [targets, datas] = _txs.reduce(
+      (accum, curr) => {
+        accum[0].push(curr.target);
+        accum[1].push(curr.data);
+
+        return accum;
+      },
+      [[], []] as [Address[], Hex[]]
+    );
+
+    return encodeFunctionData({
+      abi: SimpleAccountAbi,
+      functionName: "executeBatch",
+      args: [targets, datas],
+    });
+  }
+
+  signMessage(msg: Uint8Array | string): Promise<`0x${string}`> {
+    if (typeof msg === "string" && msg.startsWith("0x")) {
+      msg = hexToBytes(msg as Hex);
+    } else if (typeof msg === "string") {
+      msg = new TextEncoder().encode(msg);
     }
 
-    getDummySignature(): `0x${string}` {
-        return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
-    }
+    return this.owner.signMessage(msg);
+  }
 
-    async encodeExecute(
-        target: Hex,
-        value: bigint,
-        data: Hex
-    ): Promise<`0x${string}`> {
-        return encodeFunctionData({
-            abi: SimpleAccountAbi,
-            functionName: "execute",
-            args: [target, value, data],
-        });
-    }
-
-    override async encodeBatchExecute(
-        _txs: BatchUserOperationCallData
-    ): Promise<`0x${string}`> {
-        const [targets, datas] = _txs.reduce(
-            (accum, curr) => {
-                accum[0].push(curr.target);
-                accum[1].push(curr.data);
-
-                return accum;
-            },
-            [[], []] as [Address[], Hex[]]
-        );
-
-        return encodeFunctionData({
-            abi: SimpleAccountAbi,
-            functionName: "executeBatch",
-            args: [targets, datas],
-        });
-    }
-
-    signMessage(msg: Uint8Array | string): Promise<`0x${string}`> {
-        if (typeof msg === "string" && msg.startsWith("0x")) {
-            msg = hexToBytes(msg as Hex);
-        } else if (typeof msg === "string") {
-            msg = new TextEncoder().encode(msg);
-        }
-
-        return this.owner.signMessage(msg);
-    }
-
-    protected async getAccountInitCode(): Promise<`0x${string}`> {
-        return concatHex([
-            this.factoryAddress,
-            encodeFunctionData({
-                abi: SimpleAccountFactoryAbi,
-                functionName: "createAccount",
-                args: [await this.owner.getAddress(), this.index],
-            }),
-        ]);
-    }
+  protected async getAccountInitCode(): Promise<`0x${string}`> {
+    return concatHex([
+      this.factoryAddress,
+      encodeFunctionData({
+        abi: SimpleAccountFactoryAbi,
+        functionName: "createAccount",
+        args: [await this.owner.getAddress(), this.index],
+      }),
+    ]);
+  }
 }

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -1,105 +1,98 @@
 import type { Address } from "abitype";
 import {
-  concatHex,
-  encodeFunctionData,
-  hexToBytes,
-  type FallbackTransport,
-  type Hash,
-  type Hex,
-  type Transport,
+    concatHex,
+    encodeFunctionData,
+    hexToBytes,
+    type FallbackTransport,
+    type Hex,
+    type Transport,
 } from "viem";
 import { SimpleAccountAbi } from "../abis/SimpleAccountAbi.js";
 import { SimpleAccountFactoryAbi } from "../abis/SimpleAccountFactoryAbi.js";
 import type { BatchUserOperationCallData } from "../types.js";
 import {
-  BaseSmartContractAccount,
-  type BaseSmartAccountParams,
+    BaseSmartContractAccount,
+    type BaseSmartAccountParams,
 } from "./base.js";
-import type { SignTypedDataParams } from "./types.js";
-
-export interface SimpleSmartAccountOwner {
-  signMessage: (msg: Uint8Array) => Promise<Hash>;
-  getAddress: () => Promise<Address>;
-  signTypedData: (params: SignTypedDataParams) => Promise<Hash>;
-}
+import type { SmartAccountSigner } from "../signer/types.js";
 
 export interface SimpleSmartAccountParams<
-  TTransport extends Transport | FallbackTransport = Transport
+    TTransport extends Transport | FallbackTransport = Transport
 > extends BaseSmartAccountParams<TTransport> {
-  owner: SimpleSmartAccountOwner;
-  factoryAddress: Address;
-  index?: bigint;
+    owner: SmartAccountSigner;
+    factoryAddress: Address;
+    index?: bigint;
 }
 
 export class SimpleSmartContractAccount<
-  TTransport extends Transport | FallbackTransport = Transport
+    TTransport extends Transport | FallbackTransport = Transport
 > extends BaseSmartContractAccount<TTransport> {
-  protected owner: SimpleSmartAccountOwner;
-  protected factoryAddress: Address;
-  protected index: bigint;
+    protected owner: SmartAccountSigner;
+    protected factoryAddress: Address;
+    protected index: bigint;
 
-  constructor(params: SimpleSmartAccountParams) {
-    super(params);
+    constructor(params: SimpleSmartAccountParams) {
+        super(params);
 
-    this.index = params.index ?? 0n;
-    this.owner = params.owner;
-    this.factoryAddress = params.factoryAddress;
-  }
-
-  getDummySignature(): `0x${string}` {
-    return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
-  }
-
-  async encodeExecute(
-    target: Hex,
-    value: bigint,
-    data: Hex
-  ): Promise<`0x${string}`> {
-    return encodeFunctionData({
-      abi: SimpleAccountAbi,
-      functionName: "execute",
-      args: [target, value, data],
-    });
-  }
-
-  override async encodeBatchExecute(
-    _txs: BatchUserOperationCallData
-  ): Promise<`0x${string}`> {
-    const [targets, datas] = _txs.reduce(
-      (accum, curr) => {
-        accum[0].push(curr.target);
-        accum[1].push(curr.data);
-
-        return accum;
-      },
-      [[], []] as [Address[], Hex[]]
-    );
-
-    return encodeFunctionData({
-      abi: SimpleAccountAbi,
-      functionName: "executeBatch",
-      args: [targets, datas],
-    });
-  }
-
-  signMessage(msg: Uint8Array | string): Promise<`0x${string}`> {
-    if (typeof msg === "string" && msg.startsWith("0x")) {
-      msg = hexToBytes(msg as Hex);
-    } else if (typeof msg === "string") {
-      msg = new TextEncoder().encode(msg);
+        this.index = params.index ?? 0n;
+        this.owner = params.owner;
+        this.factoryAddress = params.factoryAddress;
     }
 
-    return this.owner.signMessage(msg);
-  }
+    getDummySignature(): `0x${string}` {
+        return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+    }
 
-  protected async getAccountInitCode(): Promise<`0x${string}`> {
-    return concatHex([
-      this.factoryAddress,
-      encodeFunctionData({
-        abi: SimpleAccountFactoryAbi,
-        functionName: "createAccount",
-        args: [await this.owner.getAddress(), this.index],
-      }),
-    ]);
-  }
+    async encodeExecute(
+        target: Hex,
+        value: bigint,
+        data: Hex
+    ): Promise<`0x${string}`> {
+        return encodeFunctionData({
+            abi: SimpleAccountAbi,
+            functionName: "execute",
+            args: [target, value, data],
+        });
+    }
+
+    override async encodeBatchExecute(
+        _txs: BatchUserOperationCallData
+    ): Promise<`0x${string}`> {
+        const [targets, datas] = _txs.reduce(
+            (accum, curr) => {
+                accum[0].push(curr.target);
+                accum[1].push(curr.data);
+
+                return accum;
+            },
+            [[], []] as [Address[], Hex[]]
+        );
+
+        return encodeFunctionData({
+            abi: SimpleAccountAbi,
+            functionName: "executeBatch",
+            args: [targets, datas],
+        });
+    }
+
+    signMessage(msg: Uint8Array | string): Promise<`0x${string}`> {
+        if (typeof msg === "string" && msg.startsWith("0x")) {
+            msg = hexToBytes(msg as Hex);
+        } else if (typeof msg === "string") {
+            msg = new TextEncoder().encode(msg);
+        }
+
+        return this.owner.signMessage(msg);
+    }
+
+    protected async getAccountInitCode(): Promise<`0x${string}`> {
+        return concatHex([
+            this.factoryAddress,
+            encodeFunctionData({
+                abi: SimpleAccountFactoryAbi,
+                functionName: "createAccount",
+                args: [await this.owner.getAddress(), this.index],
+            }),
+        ]);
+    }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,10 +9,7 @@ export { SimpleAccountFactoryAbi } from "./abis/SimpleAccountFactoryAbi.js";
 export { BaseSmartContractAccount } from "./account/base.js";
 export type { BaseSmartAccountParams } from "./account/base.js";
 export { SimpleSmartContractAccount } from "./account/simple.js";
-export type {
-  SimpleSmartAccountOwner,
-  SimpleSmartAccountParams,
-} from "./account/simple.js";
+export type { SimpleSmartAccountParams } from "./account/simple.js";
 export type * from "./account/types.js";
 export { HdAccountSigner } from "./signer/hd-account.js";
 export { LocalAccountSigner } from "./signer/local-account.js";


### PR DESCRIPTION
Fixes #89

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `SimpleSmartAccountParams` and `SimpleSmartContractAccount` interfaces in the `core` package. 

### Detailed summary
- Removed the `SimpleSmartAccountOwner` interface and replaced it with the `SmartAccountSigner` type in `SimpleSmartAccountParams` interface.
- Updated the `owner` property type in `SimpleSmartAccountParams` and `SimpleSmartContractAccount` classes to `SmartAccountSigner`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->