### PR TITLE
feat: add `dropAndReplaceUserOperation`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export {
   getChain,
   getUserOperationHash,
   resolveProperties,
+  bigIntMax,
 } from "./utils.js";
 
 export { Logger } from "./logger.js";

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -34,6 +34,7 @@ import {
   getUserOperationHash,
   resolveProperties,
   type Deferrable,
+  bigIntMax,
 } from "../utils.js";
 import type {
   AccountMiddlewareFn,
@@ -254,13 +255,13 @@ export class SmartAccountProvider<
       };
     });
 
-    const maxFeePerGas = this.bigIntMax(
+    const maxFeePerGas = bigIntMax(
       ...requests
         .filter((x) => x.maxFeePerGas != null)
         .map((x) => fromHex(x.maxFeePerGas!, "bigint"))
     );
 
-    const maxPriorityFeePerGas = this.bigIntMax(
+    const maxPriorityFeePerGas = bigIntMax(
       ...requests
         .filter((x) => x.maxPriorityFeePerGas != null)
         .map((x) => fromHex(x.maxPriorityFeePerGas!, "bigint"))
@@ -401,20 +402,20 @@ export class SmartAccountProvider<
     const newUo = await this._runMiddlewareStack(data);
 
     if (newUo.maxFeePerGas)
-      newUo.maxFeePerGas = this.bigIntMax(
+      newUo.maxFeePerGas = bigIntMax(
         BigInt(newUo.maxFeePerGas),
         (BigInt(oldUO.maxFeePerGas) * 110n) / 100n
       );
 
     if (newUo.maxPriorityFeePerGas)
-      newUo.maxPriorityFeePerGas = this.bigIntMax(
+      newUo.maxPriorityFeePerGas = bigIntMax(
         BigInt(newUo.maxPriorityFeePerGas),
         (BigInt(oldUO.maxPriorityFeePerGas) * 110n) / 100n
       );
 
     // callGasLimit can change if some other UserOp or Transaction took place meanwhile.
     if (newUo.callGasLimit)
-      newUo.callGasLimit = this.bigIntMax(
+      newUo.callGasLimit = bigIntMax(
         BigInt(newUo.callGasLimit),
         BigInt(oldUO.callGasLimit)
       );

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -584,12 +584,4 @@ export class SmartAccountProvider<
 
     return resolveProperties(uoStruct);
   };
-
-  private bigIntMax = (...args: bigint[]) => {
-    if (!args.length) {
-      return undefined;
-    }
-
-    return args.reduce((m, c) => (m > c ? m : c));
-  };
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -155,3 +155,17 @@ export function defineReadOnly<T, K extends keyof T>(
     writable: false,
   });
 }
+
+/**
+ * Utility function to get the maximum bigint value
+ *
+ * @param args bigint values to compare
+ * @returns the maximum bigint value among the input values
+ */
+export function bigIntMax(...args: bigint[]) {
+  if (!args.length) {
+    return undefined;
+  }
+
+  return args.reduce((m, c) => (m > c ? m : c));
+}


### PR DESCRIPTION
@moldy530 I wasn't able to test `dropAndReplaceUserOperation`

When I tried overriding gas prices I got the invalid paymaster signature error, I was thinking of overriding with less gas price so that the UserOp gets stuck and then replacing it with a UserOp with no override.

![telegram-cloud-photo-size-5-6115924363560728530-y](https://github.com/alchemyplatform/aa-sdk/assets/38040789/620f87a8-bd6c-46c9-a642-ffe703c14736)

This is how I am overriding.

![telegram-cloud-photo-size-5-6115924363560728531-y](https://github.com/alchemyplatform/aa-sdk/assets/38040789/285cdfc5-ab2e-4784-a0c1-4e6918aa50c8)

Closes #82

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new utility function `bigIntMax` to calculate the maximum value among a list of `bigint` values.
- Refactored code in `provider/base.ts` to use the new `bigIntMax` function.
- Created a new method `_runMiddlewareStack` to run the middleware stack and apply overrides to the user operation data.
- Updated the `sendUserOperation` method to use the `_runMiddlewareStack` method.
- Added a new method `dropAndReplaceUserOperation` to drop and replace a user operation with updated values.
- Updated the `dropAndReplaceUserOperation` method to use the `_runMiddlewareStack` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->