### PR TITLE
fix: interface ISmartAccountProvider annotation

### DIFF
--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -86,8 +86,8 @@ export interface ISmartAccountProvider<
    * Before executing, sendUserOperation will run the user operation through the middleware pipeline.
    * The order of the middlewares is:
    * 1. dummyPaymasterDataMiddleware -- populates a dummy paymaster data to use in estimation (default: "0x")
-   * 2. gasEstimator -- calls eth_estimateUserOperationGas
-   * 3. feeDataGetter -- sets maxfeePerGas and maxPriorityFeePerGas
+   * 2. feeDataGetter -- sets maxfeePerGas and maxPriorityFeePerGas
+   * 3. gasEstimator -- calls eth_estimateUserOperationGas
    * 4. paymasterMiddleware -- used to set paymasterAndData. (default: "0x")
    *
    * @param data - either {@link UserOperationCallData} or {@link BatchUserOperationCallData}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR reorders the middlewares in the provider's types file. The focus is on moving the `feeDataGetter` middleware to be the second one and the `gasEstimator` middleware to be the third one.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->