### PR TITLE
chore: make docs deploy automatically if only site changes

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,11 +1,12 @@
 name: Deploy VitePress site to Pages
 on:
-  workflow_dispatch:
-    inputs:
-      no_base_path:
-        required: false
-        default: false
-        type: boolean
+  push:
+    branches:
+      - main
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-site.yml"
+      - "!packages/**"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -67,5 +68,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-        env:
-          NO_BASE_PATH: ${{ inputs.no_base_path }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -92,6 +92,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-        env:
-          # TODO(moldy): just remove this altogether once we're live
-          NO_BASE_PATH: true

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -1,17 +1,9 @@
-import { $ } from "execa";
 import { defineConfig } from "vitepress";
-
-// This makes sure that this works in forked repos as well
-const getRepoRoute = $.sync`git rev-parse --show-toplevel`;
-const { stdout: basePath } = $.sync`basename ${getRepoRoute}`;
-
-const noBasePath = process.env.NO_BASE_PATH === "true";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Account Kit",
   description: "Account Abstraction Legos",
-  base: noBasePath ? undefined : `/${basePath}`,
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on the deployment of GitHub Pages. The notable changes include:

- Removed the `NO_BASE_PATH` environment variable from the deployment workflow.
- Modified the `deploy-site.yml` workflow to trigger only on push events to the `main` branch and specific paths.
- Updated the permissions of the GITHUB_TOKEN for deployment.
- Removed unused code related to the `NO_BASE_PATH` environment variable in the Vitepress config file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->