### PR TITLE
docs(site): add deployment addresses

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
               { text: "Light", link: "/light-account" },
               { text: "Modular", link: "/modular-account" },
               { text: "Using Your Own", link: "/using-your-own" },
+              {
+                text: "Deployment Addresses",
+                link: "/deployment-addresses",
+              },
             ],
           },
           {

--- a/site/smart-accounts/accounts/deployment-addresses.md
+++ b/site/smart-accounts/accounts/deployment-addresses.md
@@ -1,0 +1,49 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: Deployment Addresses
+  - - meta
+    - name: description
+      content: Deployment Addresses for LightAccount and SimpleAccount
+  - - meta
+    - property: og:description
+      content: Deployment Addresses for LightAccount and SimpleAccount
+---
+
+# Deployment Addresses
+
+The following tables list the deployed factory and account implementation contract addresses for `LightAccount` and `SimpleAccount` on different chains:
+
+## Light Account
+
+| Chain           | Factory Address                            | Account Implementation                     |
+| --------------- | ------------------------------------------ | ------------------------------------------ |
+| Eth Mainnet     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Sepolia     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Goerli      | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Polygon Mainnet | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Polygon Mumbai  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Optimism        | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Optimism Goerli | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Base            | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Base Goerli     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Arbitrum        | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Arbitrum Goerli | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+
+## Simple Account
+
+| Chain           | Factory Address                            |
+| --------------- | ------------------------------------------ |
+| Eth Mainnet     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Eth Sepolia     | 0x9406cc6185a346906296840746125a0e44976454 |
+| Eth Goerli      | 0x9406cc6185a346906296840746125a0e44976454 |
+| Polygon Mainnet | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Polygon Mumbai  | 0x9406Cc6185a346906296840746125a0E44976454 |
+| Optimism        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Optimism Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
+| Base            | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Base Goerli     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Arbitrum        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Arbitrum Goerli | 0x9406cc6185a346906296840746125a0e44976454 |

--- a/site/smart-accounts/accounts/light-account.md
+++ b/site/smart-accounts/accounts/light-account.md
@@ -44,6 +44,6 @@ Here are some benchmarks for the Light Account and other smart account implement
 
 ## Developer Links
 
-[LightAccount Github Repo](https://github.com/alchemyplatform/light-account)
-
-[Quantstamp Audit Report](https://github.com/alchemyplatform/light-account/blob/main/Quantstamp-Audit.pdf)
+- [LightAccount & Simple Account Deployment Addresses](/smart-accounts/accounts/deployment-addresses)
+- [LightAccount Github Repo](https://github.com/alchemyplatform/light-account)
+- [Quantstamp Audit Report](https://github.com/alchemyplatform/light-account/blob/main/Quantstamp-Audit.pdf)

--- a/site/smart-accounts/accounts/overview.md
+++ b/site/smart-accounts/accounts/overview.md
@@ -23,7 +23,7 @@ A smart account is a smart contract controlled by an account owner or other auth
 
 ## Kick Off with Light Account
 
-The Light Account offers a straightforward, secure, and cost-effective smart account implementation. It comes equipped with features like owner transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. For most applications, we recommend using the Light Account.
+The Light Account offers a straightforward, secure, and cost-effective smart account implementation. It comes equipped with features like owner transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. For most applications, we recommend using the Light Account. You can find the Light Account deployment addresses for different chains in the [Deployment Addresses](/smart-accounts/accounts/deployment-addresses) page.
 
 Here's a snippet that demonstrates how to work with the Light Account using Account Kit. This snippet sets up a Light Account and initiates a `UserOperation` from it:
 
@@ -34,42 +34,6 @@ Here's a snippet that demonstrates how to work with the Light Account using Acco
 The Alchemy team is actively developing the Modular Account Implementation, which adheres to the [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900) standard. It's set to include all the features of the Light Account and additional functionalities. Additionally, because ERC-6900 is [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) compliant, the Modular Account Implementation is well-suited to the ERC-4337 ecosystem. The `LightAccount` design is forward-compatible with `ModularAccount`. Until `ModularAccount` is available, it's a good practice to use `LightAccount`.
 
 If the Light Account doesn't fit your specific needs, you can always use your own smart account implementation with Account Kit. For detailed guidance on this, refer to the guide on [Using Your Own Account Implementation](/smart-accounts/accounts/using-your-own).
-
-## Deployed Contract Addresses
-
-The following tables list the deployed factory and account implementation contract addresses for `LightAccount` and `SimpleAccount` on different chains:
-
-### Light Account
-
-| Chain           | Factory Address                            | Account Implementation                     |
-| --------------- | ------------------------------------------ | ------------------------------------------ |
-| Eth Mainnet     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Eth Sepolia     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Eth Goerli      | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Polygon Mainnet | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Polygon Mumbai  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Optimism        | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Optimism Goerli | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Base            | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Base Goerli     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Arbitrum        | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Arbitrum Goerli | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-
-### Simple Account
-
-| Chain           | Factory Address                            |
-| --------------- | ------------------------------------------ |
-| Eth Mainnet     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Eth Sepolia     | 0x9406cc6185a346906296840746125a0e44976454 |
-| Eth Goerli      | 0x9406cc6185a346906296840746125a0e44976454 |
-| Polygon Mainnet | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Polygon Mumbai  | 0x9406Cc6185a346906296840746125a0E44976454 |
-| Optimism        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Optimism Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
-| Base            | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Base Goerli     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Arbitrum        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Arbitrum Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
 
 ## Benchmarks
 

--- a/site/smart-accounts/accounts/overview.md
+++ b/site/smart-accounts/accounts/overview.md
@@ -37,32 +37,39 @@ If the Light Account doesn't fit your specific needs, you can always use your ow
 
 ## Deployed Contract Addresses
 
-The following table lists the deployed factory and account instance contract addresses for `LightAccount` and `SimpleAccount` on different chains:
+The following tables list the deployed factory and account implementation contract addresses for `LightAccount` and `SimpleAccount` on different chains:
 
-| Chain           | Account Type   | Factory Address                            | Account Instance                           |
-| --------------- | -------------- | ------------------------------------------ | ------------------------------------------ |
-| Eth Mainnet     | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Eth Sepolia     | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Eth Goerli      | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Polygon Mainnet | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Polygon Mumbai  | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Optimism        | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Optimism Goerli | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Base            | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Base Goerli     | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Arbitrum        | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Arbitrum Goerli | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
-| Eth Mainnet     | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
-| Eth Sepolia     | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
-| Eth Goerli      | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
-| Polygon Mainnet | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
-| Polygon Mumbai  | Simple Account | 0x9406Cc6185a346906296840746125a0E44976454 | --                                         |
-| Optimism        | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
-| Optimism Goerli | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
-| Base            | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
-| Base Goerli     | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
-| Arbitrum        | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
-| Arbitrum Goerli | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
+### Light Account
+
+| Chain           | Factory Address                            | Account Implementation                     |
+| --------------- | ------------------------------------------ | ------------------------------------------ |
+| Eth Mainnet     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Sepolia     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Goerli      | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Polygon Mainnet | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Polygon Mumbai  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Optimism        | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Optimism Goerli | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Base            | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Base Goerli     | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Arbitrum        | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Arbitrum Goerli | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+
+### Simple Account
+
+| Chain           | Factory Address                            |
+| --------------- | ------------------------------------------ |
+| Eth Mainnet     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Eth Sepolia     | 0x9406cc6185a346906296840746125a0e44976454 |
+| Eth Goerli      | 0x9406cc6185a346906296840746125a0e44976454 |
+| Polygon Mainnet | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Polygon Mumbai  | 0x9406Cc6185a346906296840746125a0E44976454 |
+| Optimism        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Optimism Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
+| Base            | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Base Goerli     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Arbitrum        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Arbitrum Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
 
 ## Benchmarks
 

--- a/site/smart-accounts/accounts/overview.md
+++ b/site/smart-accounts/accounts/overview.md
@@ -35,6 +35,35 @@ The Alchemy team is actively developing the Modular Account Implementation, whic
 
 If the Light Account doesn't fit your specific needs, you can always use your own smart account implementation with Account Kit. For detailed guidance on this, refer to the guide on [Using Your Own Account Implementation](/smart-accounts/accounts/using-your-own).
 
+## Deployed Contract Addresses
+
+The following table lists the deployed factory and account instance contract addresses for `LightAccount` and `SimpleAccount` on different chains:
+
+| Chain           | Account Type   | Factory Address                            | Account Instance                           |
+| --------------- | -------------- | ------------------------------------------ | ------------------------------------------ |
+| Eth Mainnet     | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Sepolia     | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Goerli      | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Polygon Mainnet | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Polygon Mumbai  | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Optimism        | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Optimism Goerli | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Base            | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Base Goerli     | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Arbitrum        | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Arbitrum Goerli | Light Account  | 0x000000893A26168158fbeaDD9335Be5bC96592E2 | 0xc1B2fC4197c9187853243E6e4eb5A4aF8879a1c0 |
+| Eth Mainnet     | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
+| Eth Sepolia     | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
+| Eth Goerli      | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
+| Polygon Mainnet | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
+| Polygon Mumbai  | Simple Account | 0x9406Cc6185a346906296840746125a0E44976454 | --                                         |
+| Optimism        | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
+| Optimism Goerli | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
+| Base            | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
+| Base Goerli     | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
+| Arbitrum        | Simple Account | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 | --                                         |
+| Arbitrum Goerli | Simple Account | 0x9406cc6185a346906296840746125a0e44976454 | --                                         |
+
 ## Benchmarks
 
 Here are some benchmarks for the Light Account vs other smart account implementations:


### PR DESCRIPTION
Adding the deployment addresses for `LightAccount` and `SimpleAccount`.  Mentioned it in the overview page for "Smart Accounts" (Let me know if we want a different page and where we want to place it)

Couldn't find factory deployment addresses for `SimpleAccount` on some networks so referenced from here: https://docs.alchemy.com/reference/simple-account-factory-addresses

And also couldn't find deployment addresses for `SimpleAccount` instances on all the chains so left those cells blank ("--"), do we have a source to pull these addresses from?


https://github.com/alchemyplatform/aa-sdk/assets/83442423/75f4fe44-f18d-4376-a0d8-ac7380d17e76

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new page "Deployment Addresses" in the `site/smart-accounts/accounts` directory.
- Updated the navigation links in `site/.vitepress/config.ts` and `site/smart-accounts/accounts/light-account.md` to include the new "Deployment Addresses" page.
- Added a sentence and a link in `site/smart-accounts/accounts/overview.md` to direct users to the "Deployment Addresses" page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->