### PR TITLE
docs(site): add the hero video with custom player

### DIFF
--- a/site/.vitepress/theme/components/VideoEmbed.vue
+++ b/site/.vitepress/theme/components/VideoEmbed.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="video-container" @click="togglePlay">
+    <video ref="videoRef" muted loop>
+      <source :src="src" :type="type" />
+      Your browser does not support the video tag.
+    </video>
+    <transition name="fade">
+      <div v-if="showOverlay" class="overlay">
+        <span class="icon">{{ currentIcon }}</span>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      observer: null,
+      isPaused: false,
+      showOverlay: false,
+      currentIcon: "", // No icon by default
+    };
+  },
+  props: {
+    src: {
+      type: String,
+      required: true,
+    },
+    type: {
+      type: String,
+      default: "video/mp4",
+    },
+  },
+  watch: {
+    isPaused(newVal) {
+      if (newVal) {
+        this.currentIcon = "▶️";
+        this.showOverlay = true;
+      } else {
+        this.currentIcon = "🏃";
+        setTimeout(() => {
+          this.showOverlay = false;
+        }, 500);
+      }
+    },
+  },
+  mounted() {
+    this.initObserver();
+  },
+  beforeUnmount() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  },
+  methods: {
+    togglePlay() {
+      const videoElement = this.$refs.videoRef;
+      if (videoElement.paused) {
+        videoElement.play();
+        this.isPaused = false;
+      } else {
+        videoElement.pause();
+        this.isPaused = true;
+      }
+    },
+    initObserver() {
+      const options = {
+        root: null,
+        rootMargin: "0px",
+        threshold: 1.0,
+      };
+
+      this.observer = new IntersectionObserver((entries, observer) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            this.$refs.videoRef.play();
+            observer.disconnect();
+          }
+        });
+      }, options);
+
+      this.observer.observe(this.$refs.videoRef);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.video-container {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  cursor: pointer;
+}
+
+video {
+  width: 100%;
+  height: auto;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+}
+
+.icon {
+  color: white;
+  transition: transform 0.3s;
+  transform: scale(1);
+}
+
+video::-webkit-media-controls {
+  display: none !important;
+}
+video::-webkit-media-controls-start-playback-button {
+  display: none !important;
+}
+
+/* Fade transition styles */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s;
+}
+.fade-enter, .fade-leave-to /* .fade-leave-active in <2.1.8 */ {
+  opacity: 0;
+}
+</style>

--- a/site/.vitepress/theme/index.ts
+++ b/site/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
-// https://vitepress.dev/guide/custom-theme
 import { h } from "vue";
 import Theme from "vitepress/theme";
+import VideoEmbed from "./components/VideoEmbed.vue"; // Importing the component
 import "./style.css";
 
 export default {
@@ -11,6 +11,7 @@ export default {
     });
   },
   enhanceApp({ app, router, siteData }) {
+    app.component("VideoEmbed", VideoEmbed); // Registering the component globally
     // ...
   },
 };

--- a/site/why-account-kit.md
+++ b/site/why-account-kit.md
@@ -29,7 +29,7 @@ The user leaves your app at every step! This style of web3 onboarding is too com
 
 Account Kit provides all the tools you need to onboard the next 1B users with a simple, familiar user experience.
 
-[ HERO GIF/VIDEO ]
+<VideoEmbed src="/assets/videos/accountkit-screenflow.mp4" />
 
 With Account Kit, you can create a **smart account** for every user. Smart accounts are smart contract wallets that leverage account abstraction to radically simplify every step of the onboarding experience. Now, a new user will:
 


### PR DESCRIPTION
Was adding hero video to doc and realized the default video player is so ugly so built a custom component in Vue to display the video that: 

- only starts playing the video when the frame is in viewport
- shows no controls for the video (like the progress bar) 
- pause/resume the video when a user clicks on it with custom icons for pause / resume + smooth transitions
- makes the video responsive

Check it out:

https://github.com/alchemyplatform/aa-sdk/assets/83442423/50e71729-9c94-4f78-ad31-77742dcf2ffb



<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new `VideoEmbed` component.
- Registered the `VideoEmbed` component globally.
- Updated the `why-account-kit.md` file to use the `VideoEmbed` component.
- Created the `VideoEmbed.vue` component with the necessary functionality to play and pause videos.
- Added CSS styles for the `VideoEmbed` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->