### PR TITLE
docs: add modular account, update overview and light account

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -67,9 +67,9 @@ export default defineConfig({
             base: "/smart-accounts/accounts",
             link: "/overview",
             items: [
-              { text: "Light", link: "/light-account" },
-              { text: "Modular", link: "/modular-account" },
-              { text: "Using Your Own", link: "/using-your-own" },
+              { text: "Light Account", link: "/light-account" },
+              { text: "Modular Account (soon)", link: "/modular-account" },
+              { text: "Use Your Own Account", link: "/using-your-own" },
               {
                 text: "Deployment Addresses",
                 link: "/deployment-addresses",

--- a/site/smart-accounts/accounts/light-account.md
+++ b/site/smart-accounts/accounts/light-account.md
@@ -30,7 +30,7 @@ The code snippet below demonstrates the usage of Light Account with Account Kit.
 
 ## Benchmarks
 
-Here are some benchmarks for the Light Account and other smart account implementations you might consider:
+Here are some benchmarks for Light Account and other smart account implementations you might consider:
 
 | Account              | Creation | Native transfer | ERC20 transfer | Total Gas |
 | -------------------- | -------- | --------------- | -------------- | --------- |

--- a/site/smart-accounts/accounts/modular-account.md
+++ b/site/smart-accounts/accounts/modular-account.md
@@ -3,26 +3,40 @@ outline: deep
 head:
   - - meta
     - property: og:title
-      content: Using Modular Account
+      content: Modular Account (coming soon)
   - - meta
     - name: description
-      content: Using Modular Account with Account Kit
+      content: Modular Account is coming soon to Account Kit
   - - meta
     - property: og:description
-      content: Using Modular Account with Account Kit
+      content: Modular Account is coming soon to Account Kit
 ---
 
-# Modular Account & ERC-6900
+# Modular Account (coming soon)
 
-Support for Modular Accounts is coming soon. Modular Accounts are based on the `ERC-6900` spec and offer a lot more flexibility and extensibility. You can read more about ERC-6900 down below.
+We are working towards the first stable version of [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900) with [the community](https://ethereum-magicians.org/t/erc-6900-modular-smart-contract-accounts-and-plugins/13885).
 
-We’re currently collaborating with the community and plan to finalize the ERC soon. `LightAccount` is fully forward-compatible with `ERC-6900`. We’ll release an upgrade once the ERC is finalized.
+Soon after, we will release an ERC-6900 compatible Modular Account in Account Kit. It will support new use cases like session keys, account recovery, spending limits, and any ERC-6900 plugin you can imagine. The Light Account is forward-compatible with ERC-6900 so you can optionally upgrade it to the Modular Account once released.
 
-## ERC-6900
+If you're developing a plugin, we'd love to [chat](mailto:account-abstraction@alchemy.com)!
 
-[ERC-6900](https://eips.ethereum.org/EIPS/eip-6900) proposes a set of standards for modular smart account developers. It reflects a modular vision of smart accounts that allow both users and developers to build account experiences that reflect their needs and objectives.
+Read on to learn more about ERC-6900 and modular accounts.
 
-By standardizing basic functions and interfaces, ERC-6900 seeks to foster a growing ecosystem of wallet and plugin (or module) developers by freeing them to focus on their projects rather than fragmenting their efforts across multiple ecosystem standards. Is also seeks to create a community-defined standard that avoids lock-in by any one platform, allowing users and developers to construct wallets that offer more flexibility and functionality than are possible with standard EOA accounts.
+# Motivation
+
+In the coming years, we expect most user accounts to be smart contract accounts that leverage the benefits of account abstraction. These accounts will generally share a similar set of core features such as signature validation and ownership transfer. To ensure this core feature set is secure and does not contain any vulnerabilities, it will be prudent for most developers to re-use battle-tested smart accounts rather than writing their own accounts.
+
+However, smart acounts are also programmable, enabling developers to build new and innovative features that hook into the validation and execution logic of a smart account. We hope and expect to see a diverse ecosystem of plugins flourish.
+
+In order to maximize interoperability and code re-use, these plugins will ideally share a standard interface that is compatible with every smart contract account.
+
+# ERC-6900: Modular Smart Contract Accounts and Plugins
+
+We authored [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900) to propose a standard interface for modular smart contract accounts and plugins.
+
+By standardizing basic functions and interfaces, ERC-6900 seeks to foster a growing ecosystem of wallet and plugin developers. These developers should be able to write one plugin that works with all smart accounts, rather than fragmenting their efforts across multiple different account implementations.
+
+For users, this standard will make it easier to discover and enable plugins. Imagine a future where a user with an ERC-6900 compatible account can install any of a thousand plugins to their smart account.
 
 ### **Architecture**
 

--- a/site/smart-accounts/accounts/overview.md
+++ b/site/smart-accounts/accounts/overview.md
@@ -22,32 +22,24 @@ prev:
 
 ## What's a Smart Account?
 
-A smart account is a smart contract controlled by an account owner or other authorized entities. You can use it to manage assets, carry out transactions (known as `userOperations` or `userOps`), and more. There are many different implementations of a Smart Account, including Alchemy's [Light Account](/smart-accounts/accounts/light-account).
+A smart account is an [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) smart contract account. You can use it to manage assets, execute transactions (known as `userOperations` or `userOps`), and more. There are many different implementations of a smart account, including our [Light Account](/smart-accounts/accounts/light-account).
 
-## Kick Off with Light Account
+## Light Account
 
-The Light Account offers a straightforward, secure, and cost-effective smart account implementation. It comes equipped with features like owner transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. For most applications, we recommend using the Light Account. You can find the Light Account deployment addresses for different chains in the [Deployment Addresses](/smart-accounts/accounts/deployment-addresses) page.
+Account Kit provides a default smart account called `LightAccount`.
+
+[Light Account](/smart-accounts/accounts/light-account) is a secure, audited, gas-optimized, ERC-4337 compatible smart account implementation. It comes equipped with features like owner transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. It's also [open source](https://github.com/alchemyplatform/light-account)!
+
+For most applications, we recommend using the Light Account. It is [deployed](/smart-accounts/accounts/deployment-addresses) on Ethereum, Optimism, Arbitrum, Polygon, Base, and the respective testnets.
 
 Here's a snippet that demonstrates how to work with the Light Account using Account Kit. This snippet sets up a Light Account and initiates a `UserOperation` from it:
 
 <!--@include: ../../getting-started.md{56,68}-->
 
-## Modular Account Implementation
+## Modular Account (coming soon)
 
-The Alchemy team is actively developing the Modular Account Implementation, which adheres to the [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900) standard. It's set to include all the features of the Light Account and additional functionalities. Additionally, because ERC-6900 is [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) compliant, the Modular Account Implementation is well-suited to the ERC-4337 ecosystem. The `LightAccount` design is forward-compatible with `ModularAccount`. Until `ModularAccount` is available, it's a good practice to use `LightAccount`.
+We authoring a standard for modular smart accounts called [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900). Soon we will release an ERC-6900 compatible [Modular Account](/smart-accounts/accounts/modular-account). This will be an optional upgrade from Light Account to unlock an ecosystem of plugins for your smart account stack.
 
-If the Light Account doesn't fit your specific needs, you can always use your own smart account implementation with Account Kit. For detailed guidance on this, refer to the guide on [Using Your Own Account Implementation](/smart-accounts/accounts/using-your-own).
+## Use Your Own Account
 
-## Benchmarks
-
-Here are some benchmarks for the Light Account vs other smart account implementations:
-
-| Account              | Creation | Native transfer | ERC20 transfer | Total Gas |
-| -------------------- | -------- | --------------- | -------------- | --------- |
-| Alchemy LightAccount | 279710   | 100844          | 90345          | 470899    |
-| Kernel v2.1-lite     | 230968   | 101002          | 90321          | 422291    |
-| Kernel v2.1          | 265215   | 106460          | 96038          | 467713    |
-| Biconomy             | 270013   | 104408          | 93730          | 468151    |
-| Etherspot            | 279219   | 103719          | 93324          | 476262    |
-| Kernel v2.0          | 339882   | 110018          | 99622          | 549522    |
-| SimpleAccount        | 383218   | 101319          | 90907          | 575444    |
+If Light Account doesn't fit your specific needs, you can always use your own smart account implementation with Account Kit. To learn how, see the guide on [Using Your Own Account Implementation](/smart-accounts/accounts/using-your-own).


### PR DESCRIPTION
Update the modular account doc to talk about the product and motivations, in addition to ERC-6900. Update overview and light account files to match.