### PR TITLE
docs: add sitemap generation

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -590,4 +590,7 @@ export default defineConfig({
       },
     ],
   ],
+  sitemap: {
+    hostname: "https://accountkit.alchemy.com",
+  },
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a sitemap configuration for the site. 

### Detailed summary
- Added a sitemap configuration in `site/.vitepress/config.ts`.
- Set the `hostname` to "https://accountkit.alchemy.com" for the sitemap.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->