### PR TITLE
fix: update magic link to magic (request from magic team)

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -73,7 +73,7 @@ export default defineConfig({
             link: "/overview",
             collapsed: true,
             items: [
-              { text: "Magic.Link", link: "/magic-link" },
+              { text: "Magic", link: "/magic" },
               { text: "Web3Auth", link: "/web3auth" },
               { text: "Turnkey", link: "/turnkey" },
               { text: "Privy", link: "/privy" },

--- a/site/introduction.md
+++ b/site/introduction.md
@@ -58,7 +58,7 @@ To learn how to deploy a `LightAccount`, see [LightAccount](/smart-accounts/acco
 
 ### Signers
 
-A Signer is responsible for securely managing the private key and signing transaction requests on the smart account. Account Kit supports many popular wallet signers including [Magic.link](/smart-accounts/signers/magic-link), [web3auth](/smart-accounts/signers/web3auth), [Turnkey](/smart-accounts/signers/turnkey), [Privy](/smart-accounts/signers/privy), [Dynamic](/smart-accounts/signers/dynamic), [Fireblocks](/smart-accounts/signers/fireblocks), [Portal](/smart-accounts/signers/portal), [Capsule](/smart-accounts/signers/capsule) and [Lit Protocol](/smart-accounts/signers/lit). It also supports self-custodial wallets like Metamask or Ledger.
+A Signer is responsible for securely managing the private key and signing transaction requests on the smart account. Account Kit supports many popular wallet signers including [Magic](/smart-accounts/signers/magic), [web3auth](/smart-accounts/signers/web3auth), [Turnkey](/smart-accounts/signers/turnkey), [Privy](/smart-accounts/signers/privy), [Dynamic](/smart-accounts/signers/dynamic), [Fireblocks](/smart-accounts/signers/fireblocks), [Portal](/smart-accounts/signers/portal), [Capsule](/smart-accounts/signers/capsule) and [Lit Protocol](/smart-accounts/signers/lit). It also supports self-custodial wallets like Metamask or Ledger.
 
 To get started with a signer, read the doc: [How to Choose a Signer](/smart-accounts/signers/overview).
 

--- a/site/smart-accounts/overview.md
+++ b/site/smart-accounts/overview.md
@@ -36,7 +36,7 @@ The `LightAccount` implementation is not [ERC-6900](/smart-accounts/accounts/mod
 A signer is the entity that signs transactions (User Operations) on behalf of the smart account. It can be an EOA, a custodial service, or a multi-party computation (MPC) service. We explain the different types of signers in detail in the [overview](signers/overview) section on choosing a signer. We'll also cover the common signer examples in detail in the following sections:
 
 - [Dynamic](signers/dynamic)
-- [Magic Link](signers/magic-link)
+- [Magic](signers/magic)
 - [Web3Auth](signers/web3auth)
 - [Externally Owned Account](signers/eoa)
 

--- a/site/smart-accounts/signers/magic.md
+++ b/site/smart-accounts/signers/magic.md
@@ -3,7 +3,7 @@ outline: deep
 head:
   - - meta
     - property: og:title
-      content: Magic Link
+      content: Magic
   - - meta
     - name: description
       content: Guide to use Magic.Link as a signer
@@ -12,7 +12,7 @@ head:
       content: Guide to use Magic.Link as a signer
 ---
 
-# Magic Link
+# Magic
 
 [Magic](https://magic.link) is an embedded wallet provider that allows users to generate wallets scoped to your application via Social Logins, Email OTP, or Webauthn. This is great for enabling a better experience for your users. But ultimately these wallets are not much different from EOA's, so you don't have the benefit of Account Abstraction (gas sponsorship, batching, etc).
 

--- a/site/smart-accounts/signers/overview.md
+++ b/site/smart-accounts/signers/overview.md
@@ -44,7 +44,7 @@ The signer plays a crucial role in your app because it controls the user’s sma
 
 Account Kit is compatible with any EIP-1193 provider. Many of the most popular signers can be configured in minutes through our integration guides below:
 
-- [Magic.link](/smart-accounts/signers/magic-link)
+- [Magic](/smart-accounts/signers/magic)
 - [web3auth](/smart-accounts/signers/web3auth)
 - [Turnkey](/smart-accounts/signers/turnkey)
 - [Privy](/smart-accounts/signers/privy)

--- a/site/why-account-kit.md
+++ b/site/why-account-kit.md
@@ -59,7 +59,7 @@ Streamline your sign up flow with simple web2 login options supported by Account
 - Self-custodial wallets like MetaMask or Ledger
 - and more
 
-Account Kit integrates all the leading wallet Signers with bespoke integration guides for [Magic.link](/smart-accounts/signers/magic-link), [web3auth](/smart-accounts/signers/web3auth), [Turnkey](/smart-accounts/signers/turnkey), [Privy](/smart-accounts/signers/privy), [Dynamic](/smart-accounts/signers/dynamic), [Fireblocks](/smart-accounts/signers/fireblocks), [Portal](/smart-accounts/signers/portal), [Capsule](/smart-accounts/signers/capsule) and [Lit Protocol](/smart-accounts/signers/lit). Account Kit even supports self-custodial wallets like Metamask or Ledger. Users can even change their signer later via Account Kit’s [ownership transfer](/smart-accounts/transferring-ownership) functionality.
+Account Kit integrates all the leading wallet Signers with bespoke integration guides for [Magic](/smart-accounts/signers/magic), [web3auth](/smart-accounts/signers/web3auth), [Turnkey](/smart-accounts/signers/turnkey), [Privy](/smart-accounts/signers/privy), [Dynamic](/smart-accounts/signers/dynamic), [Fireblocks](/smart-accounts/signers/fireblocks), [Portal](/smart-accounts/signers/portal), [Capsule](/smart-accounts/signers/capsule) and [Lit Protocol](/smart-accounts/signers/lit). Account Kit even supports self-custodial wallets like Metamask or Ledger. Users can even change their signer later via Account Kit’s [ownership transfer](/smart-accounts/transferring-ownership) functionality.
 
 Learn [how to choose the right signer for your use case in this doc](/smart-accounts/signers/overview).
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Renamed "Magic Link" to "Magic" in multiple files and links.
- Updated the configuration file to reflect the change from "Magic.Link" to "Magic".
- Updated the content and headings in the "magic-link.md" file to reflect the change to "Magic".
- Updated references to "Magic.link" in the "introduction.md" and "why-account-kit.md" files to "Magic".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->