### PR TITLE
docs: add particle network to signers

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
               { text: "Portal", link: "/portal" },
               { text: "Capsule", link: "/capsule" },
               { text: "Lit Protocol", link: "/lit" },
+              { text: "Particle Network", link: "/particle-network" },
               { text: "Externally Owned Account", link: "/eoa" },
               { text: "Custom Signer", link: "/custom-signer" },
             ],

--- a/site/smart-accounts/signers/particle-network.md
+++ b/site/smart-accounts/signers/particle-network.md
@@ -1,0 +1,81 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: Particle Network
+  - - meta
+    - name: description
+      content: Guide to use Particle Network as a signer
+  - - meta
+    - property: og:description
+      content: Guide to use Particle Network as a signer
+---
+
+# Particle Network
+
+[**Particle Network**](https://particle.network/) is the Intent-Centric, Modular Access Layer of Web3. With Particle's Wallet-as-a-Service, developers can curate unparalleled user experience through modular and customizable embedded wallet components. By utilizing MPC-TSS for key management, Particle can streamline onboarding via familiar Web2 accounts—such as Google accounts, email addresses, phone numbers, etc.
+
+Leveraging both Particle and Account Kit enables a streamlined onboarding flow, with social logins and signer key management being handled by Particle while Account Kit takes this experience to the next level with account abstraction - facilitating powerful user experience.
+
+## Integration
+
+### Sign up for a Particle Account
+
+To configure Particle, you'll need to start by quickly signing up for a Particle account, creating a project, and then creating an application. You can learn more about this process within our [quickstart guide](https://docs.particle.network/getting-started/dashboard/manage-projects). Additionally, you can sign up through the [Particle dashboard](https://dashboard.particle.network/#/login).
+
+### Install the SDK
+
+::: code-group
+
+```bash [npm]
+npm i -s @particle-network/auth
+npm i -s @particle-network/provider
+```
+
+```bash [yarn]
+yarn add @particle-network/auth
+yarn add @particle-network/provider
+```
+
+:::
+
+### Create a SmartAccountSigner
+
+With `@particle-network/auth` and `@particle-network/provider` installed, you can move on to creating a `SmartAccountSigner`. To do this, you'll need to ensure you have your `projectId`, `clientKey`, and `appId` from the Particle dashboard to use in the configuration of `ParticleNetwork`.
+
+From here, setting up a `SmartAccountSigner` involves the initialization of `ParticleProvider` to be used in a viem wallet client, which then gets passed into our `SmartAccountSigner`.
+
+<<< @/snippets/particle.ts
+
+### Use it with LightAccount
+
+Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+::: code-group
+
+```ts [example.ts]
+import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import { polygonMumbai } from "viem/chains";
+import { particleSigner } from "./particleSigner";
+
+const chain = polygonMumbai;
+const provider = new AlchemyProvider({
+  apiKey: process.env.ALCHEMY_API_KEY,
+  chain,
+  entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS,
+}).connect(
+  (rpcClient) =>
+    new LightSmartContractAccount({
+      entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS,
+      chain: rpcClient.chain,
+      owner: particleSigner,
+      factoryAddress: FACTORY_CONTRACT_ADDRESS,
+      rpcClient,
+    })
+);
+```
+
+<<< @/snippets/particle.ts
+
+:::

--- a/site/smart-accounts/signers/particle-network.md
+++ b/site/smart-accounts/signers/particle-network.md
@@ -63,14 +63,14 @@ const chain = polygonMumbai;
 const provider = new AlchemyProvider({
   apiKey: process.env.ALCHEMY_API_KEY,
   chain,
-  entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS,
+  entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS, // 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
       entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS,
       chain: rpcClient.chain,
       owner: particleSigner,
-      factoryAddress: FACTORY_CONTRACT_ADDRESS,
+      factoryAddress: FACTORY_CONTRACT_ADDRESS, // For LightAccount, 0x000000893A26168158fbeaDD9335Be5bC96592E2
       rpcClient,
     })
 );

--- a/site/snippets/particle.ts
+++ b/site/snippets/particle.ts
@@ -1,14 +1,14 @@
 import { ParticleNetwork } from '@particle-network/auth';
 import { ParticleProvider } from '@particle-network/provider';
-import { createWalletClient, custom } from "viem";
-import { WalletClientSigner, SmartAccountSigner } from "@alchemy/aa-core";
+import { createWalletClient, custom } from 'viem';
+import { WalletClientSigner, SmartAccountSigner } from '@alchemy/aa-core';
 
 const particle = new ParticleNetwork({
-  projectId: process.env.REACT_APP_PROJECT_ID as string,
-  clientKey: process.env.REACT_APP_CLIENT_KEY as string,
-  appId: process.env.REACT_APP_APP_ID as string,
-  chainName: 'polygon',
-  chainId: 80001,
+	projectId: process.env.REACT_APP_PROJECT_ID as string,
+	clientKey: process.env.REACT_APP_CLIENT_KEY as string,
+	appId: process.env.REACT_APP_APP_ID as string,
+	chainName: 'polygon',
+	chainId: 80001,
 });
 
 const particleProvider = new ParticleProvider(particle.auth);
@@ -16,10 +16,10 @@ const particleProvider = new ParticleProvider(particle.auth);
 // Assumes user has logged in with something like particle.auth.login(), Particle Connect, or through other misc. connection
 
 const particleWalletClient = createWalletClient({
-  transport: custom(particleProvider),
+	transport: custom(particleProvider),
 });
 
 export const particleSigner: SmartAccountSigner = new WalletClientSigner(
-  particleWalletClient,
-  "particle"
+	particleWalletClient,
+	'particle',
 );

--- a/site/snippets/particle.ts
+++ b/site/snippets/particle.ts
@@ -1,0 +1,25 @@
+import { ParticleNetwork } from '@particle-network/auth';
+import { ParticleProvider } from '@particle-network/provider';
+import { createWalletClient, custom } from "viem";
+import { WalletClientSigner, SmartAccountSigner } from "@alchemy/aa-core";
+
+const particle = new ParticleNetwork({
+  projectId: process.env.REACT_APP_PROJECT_ID as string,
+  clientKey: process.env.REACT_APP_CLIENT_KEY as string,
+  appId: process.env.REACT_APP_APP_ID as string,
+  chainName: 'polygon',
+  chainId: 80001,
+});
+
+const particleProvider = new ParticleProvider(particle.auth);
+
+// Assumes user has logged in with something like particle.auth.login(), Particle Connect, or through other misc. connection
+
+const particleWalletClient = createWalletClient({
+  transport: custom(particleProvider),
+});
+
+export const particleSigner: SmartAccountSigner = new WalletClientSigner(
+  particleWalletClient,
+  "particle"
+);

--- a/site/snippets/particle.ts
+++ b/site/snippets/particle.ts
@@ -1,25 +1,25 @@
-import { ParticleNetwork } from '@particle-network/auth';
-import { ParticleProvider } from '@particle-network/provider';
-import { createWalletClient, custom } from 'viem';
-import { WalletClientSigner, SmartAccountSigner } from '@alchemy/aa-core';
+import { ParticleNetwork } from '@particle-network/auth'
+import { ParticleProvider } from '@particle-network/provider'
+import { createWalletClient, custom } from 'viem'
+import { WalletClientSigner, type SmartAccountSigner } from '@alchemy/aa-core'
 
 const particle = new ParticleNetwork({
-	projectId: process.env.REACT_APP_PROJECT_ID as string,
-	clientKey: process.env.REACT_APP_CLIENT_KEY as string,
-	appId: process.env.REACT_APP_APP_ID as string,
-	chainName: 'polygon',
-	chainId: 80001,
-});
+  projectId: process.env.REACT_APP_PROJECT_ID as string,
+  clientKey: process.env.REACT_APP_CLIENT_KEY as string,
+  appId: process.env.REACT_APP_APP_ID as string,
+  chainName: 'polygon',
+  chainId: 80001
+})
 
-const particleProvider = new ParticleProvider(particle.auth);
+const particleProvider = new ParticleProvider(particle.auth)
 
 // Assumes user has logged in with something like particle.auth.login(), Particle Connect, or through other misc. connection
 
 const particleWalletClient = createWalletClient({
-	transport: custom(particleProvider),
-});
+  transport: custom(particleProvider)
+})
 
 export const particleSigner: SmartAccountSigner = new WalletClientSigner(
-	particleWalletClient,
-	'particle',
-);
+  particleWalletClient,
+  'particle'
+)

--- a/site/snippets/particle.ts
+++ b/site/snippets/particle.ts
@@ -1,25 +1,25 @@
-import { ParticleNetwork } from '@particle-network/auth'
-import { ParticleProvider } from '@particle-network/provider'
-import { createWalletClient, custom } from 'viem'
-import { WalletClientSigner, type SmartAccountSigner } from '@alchemy/aa-core'
+import { ParticleNetwork } from "@particle-network/auth";
+import { ParticleProvider } from "@particle-network/provider";
+import { createWalletClient, custom } from "viem";
+import { WalletClientSigner, type SmartAccountSigner } from "@alchemy/aa-core";
 
 const particle = new ParticleNetwork({
   projectId: process.env.REACT_APP_PROJECT_ID as string,
   clientKey: process.env.REACT_APP_CLIENT_KEY as string,
   appId: process.env.REACT_APP_APP_ID as string,
-  chainName: 'polygon',
-  chainId: 80001
-})
+  chainName: "polygon",
+  chainId: 80001,
+});
 
-const particleProvider = new ParticleProvider(particle.auth)
+const particleProvider = new ParticleProvider(particle.auth);
 
 // Assumes user has logged in with something like particle.auth.login(), Particle Connect, or through other misc. connection
 
 const particleWalletClient = createWalletClient({
-  transport: custom(particleProvider)
-})
+  transport: custom(particleProvider),
+});
 
 export const particleSigner: SmartAccountSigner = new WalletClientSigner(
   particleWalletClient,
-  'particle'
-)
+  "particle",
+);


### PR DESCRIPTION
Adds the following:
- Page under 'signers' for Particle Network
- Corresponding code snippet under 'snippets'
- Altered sidebar to account for new page

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new page for Particle Network in the site's documentation
- Imported necessary modules for Particle Network integration
- Configured ParticleNetwork with project ID, client key, and app ID
- Created a SmartAccountSigner using ParticleProvider and WalletClientSigner
- Added code snippets for using Particle Network with LightSmartContractAccount

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->