### PR TITLE
feat: add extend function to enable decorating providers

### DIFF
--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -205,21 +205,23 @@ export class SmartAccountProvider<
     return this.account.signTypedData(params);
   };
 
-  signMessageWith6492(msg: string | Uint8Array): Promise<`0x${string}`> {
+  signMessageWith6492 = (msg: string | Uint8Array): Promise<`0x${string}`> => {
     if (!this.account) {
       throw new Error("account not connected!");
     }
 
     return this.account.signMessageWith6492(msg);
-  }
+  };
 
-  signTypedDataWith6492(params: SignTypedDataParams): Promise<`0x${string}`> {
+  signTypedDataWith6492 = (
+    params: SignTypedDataParams
+  ): Promise<`0x${string}`> => {
     if (!this.account) {
       throw new Error("account not connected!");
     }
 
     return this.account.signTypedDataWith6492(params);
-  }
+  };
 
   sendTransaction = async (request: RpcTransactionRequest): Promise<Hash> => {
     const uoStruct = await this.buildUserOperationFromTx(request);
@@ -552,13 +554,13 @@ export class SmartAccountProvider<
     return this;
   };
 
-  connect<TAccount extends ISmartContractAccount>(
+  connect = <TAccount extends ISmartContractAccount>(
     fn: (
       provider:
         | PublicErc4337Client<TTransport>
         | PublicErc4337Client<HttpTransport>
     ) => TAccount
-  ): this & { account: TAccount } {
+  ): this & { account: TAccount } => {
     const account = fn(this.rpcClient);
     defineReadOnly(this, "account", account);
 
@@ -593,9 +595,9 @@ export class SmartAccountProvider<
       .then((address) => this.emit("accountsChanged", [address]));
 
     return this as unknown as this & { account: TAccount };
-  }
+  };
 
-  disconnect(): this & { account: undefined } {
+  disconnect = (): this & { account: undefined } => {
     if (this.account) {
       this.emit("disconnect");
       this.emit("accountsChanged", []);
@@ -604,13 +606,23 @@ export class SmartAccountProvider<
     defineReadOnly(this, "account", undefined);
 
     return this as this & { account: undefined };
-  }
+  };
 
-  isConnected<TAccount extends ISmartContractAccount>(): this is this & {
+  isConnected = <TAccount extends ISmartContractAccount>(): this is this & {
     account: TAccount;
-  } {
+  } => {
     return this.account !== undefined;
-  }
+  };
+
+  extend = <R>(fn: (self: this) => R): this & R => {
+    const extended = fn(this) as any;
+    // this should make it so extensions can't overwrite the base methods
+    for (const key in this) {
+      delete extended[key];
+    }
+
+    return Object.assign(this, extended);
+  };
 
   private overrideMiddlewareFunction = (
     override: AccountMiddlewareOverrideFn

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -302,4 +302,28 @@ export interface ISmartAccountProvider<
    * @returns the provider with the account disconnected
    */
   disconnect(): this & { account: undefined };
+
+  /**
+   * Allows you to add additional functionality and utility methods to this provider
+   * via a decorator pattern.
+   *
+   * NOTE: this method does not allow you to override existing methods on the provider.
+   *
+   * @example
+   * ```ts
+   * const provider = new SmartAccountProvider(...).extend((provider) => ({
+   *  debugSendUserOperation: (...args) => {
+   *    console.log("debugging send useroperation");
+   *    return provider.sendUserOperation(...args);
+   *  }
+   * }));
+   *
+   * provider.debugSendUserOperation(...);
+   * ```
+   *
+   * @param extendFn -- this function gives you access to the created provider instance and returns an object
+   * with the extension methods
+   * @returns -- the provider with the extension methods added
+   */
+  extend: <R>(extendFn: (self: this) => R) => this & R;
 }

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -187,6 +187,10 @@ export default defineConfig({
                 text: "disconnect",
                 link: "/disconnect",
               },
+              {
+                text: "extend",
+                link: "/extend",
+              },
             ],
           },
           {

--- a/site/packages/aa-core/provider/extend.md
+++ b/site/packages/aa-core/provider/extend.md
@@ -1,0 +1,53 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: extend
+  - - meta
+    - name: description
+      content: Overview of the extend method on ISmartAccountProvider
+  - - meta
+    - property: og:description
+      content: Overview of the extend method on ISmartAccountProvider
+---
+
+# extend
+
+Allows you to add additional functionality and utility methods to this provider via a decorator pattern.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { provider } from "./provider";
+
+const extendedProvider = provider.extend((provider) => ({
+  debugSendUserOperation: (...args) => {
+    console.log("debugging send user operation");
+    return provider.sendUserOperation(...args);
+  },
+}));
+
+extendedProvider.debugSendUserOperation(...);
+```
+
+<<< @/snippets/provider.ts
+:::
+
+## Returns
+
+### `this & R`
+
+Where `R` is the return type of the decorator function.
+
+::: warning
+The extend method will not allow you to override existing methods or properties on the provider. To do this, you'll have to use class inheritance.
+:::
+
+## Parameters
+
+### `decoratorFn: (provider: this) => R`
+
+A lambda function that takes the current provider as input and returns a set of extension methods and properties to add to the provider.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `extend` method to the `SmartAccountProvider` class, allowing users to add additional functionality and utility methods to the provider via a decorator pattern.

### Detailed summary
- Added `extend` method to `SmartAccountProvider` class.
- The `extend` method allows users to add extension methods and properties to the provider.
- Extension methods and properties are defined in a decorator function passed to the `extend` method.
- The `extend` method does not allow overriding existing methods or properties on the provider.
- Chaining of multiple `extend` calls is supported.
- Preserves class functions when extending the provider.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->