### PR TITLE
docs: add telegram group link to modular account doc

### DIFF
--- a/site/smart-accounts/accounts/modular-account.md
+++ b/site/smart-accounts/accounts/modular-account.md
@@ -18,7 +18,7 @@ We are working towards the first stable version of [ERC-6900](https://eips.ether
 
 Soon after, we will release an ERC-6900 compatible Modular Account in Account Kit. It will support new use cases like session keys, account recovery, spending limits, and any ERC-6900 plugin you can imagine. The Light Account is forward-compatible with ERC-6900 so you can optionally upgrade it to the Modular Account once released.
 
-If you're developing a plugin, we'd love to [chat](mailto:account-abstraction@alchemy.com)!
+If you're developing a plugin or modular account, we'd love to chat! Join the Modular Accounts [Telegram group](https://t.me/+KfB9WuhKDgk5YzIx) or [say hello](mailto:account-abstraction@alchemy.com) to a team member at Alchemy.
 
 Read on to learn more about ERC-6900 and modular accounts.
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Added mention of Modular Account in Account Kit
- Added support for new use cases like session keys, account recovery, spending limits
- Added mention of ERC-6900 plugin support
- Updated contact information for developing plugins or modular accounts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->