### PR TITLE
docs: fix typos

### DIFF
--- a/packages/accounts/src/light-account/e2e-tests/light-account.test.ts
+++ b/packages/accounts/src/light-account/e2e-tests/light-account.test.ts
@@ -28,7 +28,7 @@ describe("Light Account Tests", () => {
     UNDEPLOYED_OWNER_MNEMONIC
   );
 
-  it("should succesfully get counterfactual address", async () => {
+  it("should successfully get counterfactual address", async () => {
     const signer = givenConnectedProvider({ owner, chain });
     expect(await signer.getAddress()).toMatchInlineSnapshot(
       '"0x7eDdc16B15259E5541aCfdebC46929873839B872"'

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -24,7 +24,7 @@ describe("Simple Account Tests", () => {
   };
   const chain = polygonMumbai;
 
-  it("should succesfully get counterfactual address", async () => {
+  it("should successfully get counterfactual address", async () => {
     const signer = givenConnectedProvider({ owner, chain });
     expect(await signer.getAddress()).toMatchInlineSnapshot(
       `"0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"`

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -45,7 +45,7 @@ export type AlchemyProviderConfig = {
      * the UserOperation being mined, users can increase the preVerificationGas by
      * a buffer. This buffer will always be charged, regardless of price at time of mine.
      *
-     * NOTE: this is only applied if the defualt gas estimator is used.
+     * NOTE: this is only applied if the default gas estimator is used.
      */
     preVerificationGasBufferPercent?: bigint;
   };

--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -16,7 +16,7 @@ describe("Simple Account Tests", () => {
     LocalAccountSigner.mnemonicToAccountSigner(OWNER_MNEMONIC);
   const chain = polygonMumbai;
 
-  it("should succesfully get counterfactual address", async () => {
+  it("should successfully get counterfactual address", async () => {
     const signer = givenConnectedProvider({ owner, chain });
     expect(await signer.getAddress()).toMatchInlineSnapshot(
       `"0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"`

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -78,7 +78,7 @@ describe("Base Tests", () => {
     } as any;
 
     // This says the await is not important... it is. the method is not marked sync because we don't need it to be,
-    // but the address is emited from an async method so we want to await that
+    // but the address is emitted from an async method so we want to await that
     await providerMock.connect(() => account);
 
     expect(spy.mock.calls).toMatchInlineSnapshot(`

--- a/packages/core/src/signer/__tests__/local-account.test.ts
+++ b/packages/core/src/signer/__tests__/local-account.test.ts
@@ -23,7 +23,7 @@ describe("Local Account Signer Tests", () => {
       );
 
       expect(
-        await signer.signMessage("i will definately break this test case")
+        await signer.signMessage("i will definitely break this test case")
       ).toMatchInlineSnapshot(
         '"0x1d9a20cfd63c179daab241d9e64a2549e1a47c1ca7c465df6f5b8c5720cee7266050b89b3874b384c88cd8325601572e79b3b626dc756a6aec5fff05d4ce5efc1b"'
       );
@@ -61,7 +61,7 @@ describe("Local Account Signer Tests", () => {
       );
 
       expect(
-        await signer.signMessage("i will definately break this test case")
+        await signer.signMessage("i will definitely break this test case")
       ).toMatchInlineSnapshot(
         '"0x907004e990bb1bca76d9fed6bf4a6b614a8d11b6430657cb99ae83fae55c9bc60571876d8c01832e4661dd4312fa08b799b6f59c9b9abddd67e181abc6aef17e1c"'
       );

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -22,7 +22,7 @@ describe("Simple Account Tests", async () => {
   const alchemyProvider = await alchemy.config.getProvider();
   const owner = Wallet.fromMnemonic(OWNER_MNEMONIC);
 
-  it("should succesfully get counterfactual address", async () => {
+  it("should successfully get counterfactual address", async () => {
     const signer = givenConnectedProvider({ alchemyProvider, owner });
     expect(await signer.getAddress()).toMatchInlineSnapshot(
       `"0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"`


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Fixing typos and improving code consistency.

### Detailed summary:
- Fixed a typo in the word "default" in `packages/alchemy/src/provider.ts`.
- Fixed a typo in the word "successfully" in `packages/accounts/src/light-account/e2e-tests/light-account.test.ts`.
- Fixed a typo in the word "successfully" in `packages/core/e2e-tests/simple-account.test.ts`.
- Fixed a typo in the word "successfully" in `packages/alchemy/e2e-tests/simple-account.test.ts`.
- Fixed a typo in the word "emitted" in `packages/core/src/provider/__tests__/base.test.ts`.
- Fixed a typo in the word "successfully" in `packages/ethers/e2e-tests/simple-account.test.ts`.
- Fixed a typo in the word "definitely" in `packages/core/src/signer/__tests__/local-account.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->