### PR TITLE
fix: the user operation response type was wrong

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,7 +61,9 @@ export interface UserOperationEstimateGasResponse {
   callGasLimit: BigNumberish;
 }
 
-export interface UserOperationResponse extends UserOperationRequest {
+export interface UserOperationResponse {
+  /* the User Operation */
+  userOperation: UserOperationRequest;
   /* the address of the entry point contract that executed the user operation */
   entryPoint: Address;
   /* the block number the user operation was included in */

--- a/site/packages/aa-alchemy/provider/introduction.md
+++ b/site/packages/aa-alchemy/provider/introduction.md
@@ -14,7 +14,7 @@ head:
 
 # AlchemyProvider
 
-`AlchemyProvider` is an extension of the `SmartAccountProvider` implementation. It's a simpler interface you can use to leverage the Alchemy stack - JSON-RPC requests via API Key or JSON Web Token (JWT), Alchemy Rundler (an [EIP-4337](https://eips.ethereum.org/EIPS/eip-4337) Bundler), and Alchemy Gas Manager (an [EIP-4337](https://eips.ethereum.org/EIPS/eip-4337) Paymaster).
+`AlchemyProvider` is an extension of the [`SmartAccountProvider`](/packages/aa-core/provider/introduction) implementation. It's a simpler interface you can use to leverage the Alchemy stack - JSON-RPC requests via API Key or JSON Web Token (JWT), Alchemy Rundler (an [EIP-4337](https://eips.ethereum.org/EIPS/eip-4337) Bundler), and Alchemy Gas Manager (an [EIP-4337](https://eips.ethereum.org/EIPS/eip-4337) Paymaster).
 
 Notable differences between `AlchemyProvider` and `SmartAccountProvider` are implementations for:
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `UserOperationResponse` interface and the `AlchemyProvider` class. 

### Detailed summary
- The `UserOperationResponse` interface no longer extends `UserOperationRequest`.
- The `UserOperationResponse` interface now includes a `userOperation` property of type `UserOperationRequest`.
- The `AlchemyProvider` class is now described as an extension of the `SmartAccountProvider` implementation.
- The `AlchemyProvider` class now has implementations for JSON-RPC requests, Alchemy Bundler, and Alchemy Gas Manager.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->