### PR TITLE
docs: add entrypoint address to light account script

### DIFF
--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -51,11 +51,11 @@ yarn add @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
 
 ## A Simple Light Account Example
 
-Using the SDK, we'll create a Light Account and send a User Operation from it. The Light Account will be owned by an Externally Owned Account (EOA). Here's a demonstration:
+Using the SDK, we'll deploy a Light Account and send a User Operation from it. The Light Account will be owned by an Externally Owned Account (EOA). Here's a demonstration:
 
 <<< @/snippets/light-account.ts
 
-This initializes a `provider` for your smart account which is then used to send user operations from it.
+This initializes a `provider` for your smart account which is then used to send user operations from it. It also logs the address of the deployed smart account.
 
 ::: tip Note
 Remember to:

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -17,11 +17,12 @@ const eoaSigner: SmartAccountSigner =
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY", // Replace with your Alchemy API key, you can get one at https://dashboard.alchemy.com/
   chain,
-  entryPointAddress: "0x...",
+  // Entrypoint address, you can use a different entrypoint if needed, check out https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints
+  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: "0x...",
+      entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
       chain: rpcClient.chain,
       owner: eoaSigner,
       factoryAddress: getDefaultLightAccountFactory(rpcClient.chain), // Default address for Light Account on Sepolia, you can replace it with your own.


### PR DESCRIPTION
- Adds an entrypoint address to the light account script
- Re-word some lines to make it more clear that the light account is being deployed
- Adds link to eth_supportedEntryPoints in code snippet so users can check all the supported entrypoints

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on deploying a Light Account and sending a User Operation from it. 

### Detailed summary
- Updated the code to deploy a Light Account instead of creating it
- Added logging of the deployed smart account's address
- Updated the entrypoint address in the code to use a specific value
- Added a note reminding to replace the Alchemy API key
- Updated the entrypoint address in the snippet code to use a specific value
- Updated the factory address in the snippet code to use the default address for Light Account on Sepolia

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->