### PR TITLE
docs: remove the empty code block

### DIFF
--- a/site/packages/aa-core/utils/getUserOperationHash.md
+++ b/site/packages/aa-core/utils/getUserOperationHash.md
@@ -54,7 +54,3 @@ The entrypoint address to use for the UserOperation
 ### `chainId: bigint`
 
 The chainId that this UserOperation will be submitted to
-
-```
-
-```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `getUserOperationHash.md` file in the `aa-core/utils` directory. The notable change is the removal of two empty code blocks. 

### Detailed summary
- Removed two empty code blocks in `getUserOperationHash.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->