### PR TITLE
docs: add gasless NFT Minter Demo!

### DIFF
--- a/site/demos.md
+++ b/site/demos.md
@@ -16,7 +16,13 @@ head:
 
 ## Gasless Token Minting Demo
 
-This demo shows how to mint a token to a Light Account using Alchemy's Gas Manager to provide a gas-less minting experience.
+This demo shows how to mint an ERC-20 token to a Light Account using Alchemy's Gas Manager to provide a gas-less minting experience.
 
 [Try it out!](https://aa-simple-dapp.vercel.app/)
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/alchemyplatform/aa-sdk/tree/main/examples/aa-simple-dapp?file=README.md)
+
+## Gasless NFT Minting Demo
+
+This demo shows how to mint an NFT (ERC-721 token) to a Light Account using Alchemy's Gas Manager to provide a gas-less minting experience.
+
+[Try it out!](https://gasless-nft-minter-v2.vercel.app/)


### PR DESCRIPTION
Adding the live link to the demo for users to try: https://gasless-nft-minter-v2.vercel.app/

<img width="1440" alt="Screenshot 2023-10-20 at 10 12 00 AM" src="https://github.com/alchemyplatform/aa-sdk/assets/25407127/9933a009-1386-4a97-a637-bef2ec34ef4c">


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the description of the `Gasless Token Minting Demo` to clarify that it mints an ERC-20 token.
- Added a new demo called `Gasless NFT Minting Demo` which shows how to mint an NFT (ERC-721 token) to a Light Account using Alchemy's Gas Manager.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->