### PR TITLE
feat: abstract out entry point contract address param for smart account providers

### DIFF
--- a/examples/aa-simple-dapp/src/context/wallet/index.tsx
+++ b/examples/aa-simple-dapp/src/context/wallet/index.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { entryPointAddress } from "@/config/client";
 import { useAlchemyProvider } from "@/hooks/useAlchemyProvider";
 import { useMagicSigner } from "@/hooks/useMagicSigner";
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
@@ -49,7 +48,7 @@ export const WalletContextProvider = ({
 
   const { magic, signer } = useMagicSigner();
   const { provider, connectProviderToAccount, disconnectProviderFromAccount } =
-    useAlchemyProvider({ entryPointAddress });
+    useAlchemyProvider();
 
   const login = useCallback(
     async (email: string) => {

--- a/examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts
+++ b/examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts
@@ -17,25 +17,25 @@ export const useAlchemyProvider = () => {
     useState<Address>();
   const [entryPointAddress, setEntryPointAddress] = useState<Address>();
 
-  useEffect(() => {
-    (async () => {
-      const [lightAccountFactoryAddress, entryPointAddress] = await Promise.all(
-        [
-          getDefaultLightAccountFactory(chain),
-          getDefaultEntryPointContract(chain),
-        ]
-      );
-      setEntryPointAddress(entryPointAddress);
-      setLightAccountFactoryAddress(lightAccountFactoryAddress);
-    })();
-  }, []);
-
   const [provider, setProvider] = useState<AlchemyProvider>(
     new AlchemyProvider({
       chain,
       rpcUrl: getRpcUrl(),
     })
   );
+
+  useEffect(() => {
+    if (!provider || entryPointAddress) return;
+
+    (async () => {
+      const [factoryAddress, entryPoint] = await Promise.all([
+        getDefaultLightAccountFactory(chain),
+        getDefaultEntryPointContract({ chain }),
+      ]);
+      setEntryPointAddress(entryPoint);
+      setLightAccountFactoryAddress(factoryAddress);
+    })();
+  }, [entryPointAddress, provider]);
 
   const connectProviderToAccount = useCallback(
     (signer: SmartAccountSigner, account?: Address) => {

--- a/examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts
+++ b/examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts
@@ -1,32 +1,48 @@
-import {
-  chain,
-  gasManagerPolicyId,
-  lightAccountFactoryAddress,
-} from "@/config/client";
+import { chain, gasManagerPolicyId } from "@/config/client";
 import { getRpcUrl } from "@/config/rpc";
-import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactory,
+} from "@alchemy/aa-accounts";
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
-import { SmartAccountSigner } from "@alchemy/aa-core";
-import { useCallback, useState } from "react";
+import {
+  SmartAccountSigner,
+  getDefaultEntryPointContract,
+} from "@alchemy/aa-core";
+import { useCallback, useEffect, useState } from "react";
 import { Address } from "viem";
 
-type AlchemyProviderProps = {
-  entryPointAddress: Address;
-};
+export const useAlchemyProvider = () => {
+  const [lightAccountFactoryAddress, setLightAccountFactoryAddress] =
+    useState<Address>();
+  const [entryPointAddress, setEntryPointAddress] = useState<Address>();
 
-export const useAlchemyProvider = ({
-  entryPointAddress,
-}: AlchemyProviderProps) => {
+  useEffect(() => {
+    (async () => {
+      const [lightAccountFactoryAddress, entryPointAddress] = await Promise.all(
+        [
+          getDefaultLightAccountFactory(chain),
+          getDefaultEntryPointContract(chain),
+        ]
+      );
+      setEntryPointAddress(entryPointAddress);
+      setLightAccountFactoryAddress(lightAccountFactoryAddress);
+    })();
+  }, []);
+
   const [provider, setProvider] = useState<AlchemyProvider>(
     new AlchemyProvider({
       chain,
-      entryPointAddress,
       rpcUrl: getRpcUrl(),
     })
   );
 
   const connectProviderToAccount = useCallback(
     (signer: SmartAccountSigner, account?: Address) => {
+      if (lightAccountFactoryAddress == null || entryPointAddress == null) {
+        return null;
+      }
+
       const connectedProvider = provider
         .connect((provider) => {
           return new LightSmartContractAccount({
@@ -46,7 +62,7 @@ export const useAlchemyProvider = ({
       setProvider(connectedProvider);
       return connectedProvider;
     },
-    [entryPointAddress, provider]
+    [entryPointAddress, lightAccountFactoryAddress, provider]
   );
 
   const disconnectProviderFromAccount = useCallback(() => {

--- a/examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts
+++ b/examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts
@@ -56,7 +56,6 @@ export const useAlchemyProvider = () => {
         })
         .withAlchemyGasManager({
           policyId: gasManagerPolicyId,
-          entryPoint: entryPointAddress,
         });
 
       setProvider(connectedProvider);

--- a/examples/alchemy-daapp/next.config.mjs
+++ b/examples/alchemy-daapp/next.config.mjs
@@ -6,6 +6,14 @@ await import("./src/env.mjs");
 
 /** @type {import("next").NextConfig} */
 const config = {
+  reactStrictMode: true,
+
+  /**
+   * If you have `experimental: { appDir: true }` set, then you must comment the below `i18n` config
+   * out.
+   *
+   * @see https://github.com/vercel/next.js/issues/41980
+   */
   i18n: {
     locales: ["en"],
     defaultLocale: "en",

--- a/examples/alchemy-daapp/next.config.mjs
+++ b/examples/alchemy-daapp/next.config.mjs
@@ -6,14 +6,6 @@ await import("./src/env.mjs");
 
 /** @type {import("next").NextConfig} */
 const config = {
-  reactStrictMode: true,
-
-  /**
-   * If you have `experimental: { appDir: true }` set, then you must comment the below `i18n` config
-   * out.
-   *
-   * @see https://github.com/vercel/next.js/issues/41980
-   */
   i18n: {
     locales: ["en"],
     defaultLocale: "en",

--- a/examples/alchemy-daapp/package.json
+++ b/examples/alchemy-daapp/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@alchemy/aa-accounts": "latest",
-    "@alchemy/aa-alchemy": "latest",
-    "@alchemy/aa-core": "latest",
+    "@alchemy/aa-accounts": "^0.1.1",
+    "@alchemy/aa-alchemy": "^0.1.1",
+    "@alchemy/aa-core": "^0.1.1",
     "@chakra-ui/react": "^2.6.1",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",

--- a/examples/alchemy-daapp/src/env.mjs
+++ b/examples/alchemy-daapp/src/env.mjs
@@ -7,7 +7,7 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    APP_ENV: z.enum(["development", "test", "production"]),
+    NODE_ENV: z.enum(["development", "test", "production"]),
     MUMBAI_ALCHEMY_API_URL: z.string().url(),
     SEPOLIA_ALCHEMY_API_URL: z.string().url(),
     POLYGON_ALCHEMY_API_URL: z.string().url(),

--- a/examples/alchemy-daapp/src/env.mjs
+++ b/examples/alchemy-daapp/src/env.mjs
@@ -7,7 +7,7 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    NODE_ENV: z.enum(["development", "test", "production"]),
+    APP_ENV: z.enum(["development", "test", "production"]),
     MUMBAI_ALCHEMY_API_URL: z.string().url(),
     SEPOLIA_ALCHEMY_API_URL: z.string().url(),
     POLYGON_ALCHEMY_API_URL: z.string().url(),

--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
@@ -1,8 +1,8 @@
-import { LightSmartContractAccount } from "@alchemy/aa-accounts";
-import { withAlchemyGasManager } from "@alchemy/aa-alchemy";
+import { LightSmartContractAccount, getDefaultLightAccountFactory } from "@alchemy/aa-accounts";
+import { AlchemyProvider, withAlchemyGasManager } from "@alchemy/aa-alchemy";
 import {
-  SmartAccountProvider,
   createPublicErc4337Client,
+  getDefaultEntryPointContract,
   type SmartAccountSigner
 } from "@alchemy/aa-core";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -63,28 +63,8 @@ const onboardingStepHandlers: Record<
       throw new Error("No connected account or address");
     }
     return {
-      nextStep: OnboardingStepIdentifier.GET_ENTRYPOINT,
-      addedContext: {},
-    };
-  },
-  // This step gets the entrypoint for the smart account.
-  [OnboardingStepIdentifier.GET_ENTRYPOINT]: async (context) => {
-    if (!context.owner) {
-      throw new Error("No owner");
-    }
-    const entrypointAddress = await context
-      .client!.getSupportedEntryPoints()
-      .then((entrypoints) => {
-        if (entrypoints.length === 0) {
-          throw new Error("No entrypoints found");
-        }
-        return entrypoints[0];
-      });
-    return {
       nextStep: OnboardingStepIdentifier.CREATE_SCWALLET,
-      addedContext: {
-        entrypointAddress,
-      },
+      addedContext: {},
     };
   },
   /*
@@ -93,14 +73,11 @@ const onboardingStepHandlers: Record<
    * a paymaster middleware (if useGasManager is true).
    */
   [OnboardingStepIdentifier.CREATE_SCWALLET]: async (context, appConfig) => {
-    if (!context.entrypointAddress) {
-      throw new Error("No entrypoint address was found");
-    }
-
     const chain: Chain = context.chain!;
-    const entryPointAddress = context.entrypointAddress;
-    let baseSigner = new SmartAccountProvider({
-      rpcProvider: appConfig.rpcUrl,
+    const [entryPointAddress, factoryAddress] = await Promise.all([getDefaultEntryPointContract(chain), getDefaultLightAccountFactory(chain)])
+
+    let baseSigner = new AlchemyProvider({
+      rpcUrl: appConfig.rpcUrl,
       chain,
       opts: {
         txMaxRetries: 60,
@@ -113,7 +90,7 @@ const onboardingStepHandlers: Record<
         entryPointAddress,
         chain,
         owner: context.owner,
-        factoryAddress: appConfig.lightAccountFactoryAddress,
+        factoryAddress,
         rpcClient: provider,
       });
     });
@@ -122,8 +99,7 @@ const onboardingStepHandlers: Record<
     const smartAccountAddress = await baseSigner.getAddress();
     if (context.useGasManager) {
       const smartAccountSigner = withAlchemyGasManager(baseSigner, {
-        policyId: appConfig.gasManagerPolicyId,
-        entryPoint: entryPointAddress,
+        policyId: appConfig.gasManagerPolicyId
       });
 
       return {

--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
@@ -101,9 +101,8 @@ const onboardingStepHandlers: Record<
     const entryPointAddress = context.entrypointAddress;
     let baseSigner = new SmartAccountProvider({
       rpcProvider: appConfig.rpcUrl,
-      entryPointAddress,
       chain,
-      feeOpts: {
+      opts: {
         txMaxRetries: 60,
       },
     }).connect((provider: any) => {

--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
@@ -74,15 +74,21 @@ const onboardingStepHandlers: Record<
    */
   [OnboardingStepIdentifier.CREATE_SCWALLET]: async (context, appConfig) => {
     const chain: Chain = context.chain!;
-    const [entryPointAddress, factoryAddress] = await Promise.all([getDefaultEntryPointContract(chain), getDefaultLightAccountFactory(chain)])
 
-    let baseSigner = new AlchemyProvider({
+    const provider = new AlchemyProvider({
       rpcUrl: appConfig.rpcUrl,
       chain,
       opts: {
         txMaxRetries: 60,
       },
-    }).connect((provider: any) => {
+    })
+
+    const [entryPointAddress, factoryAddress] = await Promise.all([
+      getDefaultEntryPointContract({rpcClient: provider.rpcClient}),
+      getDefaultLightAccountFactory(chain)
+    ])
+
+    let baseSigner = provider.connect((provider: any) => {
       if (!context.owner) {
         throw new Error("No owner for account was found");
       }

--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingDataModels.tsx
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingDataModels.tsx
@@ -1,12 +1,12 @@
 import {
   PublicErc4337Client,
-  SmartAccountSigner,
   SmartAccountProvider,
+  SmartAccountSigner,
 } from "@alchemy/aa-core";
+import { Link, Text } from "@chakra-ui/react";
+import { UseQueryResult } from "@tanstack/react-query";
 import { Chain } from "viem";
 import { RequestFunds } from "./RequestFunds";
-import { UseQueryResult } from "@tanstack/react-query";
-import { Link, Text } from "@chakra-ui/react";
 
 // .01 in wei
 export const MIN_ONBOARDING_WALLET_BALANCE = BigInt("10000000000000000");
@@ -20,7 +20,6 @@ export interface OnboardingContext {
   smartAccountAddress: `0x${string}`;
   smartAccountSigner: SmartAccountProvider;
   chain: Chain;
-  entrypointAddress: `0x${string}`;
   mintDeployTxnHash: `0x${string}`;
 }
 
@@ -34,7 +33,6 @@ export interface OnboardingStep {
 
 export enum OnboardingStepIdentifier {
   INITIAL_STEP,
-  GET_ENTRYPOINT,
   CREATE_SCWALLET,
   FILL_SCWALLET,
   MINT_NFT,
@@ -80,12 +78,6 @@ export function metaForStepIdentifier(
         description:
           "Pulling together current information for account creation.",
         title: "Gathering Information",
-      };
-    case OnboardingStepIdentifier.GET_ENTRYPOINT:
-      return {
-        percent: 10,
-        description: "Fetching the entrypoint address for the account.",
-        title: "Fetching Entrypoint",
       };
     case OnboardingStepIdentifier.CREATE_SCWALLET:
       return {

--- a/packages/accounts/src/kernel-zerodev/README.md
+++ b/packages/accounts/src/kernel-zerodev/README.md
@@ -40,7 +40,6 @@ const provider = new KernelAccountProvider(
   // the demo key below is public and rate-limited, it's better to create a new one
   // you can get started with a free account @ https://www.alchemy.com/
   "https://polygon-mumbai.g.alchemy.com/v2/demo", // rpcUrl
-  "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789", // entryPointAddress
   polygonMumbai // chain
 ).connect(
   (rpcClient) =>

--- a/packages/accounts/src/kernel-zerodev/__tests__/account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/account.test.ts
@@ -40,7 +40,6 @@ describe("Kernel Account Tests", () => {
 
   const provider = new KernelAccountProvider({
     rpcProvider: config.rpcProvider,
-    entryPointAddress: config.entryPointAddress,
     chain: config.chain,
   });
 

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
@@ -64,7 +64,6 @@ describe("Kernel Account Tests", () => {
 
   const provider = new KernelAccountProvider({
     rpcProvider: config.rpcProvider,
-    entryPointAddress: config.entryPointAddress,
     chain: config.chain,
   });
 

--- a/packages/accounts/src/light-account/__tests__/account.test.ts
+++ b/packages/accounts/src/light-account/__tests__/account.test.ts
@@ -81,7 +81,6 @@ const givenConnectedProvider = ({
 }) =>
   new SmartAccountProvider({
     rpcProvider: `${chain.rpcUrls.alchemy.http[0]}/${"test"}`,
-    entryPointAddress: "0xENTRYPOINT_ADDRESS",
     chain,
   }).connect((provider) => {
     const account = new LightSmartContractAccount({

--- a/packages/accounts/src/light-account/e2e-tests/light-account.test.ts
+++ b/packages/accounts/src/light-account/e2e-tests/light-account.test.ts
@@ -190,7 +190,6 @@ const givenConnectedProvider = ({
   new SmartAccountProvider({
     rpcProvider:
       RPC_URL != null ? RPC_URL : `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
-    entryPointAddress: ENTRYPOINT_ADDRESS,
     chain,
   }).connect(
     (provider) =>

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -172,7 +172,6 @@ const givenConnectedProvider = ({
   new AlchemyProvider({
     apiKey: API_KEY!,
     chain,
-    entryPointAddress: ENTRYPOINT_ADDRESS,
     feeOpts,
   }).connect(
     (provider) =>

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -61,7 +61,6 @@ describe("Simple Account Tests", () => {
       chain,
     }).withAlchemyGasManager({
       policyId: PAYMASTER_POLICY_ID,
-      entryPoint: ENTRYPOINT_ADDRESS,
     });
 
     const result = await signer.sendUserOperation({
@@ -77,7 +76,6 @@ describe("Simple Account Tests", () => {
     const signer = givenConnectedProvider({ owner, chain })
       .withAlchemyGasManager({
         policyId: PAYMASTER_POLICY_ID,
-        entryPoint: ENTRYPOINT_ADDRESS,
       })
       .withFeeDataGetter(async () => ({
         maxFeePerGas: 1n,
@@ -138,7 +136,6 @@ describe("Simple Account Tests", () => {
       chain,
     }).withAlchemyGasManager({
       policyId: PAYMASTER_POLICY_ID,
-      entryPoint: ENTRYPOINT_ADDRESS,
     });
 
     const result = await signer.sendUserOperation({

--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -79,7 +79,6 @@ const givenConnectedProvider = ({
     rpcUrl: "https://eth-mainnet.g.alchemy.com/v2",
     jwt: "test",
     chain,
-    entryPointAddress: "0xENTRYPOINT_ADDRESS",
   }).connect((provider) => {
     const account = new SimpleSmartContractAccount({
       entryPointAddress: "0xENTRYPOINT_ADDRESS",

--- a/packages/alchemy/src/middleware/gas-manager.ts
+++ b/packages/alchemy/src/middleware/gas-manager.ts
@@ -1,15 +1,14 @@
 import {
   deepHexlify,
+  getDefaultEntryPointContract,
   resolveProperties,
   type UserOperationRequest,
 } from "@alchemy/aa-core";
-import type { Address } from "viem";
 import type { AlchemyProvider } from "../provider.js";
 import type { ClientWithAlchemyMethods } from "./client.js";
 
 export interface AlchemyGasManagerConfig {
   policyId: string;
-  entryPoint: Address;
 }
 
 /**
@@ -82,6 +81,9 @@ const withAlchemyPaymasterAndDataMiddleware = (
     }
   },
   paymasterDataMiddleware: async (struct) => {
+    const entryPoint =
+      provider.account?.entryPointAddress ??
+      (await getDefaultEntryPointContract(provider.rpcClient.chain));
     const { paymasterAndData } = await (
       provider.rpcClient as ClientWithAlchemyMethods
     ).request({
@@ -89,7 +91,7 @@ const withAlchemyPaymasterAndDataMiddleware = (
       params: [
         {
           policyId: config.policyId,
-          entryPoint: config.entryPoint,
+          entryPoint,
           userOperation: deepHexlify(await resolveProperties(struct)),
         },
       ],
@@ -122,6 +124,10 @@ const withAlchemyGasAndPaymasterAndDataMiddleware = (
       };
     }
 
+    const entryPoint =
+      provider.account?.entryPointAddress ??
+      (await getDefaultEntryPointContract(provider.rpcClient.chain));
+
     const result = await (
       provider.rpcClient as ClientWithAlchemyMethods
     ).request({
@@ -129,7 +135,7 @@ const withAlchemyGasAndPaymasterAndDataMiddleware = (
       params: [
         {
           policyId: config.policyId,
-          entryPoint: config.entryPoint,
+          entryPoint,
           userOperation: userOperation,
           dummySignature: userOperation.signature,
           feeOverride: feeOverride,

--- a/packages/alchemy/src/middleware/gas-manager.ts
+++ b/packages/alchemy/src/middleware/gas-manager.ts
@@ -83,7 +83,7 @@ const withAlchemyPaymasterAndDataMiddleware = (
   paymasterDataMiddleware: async (struct) => {
     const entryPoint =
       provider.account?.entryPointAddress ??
-      (await getDefaultEntryPointContract(provider.rpcClient.chain));
+      (await getDefaultEntryPointContract({ rpcClient: provider.rpcClient }));
     const { paymasterAndData } = await (
       provider.rpcClient as ClientWithAlchemyMethods
     ).request({
@@ -126,7 +126,7 @@ const withAlchemyGasAndPaymasterAndDataMiddleware = (
 
     const entryPoint =
       provider.account?.entryPointAddress ??
-      (await getDefaultEntryPointContract(provider.rpcClient.chain));
+      (await getDefaultEntryPointContract({ rpcClient: provider.rpcClient }));
 
     const result = await (
       provider.rpcClient as ClientWithAlchemyMethods

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -58,7 +58,6 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
 
   constructor({
     chain,
-    entryPointAddress,
     opts,
     feeOpts,
     ...connectionConfig
@@ -86,7 +85,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
       }),
     });
 
-    super({ rpcProvider: client, entryPointAddress, chain: _chain, opts });
+    super({ rpcProvider: client, chain: _chain, opts });
 
     withAlchemyGasFeeEstimator(
       this,
@@ -116,7 +115,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
     const request = deepHexlify(await resolveProperties(struct));
     const estimates = await this.rpcClient.estimateUserOperationGas(
       request,
-      this.entryPointAddress
+      this.account!.entryPointAddress
     );
     estimates.preVerificationGas =
       (BigInt(estimates.preVerificationGas) * (100n + this.pvgBuffer)) / 100n;

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -2,6 +2,7 @@ import {
   SmartAccountProvider,
   createPublicErc4337Client,
   deepHexlify,
+  getDefaultEntryPointContract,
   resolveProperties,
   type AccountMiddlewareFn,
   type SmartAccountProviderConfig,
@@ -112,10 +113,13 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
   }
 
   override gasEstimator: AccountMiddlewareFn = async (struct) => {
+    const entryPoint =
+      this.account?.entryPointAddress ??
+      (await getDefaultEntryPointContract(this.chain));
     const request = deepHexlify(await resolveProperties(struct));
     const estimates = await this.rpcClient.estimateUserOperationGas(
       request,
-      this.account!.entryPointAddress
+      entryPoint
     );
     estimates.preVerificationGas =
       (BigInt(estimates.preVerificationGas) * (100n + this.pvgBuffer)) / 100n;

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -115,7 +115,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
   override gasEstimator: AccountMiddlewareFn = async (struct) => {
     const entryPoint =
       this.account?.entryPointAddress ??
-      (await getDefaultEntryPointContract(this.chain));
+      (await getDefaultEntryPointContract({ chain: this.chain }));
     const request = deepHexlify(await resolveProperties(struct));
     const estimates = await this.rpcClient.estimateUserOperationGas(
       request,

--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -70,7 +70,6 @@ const givenConnectedProvider = ({
   return new SmartAccountProvider({
     rpcProvider:
       RPC_URL != null ? RPC_URL : `${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`,
-    entryPointAddress: ENTRYPOINT_ADDRESS,
     chain,
   }).connect(
     (provider) =>

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -52,7 +52,6 @@ const givenConnectedProvider = ({
 }) =>
   new SmartAccountProvider({
     rpcProvider: `${chain.rpcUrls.alchemy.http[0]}/${"test"}`,
-    entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
     chain,
   }).connect((provider) => {
     const account = new SimpleSmartContractAccount({

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -42,6 +42,8 @@ export abstract class BaseSmartContractAccount<
   TTransport extends SupportedTransports = Transport
 > implements ISmartContractAccount
 {
+  readonly entryPointAddress: Address;
+
   protected factoryAddress: Address;
   protected deploymentState: DeploymentState = DeploymentState.UNDEFINED;
   protected accountAddress?: Address;
@@ -51,7 +53,6 @@ export abstract class BaseSmartContractAccount<
     PublicClient,
     Chain
   >;
-  protected entryPointAddress: Address;
   protected rpcProvider:
     | PublicErc4337Client<TTransport>
     | PublicErc4337Client<HttpTransport>;

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -1,12 +1,14 @@
 import type { Address } from "abitype";
 import type { Hash, Hex } from "viem";
 import type { SignTypedDataParameters } from "viem/accounts";
-import type { BatchUserOperationCallData } from "../types";
 import type { SmartAccountSigner } from "../signer/types";
+import type { BatchUserOperationCallData } from "../types";
 
 export type SignTypedDataParams = Omit<SignTypedDataParameters, "privateKey">;
 
 export interface ISmartContractAccount {
+  readonly entryPointAddress: Address;
+
   /**
    * @returns the init code for the account
    */

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -16,7 +16,6 @@ describe("Base Tests", () => {
 
   const providerMock = new SmartAccountProvider({
     rpcProvider: "ALCHEMY_RPC_URL",
-    entryPointAddress: "0xENTRYPOINT_ADDRESS",
     chain: polygonMumbai,
   });
 
@@ -164,7 +163,6 @@ describe("Base Tests", () => {
 
     const provider = new TestProvider({
       rpcProvider: "ALCHEMY_RPC_URL",
-      entryPointAddress: "0xENTRYPOINT_ADDRESS",
       chain: polygonMumbai,
     });
 

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -34,6 +34,7 @@ import {
   bigIntPercent,
   deepHexlify,
   defineReadOnly,
+  getDefaultEntryPointContract,
   getUserOperationHash,
   isValidRequest,
   resolveProperties,
@@ -466,10 +467,13 @@ export class SmartAccountProvider<
   };
 
   readonly gasEstimator: AccountMiddlewareFn = async (struct) => {
+    const entryPoint =
+      this.account?.entryPointAddress ??
+      (await getDefaultEntryPointContract(this.chain));
     const request = deepHexlify(await resolveProperties(struct));
     const estimates = await this.rpcClient.estimateUserOperationGas(
       request,
-      this.account!.entryPointAddress
+      entryPoint
     );
 
     struct.callGasLimit = estimates.callGasLimit;

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -469,7 +469,7 @@ export class SmartAccountProvider<
   readonly gasEstimator: AccountMiddlewareFn = async (struct) => {
     const entryPoint =
       this.account?.entryPointAddress ??
-      (await getDefaultEntryPointContract(this.chain));
+      (await getDefaultEntryPointContract({ chain: this.chain }));
     const request = deepHexlify(await resolveProperties(struct));
     const estimates = await this.rpcClient.estimateUserOperationGas(
       request,

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -68,10 +68,7 @@ const givenConnectedProvider = ({
   owner: Wallet;
   accountAddress?: Address;
 }) =>
-  EthersProviderAdapter.fromEthersProvider(
-    alchemyProvider,
-    ENTRYPOINT_ADDRESS
-  ).connectToAccount(
+  EthersProviderAdapter.fromEthersProvider(alchemyProvider).connectToAccount(
     (rpcClient) =>
       new SimpleSmartContractAccount({
         entryPointAddress: ENTRYPOINT_ADDRESS,

--- a/packages/ethers/src/__tests__/provider-adapter.test.ts
+++ b/packages/ethers/src/__tests__/provider-adapter.test.ts
@@ -34,21 +34,20 @@ const givenConnectedProvider = ({
   alchemyProvider: AlchemyProvider;
   owner: Wallet;
 }) =>
-  EthersProviderAdapter.fromEthersProvider(
-    alchemyProvider,
-    "0xENTRYPOINT_ADDRESS"
-  ).connectToAccount((rpcClient) => {
-    const account = new SimpleSmartContractAccount({
-      entryPointAddress: "0xENTRYPOINT_ADDRESS",
-      chain: getChain(alchemyProvider.network.chainId),
-      owner: convertWalletToAccountSigner(owner),
-      factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
-      rpcClient,
-    });
+  EthersProviderAdapter.fromEthersProvider(alchemyProvider).connectToAccount(
+    (rpcClient) => {
+      const account = new SimpleSmartContractAccount({
+        entryPointAddress: "0xENTRYPOINT_ADDRESS",
+        chain: getChain(alchemyProvider.network.chainId),
+        owner: convertWalletToAccountSigner(owner),
+        factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
+        rpcClient,
+      });
 
-    account.getAddress = vi.fn(
-      async () => "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"
-    );
+      account.getAddress = vi.fn(
+        async () => "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"
+      );
 
-    return account;
-  });
+      return account;
+    }
+  );

--- a/packages/ethers/src/provider-adapter.ts
+++ b/packages/ethers/src/provider-adapter.ts
@@ -35,7 +35,6 @@ export class EthersProviderAdapter extends JsonRpcProvider {
       const chain = getChain(opts.chainId);
       this.accountProvider = new SmartAccountProvider({
         rpcProvider: opts.rpcProvider,
-        entryPointAddress: opts.entryPointAddress,
         chain,
       });
     }

--- a/packages/ethers/src/provider-adapter.ts
+++ b/packages/ethers/src/provider-adapter.ts
@@ -2,7 +2,6 @@ import {
   SmartAccountProvider,
   getChain,
   type AccountMiddlewareFn,
-  type Address,
   type FeeDataMiddleware,
   type GasEstimatorMiddleware,
   type HttpTransport,
@@ -17,7 +16,6 @@ import { AccountSigner } from "./account-signer.js";
 export type EthersProviderAdapterOpts =
   | {
       rpcProvider: string | PublicErc4337Client<HttpTransport>;
-      entryPointAddress: Address;
       chainId: number;
     }
   | {
@@ -101,16 +99,11 @@ export class EthersProviderAdapter extends JsonRpcProvider {
    * Creates an instance of EthersProviderAdapter from an ethers.js JsonRpcProvider.
    *
    * @param provider - the ethers JSON RPC provider to convert
-   * @param entryPointAddress - the entrypoint address that will be used for UserOperations
    * @returns an instance of {@link EthersProviderAdapter}
    */
-  static fromEthersProvider(
-    provider: JsonRpcProvider,
-    entryPointAddress: Address
-  ): EthersProviderAdapter {
+  static fromEthersProvider(provider: JsonRpcProvider): EthersProviderAdapter {
     return new EthersProviderAdapter({
       rpcProvider: provider.connection.url,
-      entryPointAddress,
       chainId: provider.network.chainId,
     });
   }

--- a/site/packages/aa-alchemy/middleware/introduction.md
+++ b/site/packages/aa-alchemy/middleware/introduction.md
@@ -45,7 +45,6 @@ const providerWithGasManager = withAlchemyGasManager(
   provider,
   {
     policyId: PAYMASTER_POLICY_ID,
-    entryPoint: ENTRYPOINT_ADDRESS,
   },
   true // if true, uses `alchemy_requestGasAndPaymasterAndData`, otherwise uses `alchemy_requestPaymasterAndData`
 );

--- a/site/packages/aa-alchemy/middleware/withAlchemyGasManager.md
+++ b/site/packages/aa-alchemy/middleware/withAlchemyGasManager.md
@@ -29,7 +29,6 @@ const providerWithGasManager = withAlchemyGasManager(
   provider,
   {
     policyId: PAYMASTER_POLICY_ID,
-    entryPoint: ENTRYPOINT_ADDRESS,
   },
   true // If true, uses `alchemy_requestGasAndPaymasterAndData`, otherwise uses `alchemy_requestPaymasterAndData`
 );
@@ -51,6 +50,5 @@ A new instance of an `AlchemyProvider` with the same attributes as the input, no
 ### `AlchemyGasManagerConfig: AlchemyGasManagerConfig`
 
 - `policyId: string` -- the Alchemy Gas Manager policy ID
-- `entryPoint: Address` -- the entrypoint contract address
 
 ### `estimateGas: boolean` -- a flag to additionally estimate gas as part of

--- a/site/packages/aa-alchemy/provider/introduction.md
+++ b/site/packages/aa-alchemy/provider/introduction.md
@@ -39,7 +39,6 @@ const uoHash = await provider.sendUserOperation(uoStruct);
 // use Alchemy Gas Manager to sponsorship transactions
 const providerWithGasManager = provider.withAlchemyGasManager({
   policyId: PAYMASTER_POLICY_ID,
-  entryPoint: ENTRYPOINT_ADDRESS,
 });
 ```
 

--- a/site/packages/aa-alchemy/provider/withAlchemyGasManager.md
+++ b/site/packages/aa-alchemy/provider/withAlchemyGasManager.md
@@ -27,7 +27,6 @@ import { provider } from "./provider";
 // use Alchemy Gas Manager to sponsorship transactions
 const providerWithGasManager = provider.withAlchemyGasManager({
   policyId: PAYMASTER_POLICY_ID,
-  entryPoint: ENTRYPOINT_ADDRESS,
 });
 ```
 
@@ -45,4 +44,3 @@ A new instance of an `AlchemyProvider` with the same attributes as the input, no
 ### `config: AlchemyGasManagerConfig`
 
 - `policyId: string` -- the Alchemy Gas Manager policy ID
-- `entryPoint: Address` -- the entrypoint contract address for the chain the provider is used for

--- a/site/packages/aa-ethers/account-signer/connect.md
+++ b/site/packages/aa-ethers/account-signer/connect.md
@@ -29,10 +29,7 @@ const alchemy = new Alchemy({
   network: Network.SEPOLIA, // new chain -> new provider
 });
 const ethersProvider = await alchemy.config.getProvider();
-const newProvider = EthersProviderAdapter.fromEthersProvider(
-  ethersProvider,
-  entryPointAddress
-);
+const newProvider = EthersProviderAdapter.fromEthersProvider(ethersProvider);
 
 // connecting the signer
 const newSigner = signer.connect(newProvider);

--- a/site/packages/aa-ethers/provider-adapter/fromEthersProvider.md
+++ b/site/packages/aa-ethers/provider-adapter/fromEthersProvider.md
@@ -34,7 +34,3 @@ An instance of `EthersProviderAdapter`
 ### `provider: JsonRpcProvider`
 
 The ethers JSON RPC provider to convert
-
-### `entryPointAddress: Address`
-
-The entrypoint address that will be used for UserOperations

--- a/site/smart-accounts/signers/capsule.md
+++ b/site/smart-accounts/signers/capsule.md
@@ -78,7 +78,6 @@ const factoryAddress = await getDefaultLightAccountFactory(chain)
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/signers/dynamic.md
+++ b/site/smart-accounts/signers/dynamic.md
@@ -89,7 +89,6 @@ const factoryAddress = await getDefaultLightAccountFactory(chain);
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/signers/fireblocks.md
+++ b/site/smart-accounts/signers/fireblocks.md
@@ -57,7 +57,6 @@ const chain = sepolia;
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/signers/lit.md
+++ b/site/smart-accounts/signers/lit.md
@@ -78,7 +78,6 @@ const chain = sepolia;
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/signers/magic.md
+++ b/site/smart-accounts/signers/magic.md
@@ -59,7 +59,6 @@ const factoryAddress = await getDefaultLightAccountFactory(chain);
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/signers/portal.md
+++ b/site/smart-accounts/signers/portal.md
@@ -57,7 +57,6 @@ const chain = polygonMumbai;
 const provider = new AlchemyProvider({
   apiKey: process.env.ALCHEMY_API_KEY,
   chain,
-  entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS,
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/signers/turnkey.md
+++ b/site/smart-accounts/signers/turnkey.md
@@ -67,7 +67,6 @@ async function main() {
   const provider = new AlchemyProvider({
     apiKey: "ALCHEMY_API_KEY",
     chain,
-    entryPointAddress: "0x...",
   }).connect(
     (rpcClient) =>
       new LightSmartContractAccount({

--- a/site/smart-accounts/signers/web3auth.md
+++ b/site/smart-accounts/signers/web3auth.md
@@ -59,7 +59,6 @@ const factoryAddress = await getDefaultLightAccountFactory(chain);
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/smart-accounts/sponsoring-gas.md
+++ b/site/smart-accounts/sponsoring-gas.md
@@ -65,7 +65,6 @@ const GAS_MANAGER_POLICY_ID = "YourGasManagerPolicyId";
 // sent with this provider get sponsorship from the Gas Manager.
 provider.withAlchemyGasManager({
   policyId: GAS_MANAGER_POLICY_ID,
-  entryPoint: entryPointAddress,
 });
 
 // Here's how to send a sponsored user operation from your smart account:
@@ -99,7 +98,6 @@ const GAS_MANAGER_POLICY_ID = "YourGasManagerPolicyId";
 // sent with this provider get sponsorship from the Gas Manager.
 provider.withAlchemyGasManager({
   policyId: GAS_MANAGER_POLICY_ID,
-  entryPoint: entryPointAddress,
 });
 
 // Send a sponsored user operation from your smart account like this: // [!code focus:6]

--- a/site/snippets/account-alchemy.ts
+++ b/site/snippets/account-alchemy.ts
@@ -21,7 +21,6 @@ const owner: SmartAccountSigner =
 let provider = new AlchemyProvider({
   apiKey: API_KEY,
   chain,
-  entryPointAddress: ENTRYPOINT_ADDRESS,
 }).connect(
   (rpcClient) =>
     new SimpleSmartContractAccount({

--- a/site/snippets/account-alchemy.ts
+++ b/site/snippets/account-alchemy.ts
@@ -35,7 +35,6 @@ let provider = new AlchemyProvider({
 // [OPTIONAL] Use Alchemy Gas Manager
 provider.withAlchemyGasManager({
   policyId: PAYMASTER_POLICY_ID,
-  entryPoint: ENTRYPOINT_ADDRESS,
 });
 
 // 3. send a UserOperation

--- a/site/snippets/account-core.ts
+++ b/site/snippets/account-core.ts
@@ -22,7 +22,6 @@ const provider = new SmartAccountProvider({
   // the demo key below is public and rate-limited, it's better to create a new one
   // you can get started with a free account @ https://www.alchemy.com/
   rpcProvider: "https://polygon-mumbai.g.alchemy.com/v2/demo",
-  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
   chain: polygonMumbai,
 }).connect(
   (rpcClient) =>

--- a/site/snippets/account-ethers.ts
+++ b/site/snippets/account-ethers.ts
@@ -22,8 +22,7 @@ const owner = Wallet.fromMnemonic(MNEMONIC);
 // 2. Create the SimpleAccount signer
 // signer is an ethers.js Signer
 const signer = EthersProviderAdapter.fromEthersProvider(
-  alchemyProvider,
-  ENTRYPOINT_ADDRESS
+  alchemyProvider
 ).connectToAccount(
   (rpcClient) =>
     new SimpleSmartContractAccount({

--- a/site/snippets/core-provider.ts
+++ b/site/snippets/core-provider.ts
@@ -16,7 +16,6 @@ const factoryAddress = await getDefaultLightAccountFactory(polygonMumbai);
 
 export const provider = new SmartAccountProvider({
   rpcProvider: "https://polygon-mumbai.g.alchemy.com/v2/demo",
-  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
   chain: polygonMumbai,
 }).connect(
   (rpcClient) =>

--- a/site/snippets/ethers-provider.ts
+++ b/site/snippets/ethers-provider.ts
@@ -1,15 +1,11 @@
 import { EthersProviderAdapter } from "@alchemy/aa-ethers";
 import { Alchemy, Network } from "alchemy-sdk";
 
-export const entryPointAddress = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
-
 const alchemy = new Alchemy({
   apiKey: process.env.API_KEY!,
   network: Network.MATIC_MUMBAI,
 });
 const ethersProvider = await alchemy.config.getProvider();
 
-export const provider = EthersProviderAdapter.fromEthersProvider(
-  ethersProvider,
-  entryPointAddress
-);
+export const provider =
+  EthersProviderAdapter.fromEthersProvider(ethersProvider);

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -20,11 +20,10 @@ const factoryAddress = await getDefaultLightAccountFactory(chain);
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY", // Replace with your Alchemy API key, you can get one at https://dashboard.alchemy.com/
   chain,
-  // Entrypoint address, you can use a different entrypoint if needed, check out https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints
-  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
+      // Entrypoint address, you can use a different entrypoint if needed, check out https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints
       entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
       chain: rpcClient.chain,
       owner: eoaSigner,

--- a/site/snippets/privy.ts
+++ b/site/snippets/privy.ts
@@ -41,7 +41,6 @@ const privySigner: SmartAccountSigner = new WalletClientSigner(
 export const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain: sepolia,
-  entryPointAddress: "0x...",
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/site/snippets/provider.ts
+++ b/site/snippets/provider.ts
@@ -16,7 +16,6 @@ const factoryAddress = await getDefaultLightAccountFactory(chain);
 export const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY", // replace with your alchemy api key of the Alchemy app associated with the Gas Manager, get yours at https://dashboard.alchemy.com/
   chain,
-  entryPointAddress: entryPointAddress,
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,31 +12,6 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.4.tgz#aae21cb858bbb0411949d5b7b3051f4209043f62"
   integrity sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==
 
-"@alchemy/aa-accounts@latest":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@alchemy/aa-accounts/-/aa-accounts-0.1.1.tgz#7527e25fe2825eb91d80f6e4cb85d188606587a4"
-  integrity sha512-nHHnJuIHXGdvH5i+7DlTeSPa3RJtNLt4NpJP+G+T8G3QP/k6mxHNWFTybOhqxuCC798DACxKc4thOL2Lj8phgA==
-  dependencies:
-    "@alchemy/aa-core" "^0.1.1"
-    viem "^1.16.2"
-
-"@alchemy/aa-alchemy@latest":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@alchemy/aa-alchemy/-/aa-alchemy-0.1.1.tgz#f7f989b2aaae127a49a61e1dde6d6f52d40d0018"
-  integrity sha512-rVQZNb1QmfQoxDyaXuinB0pfrKENLydwH57TWXJn4wFW+3c+iM6xM/tsfx6zxzA7HTwodcRw8//wMvdF+5KQmg==
-  dependencies:
-    "@alchemy/aa-core" "^0.1.1"
-    viem "^1.16.2"
-
-"@alchemy/aa-core@latest":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@alchemy/aa-core/-/aa-core-0.1.1.tgz#2c81e34c0ca939897004c68d80250f1b4b423ff2"
-  integrity sha512-vEfCx9MJMTCMpmB3cY+TcM65znP8zcMTaiYE7By3+krhd7ViflWdEILe5HGGzCALGqdr6pUaBI7n08eVoyo6KQ==
-  dependencies:
-    abitype "^0.8.3"
-    eventemitter3 "^5.0.1"
-    viem "^1.16.2"
-
 "@algolia/autocomplete-core@1.9.3":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"


### PR DESCRIPTION
[app.asana.com/0/1205598840815267/1205773893380310/f](https://app.asana.com/0/1205598840815267/1205773893380310/f)

Part of the task linked above, removed entrypoint contract address param from SmartAccountProvider constructor params/class fields and instead, made entry point contract of the linked SCA account to be the source of entry point contract address.

In case the entry point contract address is needed prior to account being connected, entry point contract address defaults to the default entry point contract address from the getDefaultEntryPointContract helper.

This PR is stacked on https://github.com/alchemyplatform/aa-sdk/pull/177, and follow up PRs will made to make entry point contract address param for SmartContractAccount class as optional (in case user wants to use their own for some reason).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the `entryPointAddress` parameter with a constant value in multiple files. 

### Detailed summary
- Replaced `entryPointAddress` parameter with a constant value in multiple files.

> The following files were skipped due to too many changes: `packages/alchemy/e2e-tests/simple-account.test.ts`, `packages/ethers/src/__tests__/provider-adapter.test.ts`, `packages/alchemy/src/provider.ts`, `yarn.lock`, `examples/alchemy-daapp/src/surfaces/onboarding/OnboardingDataModels.tsx`, `packages/ethers/src/provider-adapter.ts`, `packages/core/src/utils/index.ts`, `packages/alchemy/src/middleware/gas-manager.ts`, `packages/core/src/provider/base.ts`, `examples/aa-simple-dapp/src/hooks/useAlchemyProvider.ts`, `examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->