### PR TITLE
feat: add sanity check on provider connect for clearer error message

### DIFF
--- a/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
+++ b/examples/alchemy-daapp/src/surfaces/onboarding/OnboardingController.ts
@@ -1,9 +1,9 @@
 import { LightSmartContractAccount, getDefaultLightAccountFactoryAddress } from "@alchemy/aa-accounts";
 import { AlchemyProvider, withAlchemyGasManager } from "@alchemy/aa-alchemy";
 import {
-    createPublicErc4337Client,
-    getDefaultEntryPointAddress,
-    type SmartAccountSigner
+  createPublicErc4337Client,
+  getDefaultEntryPointAddress,
+  type SmartAccountSigner
 } from "@alchemy/aa-core";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { encodeFunctionData } from "viem";
@@ -11,16 +11,16 @@ import { useAccount, useNetwork, type Chain } from "wagmi";
 import { localSmartContractStore } from "~/clients/localStorage";
 import { NFTContractABI } from "../../clients/nftContract";
 import {
-    DAAppConfiguration,
-    daappConfigurations,
+  DAAppConfiguration,
+  daappConfigurations,
 } from "../../configs/clientConfigs";
 import {
-    MIN_ONBOARDING_WALLET_BALANCE,
-    OnboardingContext,
-    OnboardingStep,
-    OnboardingStepIdentifier,
-    initialStep,
-    metaForStepIdentifier,
+  MIN_ONBOARDING_WALLET_BALANCE,
+  OnboardingContext,
+  OnboardingStep,
+  OnboardingStepIdentifier,
+  initialStep,
+  metaForStepIdentifier,
 } from "./OnboardingDataModels";
 
 async function pollForLambdaForComplete(

--- a/packages/alchemy/src/middleware/gas-manager.ts
+++ b/packages/alchemy/src/middleware/gas-manager.ts
@@ -87,7 +87,7 @@ const withAlchemyPaymasterAndDataMiddleware = (
       params: [
         {
           policyId: config.policyId,
-          entryPoint: provider.entryPointAddress,
+          entryPoint: provider.getEntryPointAddress(),
           userOperation: deepHexlify(await resolveProperties(struct)),
         },
       ],
@@ -127,7 +127,7 @@ const withAlchemyGasAndPaymasterAndDataMiddleware = (
       params: [
         {
           policyId: config.policyId,
-          entryPoint: provider.entryPointAddress,
+          entryPoint: provider.getEntryPointAddress(),
           userOperation: userOperation,
           dummySignature: userOperation.signature,
           feeOverride: feeOverride,

--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -121,7 +121,7 @@ export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
     const request = deepHexlify(await resolveProperties(struct));
     const estimates = await this.rpcClient.estimateUserOperationGas(
       request,
-      this.entryPointAddress
+      this.getEntryPointAddress()
     );
     estimates.preVerificationGas =
       (BigInt(estimates.preVerificationGas) * (100n + this.pvgBuffer)) / 100n;

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -305,6 +305,10 @@ export abstract class BaseSmartContractAccount<
     return this.factoryAddress;
   }
 
+  getEntryPointAddress(): Address {
+    return this.entryPointAddress;
+  }
+
   // Extra implementations
   async isAccountDeployed(): Promise<boolean> {
     return (await this.getDeploymentState()) === DeploymentState.DEPLOYED;

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -89,4 +89,9 @@ export interface ISmartContractAccount {
    * @returns the address of the factory contract for the smart contract account
    */
   getFactoryAddress(): Address;
+
+  /**
+   * @returns the address of the entry point contract for the smart contract account
+   */
+  getEntryPointAddress(): Address;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,7 @@ export {
   defineReadOnly,
   getChain,
   getDefaultEntryPointAddress,
-  getDefaultSimpleAccountFactoryAddressAddress,
+  getDefaultSimpleAccountFactoryAddress,
   getUserOperationHash,
   resolveProperties,
 } from "./utils/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,7 @@ export {
   defineReadOnly,
   getChain,
   getDefaultEntryPointAddress,
-  getDefaultSimpleAccountFactoryAddressAddress as getDefaultSimpleAccountFactoryAddress,
+  getDefaultSimpleAccountFactoryAddressAddress,
   getUserOperationHash,
   resolveProperties,
 } from "./utils/index.js";

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -77,6 +77,7 @@ describe("Base Tests", () => {
       rpcClient: providerMock.rpcClient,
       getAddress: async () => "0xMOCK_ADDRESS",
       getFactoryAddress: () => "0xMOCK_FACOTRY_ADDRESS",
+      getEntryPointAddress: () => entryPointAddress,
       getOwner: () => undefined,
     } as any;
 
@@ -100,6 +101,20 @@ describe("Base Tests", () => {
         ],
       ]
     `);
+  });
+
+  it("should throw error if connected account has different entry point address than the provider", async () => {
+    const account = {
+      chain: polygonMumbai,
+      entryPointAddress: "0xOTHER_ENTRY_POINT_ADDRESS",
+      rpcClient: providerMock.rpcClient,
+      getAddress: async () => "0xMOCK_ADDRESS",
+      getFactoryAddress: () => "0xMOCK_FACOTRY_ADDRESS",
+      getEntryPointAddress: () => "0xOTHER_ENTRY_POINT_ADDRESS",
+      getOwner: () => undefined,
+    } as any;
+
+    expect(() => providerMock.connect(() => account)).toThrow();
   });
 
   it("should emit disconnected event on disconnect", async () => {

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -127,7 +127,11 @@ describe("Base Tests", () => {
       chain,
     });
 
-    expect(() => providerMockWithEntryPoint.connect(() => account)).toThrow();
+    expect(() =>
+      providerMockWithEntryPoint.connect(() => account)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Account entryPoint address: ${entryPointAddress} does not match the current provider's entryPoint address: ${dummyEntryPointAddress}"`
+    );
   });
 
   it("should emit disconnected event on disconnect", async () => {

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -34,7 +34,7 @@ describe("Base Tests", () => {
   const owner: SmartAccountSigner =
     LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
 
-  const dummAccountAddress =
+  const dummyAccountAddress =
     "0x1234567890123456789012345678901234567890" as Address;
 
   const account = new SimpleSmartContractAccount({

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -110,7 +110,7 @@ describe("Base Tests", () => {
         [
           "accountsChanged",
           [
-            "${dummAccountAddress}",
+            "${dummyAccountAddress}",
           ],
         ],
       ]

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -43,7 +43,7 @@ describe("Base Tests", () => {
     owner,
     factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
     rpcClient: providerMock.rpcClient,
-    accountAddress: dummAccountAddress,
+    accountAddress: dummyAccountAddress,
   });
 
   beforeEach(() => {

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -537,7 +537,7 @@ export class SmartAccountProvider<
   ): this & { account: TAccount } => {
     const account = fn(this.rpcClient);
 
-    // sanity check. Note that this check is only performed iff the optional entryPointAddress is given upon initialization.
+    // sanity check. Note that this check is only performed if and only if the optional entryPointAddress is given upon initialization.
     if (
       this.entryPointAddress &&
       account.getEntryPointAddress() !== this.entryPointAddress

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -537,6 +537,16 @@ export class SmartAccountProvider<
     ) => TAccount
   ): this & { account: TAccount } => {
     const account = fn(this.rpcClient);
+
+    // sanity check
+    if (account.getEntryPointAddress() !== this.entryPointAddress) {
+      throw new Error(
+        `Account entryPoint address: ${account.getEntryPointAddress()} does not match the current provider's entryPoint address: ${
+          this.entryPointAddress
+        }`
+      );
+    }
+
     defineReadOnly(this, "account", account);
 
     if (this.rpcClient.transport.type === "http") {

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -606,8 +606,8 @@ export class SmartAccountProvider<
    */
   getEntryPointAddress = (): Address => {
     return (
-      this.account?.getEntryPointAddress() ??
       this.entryPointAddress ??
+      this.account?.getEntryPointAddress() ??
       getDefaultEntryPointAddress(this.chain)
     );
   };

--- a/packages/core/src/provider/schema.ts
+++ b/packages/core/src/provider/schema.ts
@@ -65,7 +65,9 @@ export const SmartAccountProviderConfigSchema = <
 
     /**
      * Optional entry point contract address for override if needed.
-     * If not provided, the default entry point contract for the chain will be used.
+     * If not provided, the entry point contract address for the provider is the connected account's entry point contract,
+     * or if not connected, falls back to the default entry point contract for the chain.
+     *
      * Refer to https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints
      * when using Alchemy as your RPC provider.
      */

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -103,7 +103,6 @@ export interface ISmartAccountProvider<
   readonly customMiddleware?: AccountMiddlewareFn;
 
   readonly account?: ISmartContractAccount;
-  readonly entryPointAddress: Address;
 
   /**
    * Sends a user operation using the connected account.

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -47,7 +47,7 @@ export const getDefaultEntryPointAddress = (chain: Chain): Address => {
  * @returns a {@link abi.Address} for the given chain
  * @throws if the chain doesn't have an address currently deployed
  */
-export const getDefaultSimpleAccountFactoryAddressAddress = (
+export const getDefaultSimpleAccountFactoryAddress = (
   chain: Chain
 ): Address => {
   switch (chain.id) {

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -269,12 +269,24 @@ export default defineConfig({
                     link: "/getNonce",
                   },
                   {
+                    text: "getOwner",
+                    link: "/getOwner",
+                  },
+                  {
                     text: "getDeploymentState",
                     link: "/getDeploymentState",
                   },
                   {
                     text: "isAccountDeployed",
                     link: "/isAccountDeployed",
+                  },
+                  {
+                    text: "getFactoryAddress",
+                    link: "/getFactoryAddress",
+                  },
+                  {
+                    text: "getEntryPointAddress",
+                    link: "/getEntryPointAddress",
                   },
                 ],
               },

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -170,6 +170,10 @@ export default defineConfig({
                 link: "/getAddress",
               },
               {
+                text: "getEntryPointAddress",
+                link: "/getEntryPointAddress",
+              },
+              {
                 text: "isConnected",
                 link: "/isConnected",
               },

--- a/site/packages/aa-core/accounts/other/getAddress.md
+++ b/site/packages/aa-core/accounts/other/getAddress.md
@@ -23,7 +23,7 @@ Returns the address of the account.
 ```ts [example.ts]
 import { provider } from "./provider";
 // [!code focus:99]
-const address = await provider.getAddress();
+const address = await provider.account.getAddress();
 ```
 
 <<< @/snippets/provider.ts

--- a/site/packages/aa-core/accounts/other/getEntryPointAddress.md
+++ b/site/packages/aa-core/accounts/other/getEntryPointAddress.md
@@ -1,0 +1,37 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: getEntryPointAddress
+  - - meta
+    - name: description
+      content: Overview of the getEntryPointAddress method on BaseSmartContractAccount
+  - - meta
+    - property: og:description
+      content: Overview of the getEntryPointAddress method on BaseSmartContractAccount
+---
+
+# getEntryPointAddress
+
+Returns the EntryPoint contract address for the account.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { provider } from "./provider";
+// [!code focus:99]
+const entryPointAddress = await provider.getEntryPointAddress();
+```
+
+<<< @/snippets/provider.ts
+
+:::
+
+## Returns
+
+### `Address`
+
+The address of the EntryPoint contract

--- a/site/packages/aa-core/accounts/other/getEntryPointAddress.md
+++ b/site/packages/aa-core/accounts/other/getEntryPointAddress.md
@@ -16,6 +16,8 @@ head:
 
 Returns the EntryPoint contract address for the account.
 
+Refer to https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints when using Alchemy as your RPC provider.
+
 ## Usage
 
 ::: code-group
@@ -23,7 +25,7 @@ Returns the EntryPoint contract address for the account.
 ```ts [example.ts]
 import { provider } from "./provider";
 // [!code focus:99]
-const entryPointAddress = await provider.getEntryPointAddress();
+const entryPointAddress = await provider.account.getEntryPointAddress();
 ```
 
 <<< @/snippets/provider.ts

--- a/site/packages/aa-core/accounts/other/getFactoryAddress.md
+++ b/site/packages/aa-core/accounts/other/getFactoryAddress.md
@@ -1,0 +1,37 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: getFactoryAddress
+  - - meta
+    - name: description
+      content: Overview of the getFactoryAddress method on BaseSmartContractAccount
+  - - meta
+    - property: og:description
+      content: Overview of the getFactoryAddress method on BaseSmartContractAccount
+---
+
+# getFactoryAddress
+
+Returns the account factory address for the account.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { provider } from "./provider";
+// [!code focus:99]
+const factoryAddress = await provider.getFactoryAddress();
+```
+
+<<< @/snippets/provider.ts
+
+:::
+
+## Returns
+
+### `Address`
+
+The address of the account factory contract

--- a/site/packages/aa-core/accounts/other/getFactoryAddress.md
+++ b/site/packages/aa-core/accounts/other/getFactoryAddress.md
@@ -23,7 +23,7 @@ Returns the account factory address for the account.
 ```ts [example.ts]
 import { provider } from "./provider";
 // [!code focus:99]
-const factoryAddress = await provider.getFactoryAddress();
+const factoryAddress = await provider.account.getFactoryAddress();
 ```
 
 <<< @/snippets/provider.ts

--- a/site/packages/aa-core/accounts/other/getOwner.md
+++ b/site/packages/aa-core/accounts/other/getOwner.md
@@ -1,0 +1,37 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: getOwner
+  - - meta
+    - name: description
+      content: Overview of the getOwner method on BaseSmartContractAccount
+  - - meta
+    - property: og:description
+      content: Overview of the getOwner method on BaseSmartContractAccount
+---
+
+# getOwner
+
+Returns the `SmartAccountSigner` that represents the current owner for the account.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { provider } from "./provider";
+// [!code focus:99]
+const ownerSigner = await provider.getOwner();
+```
+
+<<< @/snippets/provider.ts
+
+:::
+
+## Returns
+
+### `SmartAccountSigner | undefined`
+
+The `SmartAccountSigner` object that represents the current owner for the account

--- a/site/packages/aa-core/accounts/other/getOwner.md
+++ b/site/packages/aa-core/accounts/other/getOwner.md
@@ -23,7 +23,7 @@ Returns the `SmartAccountSigner` that represents the current owner for the accou
 ```ts [example.ts]
 import { provider } from "./provider";
 // [!code focus:99]
-const ownerSigner = await provider.getOwner();
+const ownerSigner = await provider.account.getOwner();
 ```
 
 <<< @/snippets/provider.ts

--- a/site/packages/aa-core/provider/getEntryPointAddress.md
+++ b/site/packages/aa-core/provider/getEntryPointAddress.md
@@ -1,0 +1,43 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: getEntryPointAddress
+  - - meta
+    - name: description
+      content: Overview of the getEntryPointAddress method on ISmartAccountProvider
+  - - meta
+    - property: og:description
+      content: Overview of the getEntryPointAddress method on ISmartAccountProvider
+---
+
+# getEntryPointAddress
+
+Returns the EntryPoint contract address being used for the provider.
+
+If the provider is connected with a `SmartContractAccount`, the EntryPoint contract of the connected account is used for the provider.
+
+If not connected, it fallbacks to the default entry point contract for the chain, unless the optional parameter `entryPointAddress` was given during the initialization as an override.
+
+Refer to https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints when using Alchemy as your RPC provider.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { provider } from "./provider";
+// [!code focus:99]
+const entryPointAddress = await provider.getEntryPointAddress();
+```
+
+<<< @/snippets/provider.ts
+
+:::
+
+## Returns
+
+### `Address`
+
+The address of the EntryPoint contract


### PR DESCRIPTION
[app.asana.com/0/1205598840815267/1205773893380310/f](https://app.asana.com/0/1205598840815267/1205773893380310/f)

Per the task linked above, added a sanity check early on on the current `connect()` so that users can get clear error message about the issue.

Follow up PR will made to make entry point contract address param as optional for SmartContractAccount

Also, updated the doc for the missing/added `Other` methods for SCA class.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
This PR introduces the `getEntryPointAddress` method to the `ISmartContractAccount` interface and the `BaseSmartContractAccount` class. It also adds implementations and documentation for the method in various files. Additionally, it updates the `SmartAccountProvider` class to use the connected account's entry point address or the default entry point address for the chain.

> The following files were skipped due to too many changes: `packages/core/src/provider/__tests__/base.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->