### PR TITLE
feat: entry point address as optional to SmartContractAccount

### DIFF
--- a/packages/accounts/src/kernel-zerodev/README.md
+++ b/packages/accounts/src/kernel-zerodev/README.md
@@ -50,7 +50,6 @@ const provider = new KernelAccountProvider(
     new KernelSmartContractAccount({
       owner,
       index: 0n,
-      entryPointAddress,
       chain,
       factoryAddress: KERNEL_ACCOUNT_FACTORY_ADDRESS,
       rpcClient,

--- a/packages/accounts/src/kernel-zerodev/__tests__/account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/account.test.ts
@@ -1,7 +1,4 @@
-import {
-  LocalAccountSigner,
-  getDefaultEntryPointAddress,
-} from "@alchemy/aa-core";
+import { LocalAccountSigner } from "@alchemy/aa-core";
 import { type Address, type Hex } from "viem";
 import { generatePrivateKey } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
@@ -14,8 +11,6 @@ import { KernelBaseValidator, ValidatorMode } from "../validator/base.js";
 import { MockSigner } from "./mocks/mock-signer.js";
 
 describe("Kernel Account Tests", () => {
-  const entryPointAddress = getDefaultEntryPointAddress(polygonMumbai);
-
   //any wallet should work
   const config = {
     privateKey: generatePrivateKey(),
@@ -25,7 +20,6 @@ describe("Kernel Account Tests", () => {
     validatorAddress: "0x180D6465F921C7E0DEA0040107D342c87455fFF5" as Address,
     accountFactoryAddress:
       "0x5D006d3880645ec6e254E18C1F879DAC9Dd71A39" as Address,
-    entryPointAddress,
   };
 
   const owner = LocalAccountSigner.privateKeyToAccountSigner(config.privateKey);
@@ -51,7 +45,6 @@ describe("Kernel Account Tests", () => {
   function account(index: bigint, owner = mockOwner) {
     const accountParams: KernelSmartAccountParams = {
       rpcClient: provider.rpcClient,
-      entryPointAddress: config.entryPointAddress,
       chain: config.chain,
       owner: owner,
       factoryAddress: config.accountFactoryAddress,

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
@@ -75,7 +75,6 @@ describe("Kernel Account Tests", () => {
   function account(index: bigint, owner = mockOwner) {
     const accountParams: KernelSmartAccountParams = {
       rpcClient: provider.rpcClient,
-      entryPointAddress: config.entryPointAddress,
       chain: config.chain,
       owner: owner,
       factoryAddress: config.accountFactoryAddress,

--- a/packages/accounts/src/light-account/__tests__/account.test.ts
+++ b/packages/accounts/src/light-account/__tests__/account.test.ts
@@ -8,6 +8,7 @@ import {
 import { polygonMumbai, type Chain } from "viem/chains";
 import { describe, it } from "vitest";
 import { LightSmartContractAccount } from "../account.js";
+import { getDefaultLightAccountFactoryAddress } from "../utils.js";
 
 describe("Light Account Tests", () => {
   const dummyMnemonic =
@@ -91,7 +92,7 @@ const givenConnectedProvider = ({
       entryPointAddress: dummyEntryPointAddress,
       chain,
       owner,
-      factoryAddress: "0xLIGHT_ACCOUNT_FACTORY_ADDRESS",
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient: provider,
     });
 

--- a/packages/accounts/src/light-account/e2e-tests/light-account.test.ts
+++ b/packages/accounts/src/light-account/e2e-tests/light-account.test.ts
@@ -1,7 +1,6 @@
 import {
   LocalAccountSigner,
   SmartAccountProvider,
-  getDefaultEntryPointAddress,
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
 import { isAddress, type Address, type Chain, type Hash } from "viem";
@@ -17,8 +16,6 @@ import {
 } from "./constants.js";
 
 const chain = sepolia;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
 describe("Light Account Tests", () => {
   const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
@@ -194,10 +191,9 @@ const givenConnectedProvider = ({
   }).connect(
     (provider) =>
       new LightSmartContractAccount({
-        entryPointAddress,
         chain,
         owner,
-        factoryAddress,
+        factoryAddress: getDefaultLightAccountFactoryAddress(chain),
         rpcClient: provider,
         accountAddress,
       })

--- a/packages/accounts/src/light-account/utils.ts
+++ b/packages/accounts/src/light-account/utils.ts
@@ -1,4 +1,3 @@
-import { chains } from "@alchemy/aa-core";
 import type { Address, Chain } from "viem";
 import {
   arbitrum,
@@ -15,10 +14,10 @@ import {
 } from "viem/chains";
 
 /**
- * Utility method returning the default light account factory address given a {@link chains.Chain} object
+ * Utility method returning the default light account factory address given a {@link Chain} object
  *
- * @param chain - a {@link chains.Chain} object
- * @returns a {@link abi.Address} for the given chain
+ * @param chain - a {@link Chain} object
+ * @returns a {@link Address} for the given chain
  * @throws if the chain doesn't have an address currently deployed
  */
 export const getDefaultLightAccountFactoryAddress = (chain: Chain): Address => {

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -1,6 +1,5 @@
 import {
   SimpleSmartContractAccount,
-  getDefaultEntryPointAddress,
   getDefaultSimpleAccountFactoryAddress,
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
@@ -11,8 +10,6 @@ import { AlchemyProvider } from "../src/provider.js";
 import { API_KEY, OWNER_MNEMONIC, PAYMASTER_POLICY_ID } from "./constants.js";
 
 const chain = polygonMumbai;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultSimpleAccountFactoryAddress(chain);
 
 describe("Simple Account Tests", () => {
   const ownerAccount = mnemonicToAccount(OWNER_MNEMONIC);
@@ -174,10 +171,9 @@ const givenConnectedProvider = ({
   }).connect(
     (provider) =>
       new SimpleSmartContractAccount({
-        entryPointAddress,
         chain,
         owner,
-        factoryAddress,
+        factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
         rpcClient: provider,
         accountAddress,
       })

--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -87,7 +87,7 @@ const givenConnectedProvider = ({
       entryPointAddress: dummyEntryPointAddress,
       chain,
       owner,
-      factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
+      factoryAddress: AACoreModule.getDefaultSimpleAccountFactoryAddress(chain),
       rpcClient: provider,
     });
 

--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -3,8 +3,7 @@ import { generatePrivateKey } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
 import { SimpleSmartContractAccount } from "../src/account/simple.js";
 import {
-  getDefaultEntryPointAddress,
-  getDefaultSimpleAccountFactoryAddressAddress,
+  getDefaultSimpleAccountFactoryAddress,
   type SmartAccountSigner,
 } from "../src/index.js";
 import { SmartAccountProvider } from "../src/provider/base.js";
@@ -12,8 +11,6 @@ import { LocalAccountSigner } from "../src/signer/local-account.js";
 import { API_KEY, OWNER_MNEMONIC, RPC_URL } from "./constants.js";
 
 const chain = polygonMumbai;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultSimpleAccountFactoryAddressAddress(chain);
 
 describe("Simple Account Tests", () => {
   const owner: SmartAccountSigner =
@@ -77,10 +74,9 @@ const givenConnectedProvider = ({
   }).connect(
     (provider) =>
       new SimpleSmartContractAccount({
-        entryPointAddress,
         chain,
         owner,
-        factoryAddress,
+        factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
         rpcClient: provider,
         accountAddress,
       })

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -1,5 +1,6 @@
 import { polygonMumbai, type Chain } from "viem/chains";
 import { describe, it } from "vitest";
+import { getDefaultSimpleAccountFactoryAddress } from "../../index.js";
 import { SmartAccountProvider } from "../../provider/base.js";
 import { LocalAccountSigner } from "../../signer/local-account.js";
 import { type SmartAccountSigner } from "../../signer/types.js";
@@ -11,6 +12,7 @@ describe("Account Simple Tests", () => {
     "test test test test test test test test test test test test";
   const owner: SmartAccountSigner =
     LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
+
   const chain = polygonMumbai;
 
   it("should correctly sign the message", async () => {
@@ -55,10 +57,9 @@ const givenConnectedProvider = ({
     chain,
   }).connect((provider) => {
     const account = new SimpleSmartContractAccount({
-      entryPointAddress: "0xENTRYPOINT_ADDRESS",
       chain,
       owner,
-      factoryAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
       rpcClient: provider,
     });
 

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -17,8 +17,6 @@ const entryPointAddress = getDefaultEntryPointAddress(chain);
 
 describe("Base Tests", () => {
   let retryMsDelays: number[] = [];
-  let dummyEntryPointAddress =
-    "0x1234567890123456789012345678901234567890" as Address;
 
   const providerMock = new SmartAccountProvider({
     rpcProvider: "ALCHEMY_RPC_URL",

--- a/packages/ethers/e2e-tests/simple-account.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.test.ts
@@ -1,7 +1,6 @@
 import {
   SimpleSmartContractAccount,
   getChain,
-  getDefaultEntryPointAddress,
   getDefaultSimpleAccountFactoryAddress,
   type Address,
 } from "@alchemy/aa-core";
@@ -13,8 +12,6 @@ import { convertWalletToAccountSigner } from "../src/utils.js";
 import { API_KEY, OWNER_MNEMONIC, RPC_URL } from "./constants.js";
 
 const chain = polygonMumbai;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultSimpleAccountFactoryAddress(chain);
 
 describe("Simple Account Tests", async () => {
   const alchemy = new Alchemy({
@@ -74,10 +71,9 @@ const givenConnectedProvider = ({
   EthersProviderAdapter.fromEthersProvider(alchemyProvider).connectToAccount(
     (rpcClient) =>
       new SimpleSmartContractAccount({
-        entryPointAddress,
         chain: getChain(alchemyProvider.network.chainId),
         owner: convertWalletToAccountSigner(owner),
-        factoryAddress,
+        factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
         rpcClient,
         accountAddress,
       })

--- a/packages/ethers/src/__tests__/provider-adapter.test.ts
+++ b/packages/ethers/src/__tests__/provider-adapter.test.ts
@@ -1,4 +1,8 @@
-import { SimpleSmartContractAccount, getChain } from "@alchemy/aa-core";
+import {
+  SimpleSmartContractAccount,
+  getChain,
+  getDefaultSimpleAccountFactoryAddress,
+} from "@alchemy/aa-core";
 import { Wallet } from "@ethersproject/wallet";
 import { Alchemy, Network, type AlchemyProvider } from "alchemy-sdk";
 import { EthersProviderAdapter } from "../../src/provider-adapter.js";
@@ -37,10 +41,11 @@ const givenConnectedProvider = ({
   EthersProviderAdapter.fromEthersProvider(alchemyProvider).connectToAccount(
     (rpcClient) => {
       const account = new SimpleSmartContractAccount({
-        entryPointAddress: "0xENTRYPOINT_ADDRESS",
         chain: getChain(alchemyProvider.network.chainId),
         owner: convertWalletToAccountSigner(owner),
-        factoryAddress: "0xSIMPLE_ACCOUNT_FACTORY_ADDRESS",
+        factoryAddress: getDefaultSimpleAccountFactoryAddress(
+          getChain(alchemyProvider.network.chainId)
+        ),
         rpcClient,
       });
 

--- a/site/packages/aa-ethers/provider-adapter/introduction.md
+++ b/site/packages/aa-ethers/provider-adapter/introduction.md
@@ -29,6 +29,12 @@ Notable differences between `EthersProviderAdapter` and `JsonRpcProvider` are im
 
 ```ts [example.ts]
 import { provider } from "./ethers-provider";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactoryAddress,
+} from "@alchemy/aa-accounts";
+import { LocalAccountSigner, type SmartAccountSigner } from "@alchemy/aa-core";
+import { polygonMumbai } from "viem/chains";
 // [!code focus:99]
 // EIP-1193 compliant requests
 const chainId = await provider.send("eth_chainId", []);
@@ -43,9 +49,8 @@ const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
 const signer = provider.connectToAccount(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: entryPointAddress,
       chain: polygonMumbai,
-      factoryAddress: "0xfactoryAddress",
+      factoryAddress: getDefaultLightAccountFactoryAddress(polygonMumbai),
       rpcClient,
       owner,
     })

--- a/site/smart-accounts/signers/capsule.md
+++ b/site/smart-accounts/signers/capsule.md
@@ -80,18 +80,16 @@ import { sepolia } from "viem/chains";
 import { capsuleSigner } from "./capsule";
 
 const chain = sepolia;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
+
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress,
-      chain: rpcClient.chain,
+      chain,
       owner: capsuleSigner,
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/smart-accounts/signers/dynamic.md
+++ b/site/smart-accounts/signers/dynamic.md
@@ -91,18 +91,16 @@ import { sepolia } from "viem/chains";
 import { dynamicSigner } from "./dynamic";
 
 const chain = sepolia;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
+
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress,
-      chain: rpcClient.chain,
+      chain,
       owner: dynamicSigner,
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/smart-accounts/signers/fireblocks.md
+++ b/site/smart-accounts/signers/fireblocks.md
@@ -55,7 +55,10 @@ Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `a
 
 ```ts [example.ts]
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
-import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactoryAddress,
+} from "@alchemy/aa-accounts";
 import { sepolia } from "viem/chains";
 import { fireblocksSigner } from "./fireblocks";
 
@@ -66,10 +69,9 @@ const provider = new AlchemyProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: "0x...",
       chain: rpcClient.chain,
       owner: fireblocksSigner,
-      factoryAddress: "0x...",
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/smart-accounts/signers/lit.md
+++ b/site/smart-accounts/signers/lit.md
@@ -77,7 +77,10 @@ We can link our `SmartAccountSigner` to a `LightSmartContractAccount` from `aa-a
 
 ```ts [example.ts]
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
-import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactoryAddress,
+} from "@alchemy/aa-accounts";
 import { litSigner } from "./lit";
 
 const chain = sepolia;
@@ -87,10 +90,9 @@ const provider = new AlchemyProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: "0x...",
-      chain: rpcClient.chain,
+      chain,
       owner: litSigner,
-      factoryAddress: "0x...",
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/smart-accounts/signers/magic.md
+++ b/site/smart-accounts/signers/magic.md
@@ -61,8 +61,6 @@ import { sepolia } from "viem/chains";
 import { createMagicSigner } from "./magic";
 
 const chain = sepolia;
-const entryPointAddress = getDefaultEntryPointContract(chain);
-const factoryAddress = getDefaultLightAccountFactory(chain);
 
 // NOTE: the below is async because it depends on creating a magic signer. You can choose to break that up how you want
 // eg. use a useEffect + useState to create the signer and then pass it down to the provider
@@ -75,7 +73,7 @@ const provider = new AlchemyProvider({
       entryPointAddress,
       chain: rpcClient.chain,
       owner: await createMagicSigner(),
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/smart-accounts/signers/portal.md
+++ b/site/smart-accounts/signers/portal.md
@@ -55,7 +55,10 @@ Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `a
 
 ```ts [example.ts]
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
-import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactoryAddress,
+} from "@alchemy/aa-accounts";
 import { polygonMumbai } from "viem/chains";
 import { portalSigner } from "./portalSigner";
 
@@ -66,10 +69,9 @@ const provider = new AlchemyProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: ENTRY_POINT_CONTRACT_ADDRESS,
-      chain: rpcClient.chain,
+      chain,
       owner: portalSigner,
-      factoryAddress: FACTORY_CONTRACT_ADDRESS,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/smart-accounts/signers/turnkey.md
+++ b/site/smart-accounts/signers/turnkey.md
@@ -69,18 +69,16 @@ import { newTurnkeySigner } from "./turnkey";
 async function main() {
   const owner = await newTurnkeySigner();
   const chain = sepolia;
-  const entryPointAddress = getDefaultEntryPointAddress(chain);
-  const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
+
   const provider = new AlchemyProvider({
     apiKey: "ALCHEMY_API_KEY",
     chain,
   }).connect(
     (rpcClient) =>
       new LightSmartContractAccount({
-        entryPointAddress,
-        chain: rpcClient.chain,
+        chain,
         owner,
-        factoryAddress,
+        factoryAddress: getDefaultLightAccountFactoryAddress(chain),
         rpcClient,
       })
   );

--- a/site/smart-accounts/signers/web3auth.md
+++ b/site/smart-accounts/signers/web3auth.md
@@ -61,18 +61,16 @@ import { sepolia } from "viem/chains";
 import { web3authSigner } from "./web3auth";
 
 const chain = sepolia;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
+
 const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY",
   chain,
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress,
-      chain: rpcClient.chain,
+      chain,
       owner: web3authSigner,
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );

--- a/site/snippets/account-core.ts
+++ b/site/snippets/account-core.ts
@@ -4,7 +4,6 @@ import {
   LocalAccountSigner,
   SimpleSmartContractAccount,
   SmartAccountProvider,
-  getDefaultEntryPointAddress,
   getDefaultSimpleAccountFactoryAddress,
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
@@ -17,21 +16,18 @@ const owner: SmartAccountSigner =
   LocalAccountSigner.mnemonicToAccountSigner(MNEMONIC);
 
 const chain = polygonMumbai;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultSimpleAccountFactoryAddress(chain);
 
 // 2. initialize the provider and connect it to the account
 const provider = new SmartAccountProvider({
   // the demo key below is public and rate-limited, it's better to create a new one
   // you can get started with a free account @ https://www.alchemy.com/
   rpcProvider: "https://polygon-mumbai.g.alchemy.com/v2/demo",
-  chain: polygonMumbai,
+  chain,
 }).connect(
   (rpcClient) =>
     new SimpleSmartContractAccount({
-      entryPointAddress,
-      chain: polygonMumbai,
-      factoryAddress,
+      chain,
+      factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
       rpcClient,
       owner,
       // optionally if you already know the account's address

--- a/site/snippets/core-provider.ts
+++ b/site/snippets/core-provider.ts
@@ -6,15 +6,12 @@ import {
   LocalAccountSigner,
   SmartAccountProvider,
   SmartAccountSigner,
-  getDefaultEntryPointAddress,
 } from "@alchemy/aa-core";
 import { polygonMumbai } from "viem/chains";
 
 const chain = polygonMumbai;
 const owner: SmartAccountSigner =
   LocalAccountSigner.mnemonicToAccountSigner(YOUR_OWNER_MNEMONIC);
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
 export const provider = new SmartAccountProvider({
   rpcProvider: "https://polygon-mumbai.g.alchemy.com/v2/demo",
@@ -22,9 +19,8 @@ export const provider = new SmartAccountProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress,
       chain,
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
       owner,
     })

--- a/site/snippets/ethers-signer.ts
+++ b/site/snippets/ethers-signer.ts
@@ -2,11 +2,7 @@ import {
   LightSmartContractAccount,
   getDefaultLightAccountFactoryAddress,
 } from "@alchemy/aa-accounts";
-import {
-  LocalAccountSigner,
-  SmartAccountSigner,
-  getDefaultEntryPointAddress,
-} from "@alchemy/aa-core";
+import { LocalAccountSigner, SmartAccountSigner } from "@alchemy/aa-core";
 import { polygonMumbai } from "viem/chains";
 import { provider } from "./ethers-provider.js";
 
@@ -15,15 +11,12 @@ const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
 );
 
 const chain = polygonMumbai;
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
 export const signer = provider.connectToAccount(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress,
       chain,
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
       owner,
     })

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -4,11 +4,7 @@ import {
   getDefaultLightAccountFactoryAddress,
 } from "@alchemy/aa-accounts";
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
-import {
-  LocalAccountSigner,
-  getDefaultEntryPointAddress,
-  type SmartAccountSigner,
-} from "@alchemy/aa-core";
+import { LocalAccountSigner, type SmartAccountSigner } from "@alchemy/aa-core";
 import { sepolia } from "viem/chains";
 
 const chain = sepolia;
@@ -17,8 +13,6 @@ const PRIVATE_KEY = "0xYourEOAPrivateKey"; // Replace with the private key of yo
 const eoaSigner: SmartAccountSigner =
   LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY); // Create a signer for your EOA
 
-// Entrypoint address. Check out https://docs.alchemy.com/reference/eth-supportedentrypoints for all the supported entrypoints
-const entryPointAddress = getDefaultEntryPointAddress(chain);
 // Default address for Light Account on Sepolia, you can replace it with your own.
 const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
@@ -29,7 +23,6 @@ const provider = new AlchemyProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress,
       chain,
       owner: eoaSigner,
       factoryAddress,

--- a/site/snippets/privy.ts
+++ b/site/snippets/privy.ts
@@ -2,7 +2,10 @@
  * This example assumes your app is wrapped with the `PrivyProvider` and
  * is configured to create embedded wallets for users upon login.
  */
-import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactoryAddress,
+} from "@alchemy/aa-accounts";
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
 import { WalletClientSigner, type SmartAccountSigner } from "@alchemy/aa-core";
 import { useWallets } from "@privy-io/react-auth";
@@ -44,10 +47,9 @@ export const provider = new AlchemyProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: "0x...",
       chain: rpcClient.chain,
       owner: privySigner,
-      factoryAddress: "0x...",
+      factoryAddress: getDefaultLightAccountFactoryAddress(rpcClient.chain),
       rpcClient,
     })
 );

--- a/site/snippets/provider.ts
+++ b/site/snippets/provider.ts
@@ -3,19 +3,13 @@ import {
   getDefaultLightAccountFactoryAddress,
 } from "@alchemy/aa-accounts";
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
-import {
-  LocalAccountSigner,
-  getDefaultEntryPointAddress,
-  type SmartAccountSigner,
-} from "@alchemy/aa-core";
+import { LocalAccountSigner, type SmartAccountSigner } from "@alchemy/aa-core";
 import { sepolia } from "viem/chains";
 
 const chain = sepolia;
 const PRIVATE_KEY = "0xYourEOAPrivateKey";
 const eoaSigner: SmartAccountSigner =
   LocalAccountSigner.privateKeyToAccountSigner(`0x${PRIVATE_KEY}`);
-const entryPointAddress = getDefaultEntryPointAddress(chain);
-const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
 export const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY", // replace with your alchemy api key of the Alchemy app associated with the Gas Manager, get yours at https://dashboard.alchemy.com/
@@ -23,10 +17,9 @@ export const provider = new AlchemyProvider({
 }).connect(
   (rpcClient) =>
     new LightSmartContractAccount({
-      entryPointAddress: entryPointAddress,
-      chain: rpcClient.chain,
+      chain,
       owner: eoaSigner,
-      factoryAddress,
+      factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })
 );


### PR DESCRIPTION
[app.asana.com/0/1205598840815267/1205773893380310/f](https://app.asana.com/0/1205598840815267/1205773893380310/f)

Made to make entry point contract address param for SmartContractAccount class as optional (in case user wants to use their own for some reason).

Also, fixed some .gitignore issues. cc: @moldy530

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the `factoryAddress` parameter in multiple files to use the `getDefaultLightAccountFactoryAddress` function from `@alchemy/aa-accounts` instead of hardcoding the address.
- Updated the `factoryAddress` parameter in multiple files to use the `getDefaultSimpleAccountFactoryAddress` function from `@alchemy/aa-core` instead of hardcoding the address.
- Removed unused imports and variables.

> The following files were skipped due to too many changes: `site/snippets/ethers-signer.ts`, `packages/alchemy/e2e-tests/simple-account.test.ts`, `packages/ethers/e2e-tests/simple-account.test.ts`, `packages/core/src/account/__tests__/simple.test.ts`, `packages/core/e2e-tests/simple-account.test.ts`, `site/snippets/account-core.ts`, `site/snippets/light-account.ts`, `site/snippets/provider.ts`, `packages/accounts/src/kernel-zerodev/__tests__/account.test.ts`, `packages/core/src/account/base.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->