### PR TITLE
docs: fix integration typo

### DIFF
--- a/site/smart-accounts/signers/fireblocks.md
+++ b/site/smart-accounts/signers/fireblocks.md
@@ -20,7 +20,7 @@ Fireblocks' security structure provides a truly secure environment for storing, 
 
 Fireblocks' MPC wallets are EOA accounts, which in any account abstraction enabled wallet is the root of their security & trust model. Using Fireblocks MPC based EOA wallets in combination with the Alchemy Account Kit will give you the best of both worlds; Enterprise grade security for securing your off-chain key material, and the utmost flexibility of your on-chain Smart Accounts
 
-# Integrataion
+# Integration
 
 ### Install the Fireblocks Web3 Provider
 

--- a/site/smart-accounts/signers/web3auth.md
+++ b/site/smart-accounts/signers/web3auth.md
@@ -18,7 +18,7 @@ head:
 
 Combining Web3Auth with Account Kit allows you to get the best of both worlds. You can use Web3Auth to generate a wallet scoped to your application, and then use Account Kit to create Smart Contract Accounts for your users!
 
-# Integrataion
+# Integration
 
 ### Install the SDK
 


### PR DESCRIPTION
## Summary

Typo `integrataion` for `integration` has been fixed in `smart-accounts/signers/fireblocks.md` and `smart-accounts/signers/web3Auth.md`

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed a typo in the word "Integration" in two files: `site/smart-accounts/signers/web3auth.md` and `site/smart-accounts/signers/fireblocks.md`.
- No other notable changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->