### PR TITLE
feat: remove sub-account support for light account

### DIFF
--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -108,7 +108,8 @@ export class LightSmartContractAccount<
       encodeFunctionData({
         abi: LightAccountFactoryAbi,
         functionName: "createAccount",
-        args: [await this.owner.getAddress(), this.index],
+        // light account does not support sub-accounts
+        args: [await this.owner.getAddress(), 0n],
       }),
     ]);
   }

--- a/packages/accounts/src/light-account/utils.ts
+++ b/packages/accounts/src/light-account/utils.ts
@@ -1,4 +1,3 @@
-import { chains } from "@alchemy/aa-core";
 import type { Address, Chain } from "viem";
 import {
   arbitrum,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `args` parameter in the `createAccount` function in `utils.ts` to always use `0n` as the second argument, indicating that the light account does not support sub-accounts.

### Detailed summary
- Updated `args` parameter in `createAccount` function to use `[await this.owner.getAddress(), 0n]` instead of `[await this.owner.getAddress(), this.index]`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->