### PR TITLE
feat(arb-sepolia): add support for arb sepolia

### DIFF
--- a/packages/alchemy/src/chains.ts
+++ b/packages/alchemy/src/chains.ts
@@ -11,6 +11,7 @@ import {
   sepolia,
   base,
   baseGoerli,
+  arbitrumSepolia,
 } from "viem/chains";
 
 export const SupportedChains = new Map<number, Chain>([
@@ -20,6 +21,7 @@ export const SupportedChains = new Map<number, Chain>([
   [sepolia.id, sepolia],
   [goerli.id, goerli],
   [arbitrumGoerli.id, arbitrumGoerli],
+  [arbitrumSepolia.id, arbitrumSepolia],
   [arbitrum.id, arbitrum],
   [optimism.id, optimism],
   [optimismGoerli.id, optimismGoerli],


### PR DESCRIPTION
Add Arb sepolia to supported chains to get ready for rundler support

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the `arbitrumSepolia` chain in the `SupportedChains` map.

### Detailed summary
- Added `arbitrumSepolia` to the `SupportedChains` map.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->