### PR TITLE
feat: add support for overriding the initCode for an account

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/dist/*
 examples/alchemy-daapp/*
+site/.vitepress/cache/**/*

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -40,6 +40,7 @@ export abstract class BaseSmartContractAccount<
   protected factoryAddress: Address;
   protected deploymentState: DeploymentState = DeploymentState.UNDEFINED;
   protected accountAddress?: Address;
+  protected accountInitCode?: Hex;
   protected owner: SmartAccountSigner | undefined;
   protected entryPoint: GetContractReturnType<
     typeof EntryPointAbi,
@@ -51,8 +52,9 @@ export abstract class BaseSmartContractAccount<
     | PublicErc4337Client<TTransport>
     | PublicErc4337Client<HttpTransport>;
 
-  constructor(params: BaseSmartAccountParams<TTransport>) {
-    createBaseSmartAccountParamsSchema<TTransport>().parse(params);
+  constructor(params_: BaseSmartAccountParams<TTransport>) {
+    const params =
+      createBaseSmartAccountParamsSchema<TTransport>().parse(params_);
 
     this.entryPointAddress =
       params.entryPointAddress ?? getDefaultEntryPointAddress(params.chain);
@@ -95,6 +97,7 @@ export abstract class BaseSmartContractAccount<
     this.accountAddress = params.accountAddress;
     this.factoryAddress = params.factoryAddress;
     this.owner = params.owner;
+    this.accountInitCode = params.initCode;
 
     this.entryPoint = getContract({
       address: this.entryPointAddress,
@@ -138,7 +141,7 @@ export abstract class BaseSmartContractAccount<
 
   /**
    * this should return the init code that will be used to create an account if one does not exist.
-   * Usually this is the concatenation of the account's factory address and the abi encoded function data of the account factory's `createAccount` method.
+   * This is the concatenation of the account's factory address and the abi encoded function data of the account factory's `createAccount` method.
    */
   protected abstract getAccountInitCode(): Promise<Hash>;
 
@@ -189,29 +192,6 @@ export abstract class BaseSmartContractAccount<
     return this.create6492Signature(isDeployed, signature);
   }
 
-  private async create6492Signature(
-    isDeployed: boolean,
-    signature: Hash
-  ): Promise<Hash> {
-    if (isDeployed) {
-      return signature;
-    }
-
-    const [factoryAddress, factoryCalldata] =
-      await this.parseFactoryAddressFromAccountInitCode();
-
-    Logger.debug(
-      `[BaseSmartContractAccount](create6492Signature)\
-        factoryAddress: ${factoryAddress}, factoryCalldata: ${factoryCalldata}`
-    );
-
-    return wrapSignatureWith6492({
-      factoryAddress,
-      factoryCalldata,
-      signature,
-    });
-  }
-
   /**
    * Not all contracts support batch execution.
    * If your contract does, this method should encode a list of
@@ -227,6 +207,7 @@ export abstract class BaseSmartContractAccount<
   }
   // #endregion optional-methods
 
+  // Extra implementations
   async getNonce(): Promise<bigint> {
     if (!(await this.isAccountDeployed())) {
       return 0n;
@@ -250,12 +231,12 @@ export abstract class BaseSmartContractAccount<
       this.deploymentState = DeploymentState.NOT_DEPLOYED;
     }
 
-    return this.getAccountInitCode();
+    return this._getAccountInitCode();
   }
 
   async getAddress(): Promise<Address> {
     if (!this.accountAddress) {
-      const initCode = await this.getAccountInitCode();
+      const initCode = await this._getAccountInitCode();
       Logger.debug(
         "[BaseSmartContractAccount](getAddress) initCode: ",
         initCode
@@ -291,7 +272,6 @@ export abstract class BaseSmartContractAccount<
     return this.entryPointAddress;
   }
 
-  // Extra implementations
   async isAccountDeployed(): Promise<boolean> {
     return (await this.getDeploymentState()) === DeploymentState.DEPLOYED;
   }
@@ -316,9 +296,36 @@ export abstract class BaseSmartContractAccount<
   protected async parseFactoryAddressFromAccountInitCode(): Promise<
     [Address, Hex]
   > {
-    const initCode = await this.getAccountInitCode();
+    const initCode = await this._getAccountInitCode();
     const factoryAddress = `0x${initCode.substring(2, 42)}` as Address;
     const factoryCalldata = `0x${initCode.substring(42)}` as Hex;
     return [factoryAddress, factoryCalldata];
+  }
+
+  private async _getAccountInitCode(): Promise<Hash> {
+    return this.accountInitCode ?? this.getAccountInitCode();
+  }
+
+  private async create6492Signature(
+    isDeployed: boolean,
+    signature: Hash
+  ): Promise<Hash> {
+    if (isDeployed) {
+      return signature;
+    }
+
+    const [factoryAddress, factoryCalldata] =
+      await this.parseFactoryAddressFromAccountInitCode();
+
+    Logger.debug(
+      `[BaseSmartContractAccount](create6492Signature)\
+        factoryAddress: ${factoryAddress}, factoryCalldata: ${factoryCalldata}`
+    );
+
+    return wrapSignatureWith6492({
+      factoryAddress,
+      factoryCalldata,
+      signature,
+    });
   }
 }

--- a/packages/core/src/account/schema.ts
+++ b/packages/core/src/account/schema.ts
@@ -1,5 +1,5 @@
 import { Address } from "abitype/zod";
-import type { Transport } from "viem";
+import { isHex, type Transport } from "viem";
 import z from "zod";
 import { createPublicErc4337ClientSchema } from "../client/schema.js";
 import type { SupportedTransports } from "../client/types";
@@ -18,5 +18,12 @@ export const createBaseSmartAccountParamsSchema = <
     owner: SignerSchema.optional(),
     entryPointAddress: Address.optional(),
     chain: ChainSchema,
-    accountAddress: Address.optional(),
+    accountAddress: Address.optional().describe(
+      "Optional override for the account address."
+    ),
+    initCode: z
+      .string()
+      .refine(isHex, "initCode must be a valid hex.")
+      .optional()
+      .describe("Optional override for the account init code."),
   });


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, see guidleines below)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:fix`)
- [x] Is the base branch you're merging into `development` and not `main`?

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added support for optional override of the account address and init code in the `createBaseSmartAccountParamsSchema` function in `packages/core/src/account/schema.ts`.
- Modified the `SimpleSmartContractAccount` constructor in `packages/core/src/account/__tests__/simple.test.ts` to use the account init code override.
- Added the `accountInitCode` property to the `BaseSmartContractAccount` class in `packages/core/src/account/base.ts` to store the account init code.
- Modified the `getAccountInitCode` method in the `BaseSmartContractAccount` class to return the account init code override if available, otherwise call the abstract `getAccountInitCode` method.
- Added the `_getAccountInitCode` and `create6492Signature` methods to the `BaseSmartContractAccount` class to handle the account init code and signature creation logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->