### PR TITLE
docs: add constructor docs for each provider and account type

### DIFF
--- a/packages/alchemy/src/schema.ts
+++ b/packages/alchemy/src/schema.ts
@@ -28,12 +28,12 @@ export const FeeOptsSchema = z.object({
   /** this adds a percent buffer on top of the base fee estimated (default 50%)
    * NOTE: this is only applied if the default fee estimator is used.
    */
-  baseFeeBufferPercent: z.bigint().optional().default(50n),
+  baseFeeBufferPercent: z.bigint().optional(),
   /** this adds a percent buffer on top of the priority fee estimated (default 5%)'
    * * NOTE: this is only applied if the default fee estimator is used.
    */
-  maxPriorityFeeBufferPercent: z.bigint().optional().default(5n),
-  /** this adds a percent buffer on top of the preVerificationGasEstimated
+  maxPriorityFeeBufferPercent: z.bigint().optional(),
+  /** this adds a percent buffer on top of the preVerificationGas estimated
    *
    * Defaults 5% on Arbitrum and Optimism, 0% elsewhere
    *

--- a/packages/core/src/provider/schema.ts
+++ b/packages/core/src/provider/schema.ts
@@ -9,22 +9,22 @@ export const SmartAccountProviderOptsSchema = z.object({
   /**
    * The maximum number of times to try fetching a transaction receipt before giving up (default: 5)
    */
-  txMaxRetries: z.number().optional().default(5),
+  txMaxRetries: z.number().optional(),
 
   /**
    * The interval in milliseconds to wait between retries while waiting for tx receipts (default: 2_000)
    */
-  txRetryIntervalMs: z.number().optional().default(2_000),
+  txRetryIntervalMs: z.number().optional(),
 
   /**
    * The mulitplier on interval length to wait between retries while waiting for tx receipts (default: 1.5)
    */
-  txRetryMulitplier: z.number().optional().default(1.5),
+  txRetryMulitplier: z.number().optional(),
 
   /**
    * used when computing the fees for a user operation (default: 100_000_000n)
    */
-  minPriorityFeePerBid: z.bigint().optional().default(100_000_000n),
+  minPriorityFeePerBid: z.bigint().optional(),
 });
 
 export const createSmartAccountProviderConfigSchema = <

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -146,7 +146,7 @@ export default defineConfig({
                 link: "/introduction",
               },
               {
-                text: "constructor for SmartContractProvider",
+                text: "constructor for SmartAccountProvider",
                 link: "/constructor",
               },
               {

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -146,7 +146,7 @@ export default defineConfig({
                 link: "/introduction",
               },
               {
-                text: "constructor for SimpleSmartContractAccount",
+                text: "constructor for SmartContractProvider",
                 link: "/constructor",
               },
               {

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -146,6 +146,10 @@ export default defineConfig({
                 link: "/introduction",
               },
               {
+                text: "constructor for SimpleSmartContractAccount",
+                link: "/constructor",
+              },
+              {
                 text: "sendUserOperation",
                 link: "/sendUserOperation",
               },
@@ -247,6 +251,10 @@ export default defineConfig({
               {
                 text: "Overview of ISmartContractAccount",
                 link: "/introduction",
+              },
+              {
+                text: "constructor for SimpleSmartContractAccount",
+                link: "/constructor",
               },
               {
                 text: "Required Methods",
@@ -460,6 +468,10 @@ export default defineConfig({
               {
                 text: "Overview of AlchemyProvider",
                 link: "/introduction",
+              },
+              {
+                text: "constructor",
+                link: "/constructor",
               },
               { text: "gasEstimator", link: "/gasEstimator" },
               {

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -470,7 +470,7 @@ export default defineConfig({
                 link: "/introduction",
               },
               {
-                text: "constructor",
+                text: "constructor for AlchemyProvider",
                 link: "/constructor",
               },
               { text: "gasEstimator", link: "/gasEstimator" },
@@ -530,6 +530,10 @@ export default defineConfig({
               {
                 text: "Overview of LightSmartContractAccount",
                 link: "/introduction",
+              },
+              {
+                text: "constructor for LightSmartContractAccount",
+                link: "/constructor",
               },
               {
                 text: "signMessageWith6492",

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -581,6 +581,10 @@ export default defineConfig({
                 link: "/introduction",
               },
               {
+                text: "constructor for EthersProviderAdapter",
+                link: "/constructor",
+              },
+              {
                 text: "send",
                 link: "/send",
               },

--- a/site/packages/aa-accounts/light-account/constructor.md
+++ b/site/packages/aa-accounts/light-account/constructor.md
@@ -14,7 +14,7 @@ head:
 
 # constructor
 
-To initialize an `LightSmartContractAccount`, you must provide a set of parameters detailed below.
+To initialize a `LightSmartContractAccount`, you must provide a set of parameters detailed below.
 
 Note that there is no difference in constructor arguments used for `LightSmartContractAccount` when compared to `SimpleSmartContractAccount`.
 

--- a/site/packages/aa-accounts/light-account/constructor.md
+++ b/site/packages/aa-accounts/light-account/constructor.md
@@ -57,7 +57,7 @@ export const account = new LightSmartContractAccount({
 
 ### `LightSmartContractAccount`
 
-A new instance of an `LightSmartContractAccount`.
+A new instance of a `LightSmartContractAccount`.
 
 ## Parameters
 

--- a/site/packages/aa-accounts/light-account/constructor.md
+++ b/site/packages/aa-accounts/light-account/constructor.md
@@ -1,0 +1,77 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: LightSmartContractAccount • constructor
+  - - meta
+    - name: description
+      content: Overview of the constructor method on LightSmartContractAccount in aa-accounts
+  - - meta
+    - property: og:description
+      content: Overview of the constructor method on LightSmartContractAccount in aa-accounts
+---
+
+# constructor
+
+To initialize an `LightSmartContractAccount`, you must provide a set of parameters detailed below.
+
+Note that there is no difference in constructor arguments used for `LightSmartContractAccount` when compared to `SimpleSmartContractAccount`.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactoryAddress,
+} from "@alchemy/aa-accounts";
+import {
+  LocalAccountSigner,
+  getDefaultEntryPointAddress,
+  type SmartAccountSigner,
+} from "@alchemy/aa-core";
+import { sepolia } from "viem/chains";
+
+const PRIVATE_KEY = "0xYourEOAPrivateKey";
+const eoaSigner: SmartAccountSigner =
+  LocalAccountSigner.privateKeyToAccountSigner(`0x${PRIVATE_KEY}`);
+
+export const account = new LightSmartContractAccount({
+  rpcClient: "ALCHEMY_RPC_URL",
+  chain: sepolia,
+  factoryAddress: getDefaultLightAccountFactoryAddress(sepolia),
+  owner: eoaSigner,
+  entryPointAddress: getDefaultEntryPointAddress(sepolia),
+  accountAddress: "0xYourSmartAccountAddress",
+  index: 0n,
+});
+```
+
+:::
+
+## Returns
+
+### `LightSmartContractAccount`
+
+A new instance of an `LightSmartContractAccount`.
+
+## Parameters
+
+### `params: SimpleSmartAccountParams`
+
+- `rpcClient: string | PublicErc4337Client` -- a JSON-RPC URL, or a viem Client that supports ERC-4337 methods and Viem public actions. See [createPublicErc4337Client](/packages/aa-core/client/createPublicErc4337Client.md).
+
+- `chain: Chain` -- the chain on which to create the provider.
+
+- `factoryAddress: Address` -- the factory address for the smart account implementation, which is required for creating the account if not already deployed.
+
+- `owner: SmartAccountSigner` -- the owner EOA address responsible for signing user operations on behalf of the smart account.
+
+- `entryPointAddress: Address | undefined` -- [optional] entry point contract address. If not provided, the entry point contract address for the provider is the connected account's entry point contract, or if not connected, falls back to the default entry point contract for the chain. See [getDefaultEntryPointAddress](/packages/aa-core/utils/getDefaultEntryPointAddress.html#getdefaultentrypointaddress).
+
+- `accountAddress: Address | undefined` -- the owner EOA address responsible for signing user operations on behalf of the smart account.
+
+- `index: bigint | undefined` -- [optional] additional salt value used when creating the smart account. Allows for a one-to-many creation from one owner address to many smart account addresses.

--- a/site/packages/aa-accounts/light-account/constructor.md
+++ b/site/packages/aa-accounts/light-account/constructor.md
@@ -39,6 +39,7 @@ const PRIVATE_KEY = "0xYourEOAPrivateKey";
 const eoaSigner: SmartAccountSigner =
   LocalAccountSigner.privateKeyToAccountSigner(`0x${PRIVATE_KEY}`);
 
+// instantiates using every possible parameter, as a reference
 export const account = new LightSmartContractAccount({
   rpcClient: "ALCHEMY_RPC_URL",
   chain: sepolia,

--- a/site/packages/aa-accounts/light-account/constructor.md
+++ b/site/packages/aa-accounts/light-account/constructor.md
@@ -75,4 +75,4 @@ A new instance of an `LightSmartContractAccount`.
 
 - `accountAddress: Address | undefined` -- the owner EOA address responsible for signing user operations on behalf of the smart account.
 
-- `index: bigint | undefined` -- [optional] additional salt value used when creating the smart account. Allows for a one-to-many creation from one owner address to many smart account addresses.
+- `index: bigint | undefined` -- [optional] additional salt value used when creating the smart account.

--- a/site/packages/aa-alchemy/provider/constructor.md
+++ b/site/packages/aa-alchemy/provider/constructor.md
@@ -6,15 +6,15 @@ head:
       content: AlchemyProvider • constructor
   - - meta
     - name: description
-      content: Overview of the constructor method on Alchemy Provider in aa-alchemy
+      content: Overview of the constructor method on AlchemyProvider in aa-alchemy
   - - meta
     - property: og:description
-      content: Overview of the constructor method on Alchemy Provider in aa-alchemy
+      content: Overview of the constructor method on AlchemyProvider in aa-alchemy
 ---
 
 # constructor
 
-To initialize the Alchemy Provider
+To initialize an `AlchemyProvider`, you must provide a set of parameters detailed below.
 
 ## Usage
 
@@ -22,11 +22,24 @@ To initialize the Alchemy Provider
 
 ```ts [example.ts]
 import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import { getDefaultEntryPointAddress } from "@alchemy/aa-core";
 import { sepolia } from "viem/chains";
 
 export const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key
   chain: sepolia,
+  entryPointAddress: getDefaultEntryPointAddress(sepolia),
+  opts: {
+    txMaxRetries: 10,
+    txRetryIntervalMs: 2_000,
+    txRetryMulitplier: 1.5,
+    minPriorityFeePerBid: 100_000_000n,
+  },
+  feeOpts: {
+    baseFeeBufferPercent: 50n,
+    maxPriorityFeeBufferPercent: 5n,
+    preVerificationGasBufferPercent: 5n,
+  },
 });
 ```
 
@@ -40,6 +53,32 @@ A new instance of an `AlchemyProvider`.
 
 ## Parameters
 
-### `config: AlchemyGasManagerConfig`
+### `config: AlchemyProviderConfig`
 
-- `policyId: string` -- the Alchemy Gas Manager policy ID
+- `rpcUrl: string | undefined | never` -- a JSON-RPC URL. This is required if there is no `apiKey`.
+
+- `apiKey: string | undefined | never` -- an Alchemy API Key. This is required if there is no `rpcUrl` or `jwt`.
+
+- `jwt: string | undefined | never` -- an Alchemy JWT (JSON web token). This is required if there is no `apiKey`.
+
+- `chain: Chain` -- the chain on which to create the provider.
+
+- `entryPointAddress: Address | undefined` -- [optional] the entry point contract address. If not provided, the entry point contract address for the provider is the connected account's entry point contract, or if not connected, falls back to the default entry point contract for the chain. See [getDefaultEntryPointAddress](/packages/aa-core/utils/getDefaultEntryPointAddress.html#getdefaultentrypointaddress).
+
+- `opts: Object | undefined` -- [optional] overrides on provider config variables having to do with fetching transaction receipts and fee computation.
+
+  - `txMaxRetries: string | undefined` -- [optional] the maximum number of times to try fetching a transaction receipt before giving up (default: 5).
+
+  - `txRetryIntervalMs: string | undefined` -- [optional] the interval in milliseconds to wait between retries while waiting for transaction receipts (default: 2_000).
+
+  - `txRetryMulitplier: string | undefined` -- [optional] the mulitplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
+
+  - `minPriorityFeePerBid: string | undefined` --[optional] used when computing the fees for a user operation (default: 100_000_000).
+
+- `feeOpts: Object | undefined` -- [optional] overrides on provider config variables having to do with gas and fee estimation.
+
+  - `baseFeeBufferPercent: bigint | undefined` -- [optional] a percent buffer on top of the base fee estimated (default 50%). This is only applied if the default fee estimator is used.
+
+  - `maxPriorityFeeBufferPercent: bigint | undefined` -- [optional] a percent buffer on top of the priority fee estimated (default 5%). This is only applied if the default fee estimator is used.
+
+  - `preVerificationGasBufferPercent: bigint | undefined` -- [optional] a percent buffer on top of the preVerificationGas estimated (default 5% on Arbitrum and Optimism, 0% elsewhere). This is only useful on Arbitrum and Optimism, where the preVerificationGas is dependent on the gas fee during the time of estimation. To improve chances of the UserOperation being mined, users can increase the preVerificationGas by a buffer. This buffer will always be charged, regardless of price at time of mine. This is only applied if the default gas estimator is used.

--- a/site/packages/aa-alchemy/provider/constructor.md
+++ b/site/packages/aa-alchemy/provider/constructor.md
@@ -1,0 +1,45 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: AlchemyProvider • constructor
+  - - meta
+    - name: description
+      content: Overview of the constructor method on Alchemy Provider in aa-alchemy
+  - - meta
+    - property: og:description
+      content: Overview of the constructor method on Alchemy Provider in aa-alchemy
+---
+
+# constructor
+
+To initialize the Alchemy Provider
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import { sepolia } from "viem/chains";
+
+export const provider = new AlchemyProvider({
+  apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key
+  chain: sepolia,
+});
+```
+
+:::
+
+## Returns
+
+### `AlchemyProvider`
+
+A new instance of an `AlchemyProvider`.
+
+## Parameters
+
+### `config: AlchemyGasManagerConfig`
+
+- `policyId: string` -- the Alchemy Gas Manager policy ID

--- a/site/packages/aa-alchemy/provider/constructor.md
+++ b/site/packages/aa-alchemy/provider/constructor.md
@@ -25,6 +25,7 @@ import { AlchemyProvider } from "@alchemy/aa-alchemy";
 import { getDefaultEntryPointAddress } from "@alchemy/aa-core";
 import { sepolia } from "viem/chains";
 
+// instantiates using every possible parameter, as a reference
 export const provider = new AlchemyProvider({
   apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key
   chain: sepolia,

--- a/site/packages/aa-core/accounts/constructor.md
+++ b/site/packages/aa-core/accounts/constructor.md
@@ -36,6 +36,7 @@ const PRIVATE_KEY = "0xYourEOAPrivateKey";
 const eoaSigner: SmartAccountSigner =
   LocalAccountSigner.privateKeyToAccountSigner(`0x${PRIVATE_KEY}`);
 
+// instantiates using every possible parameter, as a reference
 export const account = new SimpleSmartContractAccount({
   rpcClient: "ALCHEMY_RPC_URL",
   chain: sepolia,

--- a/site/packages/aa-core/accounts/constructor.md
+++ b/site/packages/aa-core/accounts/constructor.md
@@ -14,7 +14,7 @@ head:
 
 # constructor
 
-To initialize an `SimpleSmartContractAccount`, you must provide a set of parameters detailed below.
+To initialize a `SimpleSmartContractAccount`, you must provide a set of parameters detailed below.
 
 Note that `BaseSmartContractAccount` is an abstract class, and so cannot be initialized even though it has a constructor.
 

--- a/site/packages/aa-core/accounts/constructor.md
+++ b/site/packages/aa-core/accounts/constructor.md
@@ -1,0 +1,74 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: SimpleSmartContractAccount • constructor
+  - - meta
+    - name: description
+      content: Overview of the constructor method on SimpleSmartContractAccount in aa-core
+  - - meta
+    - property: og:description
+      content: Overview of the constructor method on SimpleSmartContractAccount in aa-core
+---
+
+# constructor
+
+To initialize an `SimpleSmartContractAccount`, you must provide a set of parameters detailed below.
+
+Note that `BaseSmartContractAccount` is an abstract class, and so cannot be initialized even though it has a constructor.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import {
+  LocalAccountSigner,
+  SimpleSmartContractAccount,
+  getDefaultEntryPointAddress,
+  getDefaultSimpleAccountFactoryAddress,
+  type SmartAccountSigner,
+} from "@alchemy/aa-core";
+import { sepolia } from "viem/chains";
+
+const PRIVATE_KEY = "0xYourEOAPrivateKey";
+const eoaSigner: SmartAccountSigner =
+  LocalAccountSigner.privateKeyToAccountSigner(`0x${PRIVATE_KEY}`);
+
+export const account = new SimpleSmartContractAccount({
+  rpcClient: "ALCHEMY_RPC_URL",
+  chain: sepolia,
+  factoryAddress: getDefaultSimpleAccountFactoryAddress(sepolia),
+  owner: eoaSigner,
+  entryPointAddress: getDefaultEntryPointAddress(sepolia),
+  accountAddress: "0xYourSmartAccountAddress",
+  index: 0n,
+});
+```
+
+:::
+
+## Returns
+
+### `SimpleSmartContractAccount`
+
+A new instance of an `SimpleSmartContractAccount`.
+
+## Parameters
+
+### `params: SimpleSmartAccountParams`
+
+- `rpcClient: string | PublicErc4337Client` -- a JSON-RPC URL, or a viem Client that supports ERC-4337 methods and Viem public actions. See [createPublicErc4337Client](/packages/aa-core/client/createPublicErc4337Client.md).
+
+- `chain: Chain` -- the chain on which to create the provider.
+
+- `factoryAddress: Address` -- the factory address for the smart account implementation, which is required for creating the account if not already deployed.
+
+- `owner: SmartAccountSigner` -- the owner EOA address responsible for signing user operations on behalf of the smart account.
+
+- `entryPointAddress: Address | undefined` -- [optional] entry point contract address. If not provided, the entry point contract address for the provider is the connected account's entry point contract, or if not connected, falls back to the default entry point contract for the chain. See [getDefaultEntryPointAddress](/packages/aa-core/utils/getDefaultEntryPointAddress.html#getdefaultentrypointaddress).
+
+- `accountAddress: Address | undefined` -- the owner EOA address responsible for signing user operations on behalf of the smart account.
+
+- `index: bigint | undefined` -- [optional] additional salt value used when creating the smart account. Allows for a one-to-many creation from one owner address to many smart account addresses.

--- a/site/packages/aa-core/accounts/constructor.md
+++ b/site/packages/aa-core/accounts/constructor.md
@@ -54,7 +54,7 @@ export const account = new SimpleSmartContractAccount({
 
 ### `SimpleSmartContractAccount`
 
-A new instance of an `SimpleSmartContractAccount`.
+A new instance of a `SimpleSmartContractAccount`.
 
 ## Parameters
 

--- a/site/packages/aa-core/provider/constructor.md
+++ b/site/packages/aa-core/provider/constructor.md
@@ -14,7 +14,7 @@ head:
 
 # constructor
 
-To initialize an `SmartAccountProvider`, you must provide a set of parameters detailed below.
+To initialize a `SmartAccountProvider`, you must provide a set of parameters detailed below.
 
 ## Usage
 

--- a/site/packages/aa-core/provider/constructor.md
+++ b/site/packages/aa-core/provider/constructor.md
@@ -9,7 +9,7 @@ head:
       content: Overview of the constructor method on SmartAccountProvider in aa-core
   - - meta
     - property: og:description
-      content: Overview of the constructor method on SmartAccountProvider in aa-alchemy
+      content: Overview of the constructor method on SmartAccountProvider in aa-core
 ---
 
 # constructor
@@ -25,6 +25,7 @@ import { SmartAccountProvider } from "@alchemy/aa-core";
 import { getDefaultEntryPointAddress } from "@alchemy/aa-core";
 import { sepolia } from "viem/chains";
 
+// instantiates using every possible parameter, as a reference
 export const provider = new SmartAccountProvider({
   rpcProvider: "ALCHEMY_RPC_URL",
   chain: sepolia,

--- a/site/packages/aa-core/provider/constructor.md
+++ b/site/packages/aa-core/provider/constructor.md
@@ -45,7 +45,7 @@ export const provider = new SmartAccountProvider({
 
 ### `SmartAccountProvider`
 
-A new instance of an `SmartAccountProvider`.
+A new instance of a `SmartAccountProvider`.
 
 ## Parameters
 

--- a/site/packages/aa-core/provider/constructor.md
+++ b/site/packages/aa-core/provider/constructor.md
@@ -1,0 +1,67 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: SmartAccountProvider • constructor
+  - - meta
+    - name: description
+      content: Overview of the constructor method on SmartAccountProvider in aa-core
+  - - meta
+    - property: og:description
+      content: Overview of the constructor method on SmartAccountProvider in aa-alchemy
+---
+
+# constructor
+
+To initialize an `SmartAccountProvider`, you must provide a set of parameters detailed below.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { SmartAccountProvider } from "@alchemy/aa-core";
+import { getDefaultEntryPointAddress } from "@alchemy/aa-core";
+import { sepolia } from "viem/chains";
+
+export const provider = new SmartAccountProvider({
+  rpcProvider: "ALCHEMY_RPC_URL",
+  chain: sepolia,
+  entryPointAddress: getDefaultEntryPointAddress(sepolia),
+  opts: {
+    txMaxRetries: 10,
+    txRetryIntervalMs: 2_000,
+    txRetryMulitplier: 1.5,
+    minPriorityFeePerBid: 100_000_000n,
+  },
+});
+```
+
+:::
+
+## Returns
+
+### `SmartAccountProvider`
+
+A new instance of an `SmartAccountProvider`.
+
+## Parameters
+
+### `config: SmartAccountProviderConfig`
+
+- `rpcProvider: string | PublicErc4337Client<TTransport extends SupportedTransports = Transport>` -- a JSON-RPC URL, or a viem Client that supports ERC-4337 methods and Viem public actions. See [createPublicErc4337Client](/packages/aa-core/client/createPublicErc4337Client.md).
+
+- `chain: Chain` -- the chain on which to create the provider.
+
+- `entryPointAddress: Address | undefined` -- [optional] the entry point contract address. If not provided, the entry point contract address for the provider is the connected account's entry point contract, or if not connected, falls back to the default entry point contract for the chain. See [getDefaultEntryPointAddress](/packages/aa-core/utils/getDefaultEntryPointAddress.html#getdefaultentrypointaddress).
+
+- `opts: Object | undefined` -- [optional] overrides on provider config variables having to do with fetching transaction receipts and fee computation.
+
+  - `txMaxRetries: string | undefined` -- [optional] the maximum number of times to try fetching a transaction receipt before giving up (default: 5).
+
+  - `txRetryIntervalMs: string | undefined` -- [optional] the interval in milliseconds to wait between retries while waiting for transaction receipts (default: 2_000).
+
+  - `txRetryMulitplier: string | undefined` -- [optional] the mulitplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
+
+  - `minPriorityFeePerBid: string | undefined` --[optional] used when computing the fees for a user operation (default: 100_000_000).

--- a/site/packages/aa-ethers/provider-adapter/constructor.md
+++ b/site/packages/aa-ethers/provider-adapter/constructor.md
@@ -29,11 +29,11 @@ import { EthersProviderAdapter } from "@alchemy/aa-ethers";
 import { sepolia } from "viem/chains";
 
 export const provider = new EthersProviderAdapter({
-  rpcProvider: "ALCHEMY_RPC_URL", // replace with your Alchemy API Key
+  rpcProvider: "ALCHEMY_RPC_URL",
   chainId: 80001,
 });
 
-export const otherProvider = new EthersProviderAdapter({
+export const anotherProvider = new EthersProviderAdapter({
   accountProvider: new AlchemyProvider({
     apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key
     chain: sepolia,

--- a/site/packages/aa-ethers/provider-adapter/constructor.md
+++ b/site/packages/aa-ethers/provider-adapter/constructor.md
@@ -28,11 +28,13 @@ import { getDefaultEntryPointAddress } from "@alchemy/aa-core";
 import { EthersProviderAdapter } from "@alchemy/aa-ethers";
 import { sepolia } from "viem/chains";
 
+// one way to initialize
 export const provider = new EthersProviderAdapter({
   rpcProvider: "ALCHEMY_RPC_URL",
   chainId: 80001,
 });
 
+// another way to initialize
 export const anotherProvider = new EthersProviderAdapter({
   accountProvider: new AlchemyProvider({
     apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key

--- a/site/packages/aa-ethers/provider-adapter/constructor.md
+++ b/site/packages/aa-ethers/provider-adapter/constructor.md
@@ -1,0 +1,76 @@
+---
+outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: EthersProviderAdapter • constructor
+  - - meta
+    - name: description
+      content: Overview of the constructor method on EthersProviderAdapter in aa-ethers
+  - - meta
+    - property: og:description
+      content: Overview of the constructor method on EthersProviderAdapter in aa-ethers
+---
+
+# constructor
+
+To initialize an `EthersProviderAdapter`, you must provide a set of parameters detailed below.
+
+Note that we still recommend to use the [fromEthersProvider](/packages/aa-ethers/provider-adapter/fromEthersProvider.md) method to constructor an `EthersProviderAdapter`.
+
+## Usage
+
+::: code-group
+
+```ts [example.ts]
+import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import { getDefaultEntryPointAddress } from "@alchemy/aa-core";
+import { EthersProviderAdapter } from "@alchemy/aa-ethers";
+import { sepolia } from "viem/chains";
+
+export const provider = new EthersProviderAdapter({
+  rpcProvider: "ALCHEMY_RPC_URL", // replace with your Alchemy API Key
+  chainId: 80001,
+});
+
+export const otherProvider = new EthersProviderAdapter({
+  accountProvider: new AlchemyProvider({
+    apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key
+    chain: sepolia,
+    entryPointAddress: getDefaultEntryPointAddress(sepolia),
+    opts: {
+      txMaxRetries: 10,
+      txRetryIntervalMs: 2_000,
+      txRetryMulitplier: 1.5,
+      minPriorityFeePerBid: 100_000_000n,
+    },
+    feeOpts: {
+      baseFeeBufferPercent: 50n,
+      maxPriorityFeeBufferPercent: 5n,
+      preVerificationGasBufferPercent: 5n,
+    },
+  }),
+});
+```
+
+:::
+
+## Returns
+
+### `EthersProviderAdapter`
+
+A new instance of an `EthersProviderAdapter`.
+
+## Parameters
+
+### `opts: EthersProviderAdapterOpts`
+
+Either:
+
+- `rpcProvider: string | PublicErc4337Client` -- a JSON-RPC URL, or a viem Client that supports ERC-4337 methods and Viem public actions. See [createPublicErc4337Client](/packages/aa-core/client/createPublicErc4337Client.md).
+
+- `chainId: number` -- the ID of thechain on which to create the provider.
+
+Or:
+
+- `accountProvider: SmartAccountProvider` -- See [SmartAccountProvider](/packages/aa-core/provider/constructor.md).


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, see guidleines below)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:fix`)
- [x] Is the base branch you're merging into `development` and not `main`?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing default values for certain properties in the code. 

### Detailed summary
- Removed default value for `baseFeeBufferPercent` property in `schema.ts`.
- Removed default value for `maxPriorityFeeBufferPercent` property in `schema.ts`.
- Removed default value for `txMaxRetries` property in `schema.ts`.
- Removed default value for `txRetryIntervalMs` property in `schema.ts`.
- Removed default value for `txRetryMulitplier` property in `schema.ts`.
- Removed default value for `minPriorityFeePerBid` property in `schema.ts`.
- Added constructor for `SmartAccountProvider` in `config.ts`.
- Added constructor for `EthersProviderAdapter` in `config.ts`.
- Added constructor for `EthersProviderAdapter` in `provider-adapter/constructor.md`.
- Added constructor for `SmartAccountProvider` in `provider/constructor.md`.
- Added constructor for `SimpleSmartContractAccount` in `accounts/constructor.md`.
- Added constructor for `LightSmartContractAccount` in `accounts/constructor.md`.

> The following files were skipped due to too many changes: `site/packages/aa-accounts/light-account/constructor.md`, `site/packages/aa-alchemy/provider/constructor.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

![image](https://github.com/alchemyplatform/aa-sdk/assets/43521356/946ad94d-ffa4-4573-85ce-de2cb4f770b7)
![image](https://github.com/alchemyplatform/aa-sdk/assets/43521356/3b85f8ad-fab0-4e4f-8c81-f7660267ad78)
![image](https://github.com/alchemyplatform/aa-sdk/assets/43521356/ed677eab-92ff-4167-b72c-2dfd1527b778)
![image](https://github.com/alchemyplatform/aa-sdk/assets/43521356/3df32d93-e2df-4f00-9af6-c6e3f7d1f600)
![image](https://github.com/alchemyplatform/aa-sdk/assets/43521356/7ab8729c-314e-4225-b438-303846e51bff)