### PR TITLE
feat(sepolia): add min priority per bid

### DIFF
--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -10,7 +10,7 @@ import {
   type Transaction,
   type Transport,
 } from "viem";
-import { arbitrum, arbitrumGoerli } from "viem/chains";
+import { arbitrum, arbitrumGoerli, arbitrumSepolia } from "viem/chains";
 import type {
   ISmartContractAccount,
   SignTypedDataParams,
@@ -61,6 +61,7 @@ export const noOpMiddleware: AccountMiddlewareFn = async (
 const minPriorityFeePerBidDefaults = new Map<number, bigint>([
   [arbitrum.id, 10_000_000n],
   [arbitrumGoerli.id, 10_000_000n],
+  [arbitrumSepolia.id, 10_000_000n],
 ]);
 
 export class SmartAccountProvider<


### PR DESCRIPTION
Missed this on the last sepolia PR

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding support for the `arbitrumSepolia` chain in the `SmartAccountProvider` class.

### Detailed summary:
- Added `arbitrumSepolia` import from `viem/chains`.
- Added `arbitrumSepolia` to the `minPriorityFeePerBidDefaults` map.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->