### PR TITLE
feat(arb-sepolia): add arb sepolia to defaults

### DIFF
--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -2,6 +2,7 @@ import { type Address, type Chain } from "viem";
 import {
   arbitrum,
   arbitrumGoerli,
+  arbitrumSepolia,
   base,
   baseGoerli,
   goerli,
@@ -31,6 +32,7 @@ export const getDefaultEntryPointAddress = (chain: Chain): Address => {
     case optimismGoerli.id:
     case arbitrum.id:
     case arbitrumGoerli.id:
+    case arbitrumSepolia.id:
     case base.id:
     case baseGoerli.id:
       return "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
@@ -64,6 +66,8 @@ export const getDefaultSimpleAccountFactoryAddress = (
     case optimismGoerli.id:
     case arbitrumGoerli.id:
       return "0x9406Cc6185a346906296840746125a0E44976454";
+    case arbitrumSepolia.id:
+      return "0x8d4CCBaa194ED721AC3e231a1A3863966c2D7921";
   }
 
   throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,31 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.4.tgz#aae21cb858bbb0411949d5b7b3051f4209043f62"
   integrity sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==
 
+"@alchemy/aa-accounts@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@alchemy/aa-accounts/-/aa-accounts-0.1.1.tgz#7527e25fe2825eb91d80f6e4cb85d188606587a4"
+  integrity sha512-nHHnJuIHXGdvH5i+7DlTeSPa3RJtNLt4NpJP+G+T8G3QP/k6mxHNWFTybOhqxuCC798DACxKc4thOL2Lj8phgA==
+  dependencies:
+    "@alchemy/aa-core" "^0.1.1"
+    viem "^1.16.2"
+
+"@alchemy/aa-alchemy@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@alchemy/aa-alchemy/-/aa-alchemy-0.1.1.tgz#f7f989b2aaae127a49a61e1dde6d6f52d40d0018"
+  integrity sha512-rVQZNb1QmfQoxDyaXuinB0pfrKENLydwH57TWXJn4wFW+3c+iM6xM/tsfx6zxzA7HTwodcRw8//wMvdF+5KQmg==
+  dependencies:
+    "@alchemy/aa-core" "^0.1.1"
+    viem "^1.16.2"
+
+"@alchemy/aa-core@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@alchemy/aa-core/-/aa-core-0.1.1.tgz#2c81e34c0ca939897004c68d80250f1b4b423ff2"
+  integrity sha512-vEfCx9MJMTCMpmB3cY+TcM65znP8zcMTaiYE7By3+krhd7ViflWdEILe5HGGzCALGqdr6pUaBI7n08eVoyo6KQ==
+  dependencies:
+    abitype "^0.8.3"
+    eventemitter3 "^5.0.1"
+    viem "^1.16.2"
+
 "@algolia/autocomplete-core@1.9.3":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"


### PR DESCRIPTION
add arb sepolia to defaults so we do not need to pass in entry point address and simple account during load tests

not too sure why the yarn.lock changed if anyone knows that would be helpful

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for the `arbitrumSepolia` chain and updating default addresses. 

### Detailed summary
- Added `arbitrumSepolia` to the list of supported chains.
- Updated the default entry point address for `arbitrumSepolia`.
- Updated the default simple account factory address for `arbitrumSepolia`.
- Added new dependencies for `@alchemy/aa-accounts`, `@alchemy/aa-alchemy`, and `@alchemy/aa-core`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->