### PR TITLE
chore: update tests to use aa-sdk-tests as signerType to avoid confusion in telemetry

### DIFF
--- a/packages/accounts/src/kernel-zerodev/__tests__/mocks/mock-signer.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/mocks/mock-signer.ts
@@ -4,9 +4,10 @@ import type {
   SignTypedDataParams,
   SmartAccountSigner,
 } from "@alchemy/aa-core";
+import { AA_SDK_TESTS_SIGNER_TYPE } from "@alchemy/aa-core";
 
 export class MockSigner implements SmartAccountSigner {
-  signerType = "mock";
+  signerType = AA_SDK_TESTS_SIGNER_TYPE;
 
   getAddress(): Promise<Address> {
     return Promise.resolve("0x48D4d3536cDe7A257087206870c6B6E76e3D4ff4");

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
@@ -2,6 +2,7 @@ import {
   getDefaultEntryPointAddress,
   type BatchUserOperationCallData,
   type SmartAccountSigner,
+  AA_SDK_TESTS_SIGNER_TYPE,
 } from "@alchemy/aa-core";
 import {
   encodeAbiParameters,
@@ -36,7 +37,7 @@ describe("Kernel Account Tests", () => {
 
   const ownerAccount = mnemonicToAccount(OWNER_MNEMONIC);
   const owner: SmartAccountSigner = {
-    signerType: "kernel-zerodev",
+    signerType: AA_SDK_TESTS_SIGNER_TYPE,
     signMessage: async (msg) =>
       ownerAccount.signMessage({
         message: { raw: toHex(msg) },

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/mocks/mock-signer.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/mocks/mock-signer.ts
@@ -1,12 +1,13 @@
-import type {
-  Address,
-  Hex,
-  SignTypedDataParams,
-  SmartAccountSigner,
+import {
+  AA_SDK_TESTS_SIGNER_TYPE,
+  type Address,
+  type Hex,
+  type SignTypedDataParams,
+  type SmartAccountSigner,
 } from "@alchemy/aa-core";
 
 export class MockSigner implements SmartAccountSigner {
-  signerType = "mock";
+  signerType = AA_SDK_TESTS_SIGNER_TYPE;
 
   getAddress(): Promise<Address> {
     return Promise.resolve("0x48D4d3536cDe7A257087206870c6B6E76e3D4ff4");

--- a/packages/accounts/src/kernel-zerodev/validator/__tests__/mocks/mock-signer-validator.ts
+++ b/packages/accounts/src/kernel-zerodev/validator/__tests__/mocks/mock-signer-validator.ts
@@ -1,12 +1,13 @@
-import type {
-  Address,
-  Hex,
-  SignTypedDataParams,
-  SmartAccountSigner,
+import {
+  AA_SDK_TESTS_SIGNER_TYPE,
+  type Address,
+  type Hex,
+  type SignTypedDataParams,
+  type SmartAccountSigner,
 } from "@alchemy/aa-core";
 
 export class MockSignerValidator implements SmartAccountSigner {
-  signerType = "mock-validator";
+  signerType = AA_SDK_TESTS_SIGNER_TYPE;
 
   signTypedData(params: SignTypedDataParams): Promise<`0x${string}`> {
     return Promise.resolve("0xMOCK_SIGN_TYPED_DATA");

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -2,6 +2,7 @@ import {
   SimpleSmartContractAccount,
   getDefaultSimpleAccountFactoryAddress,
   type SmartAccountSigner,
+  AA_SDK_TESTS_SIGNER_TYPE,
 } from "@alchemy/aa-core";
 import { toHex, type Address, type Chain, type Hash } from "viem";
 import { mnemonicToAccount } from "viem/accounts";
@@ -20,7 +21,7 @@ describe("Simple Account Tests", () => {
       }),
     signTypedData: async () => "0xHash",
     getAddress: async () => ownerAccount.address,
-    signerType: "e2e-test",
+    signerType: AA_SDK_TESTS_SIGNER_TYPE,
   };
 
   it("should successfully get counterfactual address", async () => {

--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -21,7 +21,7 @@ describe("Alchemy Provider Tests", () => {
       }),
     signTypedData: async () => "0xHash",
     getAddress: async () => ownerAccount.address,
-    signerType: "e2e-test",
+    signerType: AACoreModule.AA_SDK_TESTS_SIGNER_TYPE,
   };
   const chain = polygonMumbai;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export type { BaseSmartAccountParams } from "./account/types.js";
 export { LocalAccountSigner } from "./signer/local-account.js";
 export { SignerSchema } from "./signer/schema.js";
 export type { SmartAccountSigner } from "./signer/types.js";
+export { AA_SDK_TESTS_SIGNER_TYPE } from "./signer/types.js";
 export {
   verifyEIP6492Signature,
   wrapSignatureWith6492,

--- a/packages/core/src/signer/types.ts
+++ b/packages/core/src/signer/types.ts
@@ -8,3 +8,5 @@ export interface SmartAccountSigner {
   signTypedData: (params: SignTypedDataParams) => Promise<Hash>;
   getAddress: () => Promise<Address>;
 }
+
+export const AA_SDK_TESTS_SIGNER_TYPE = "aa-sdk-tests";


### PR DESCRIPTION
https://app.asana.com/0/1205598840815267/1205879669498253/f

Context 
- https://alchemyinsights.slack.com/archives/C05EA8Z0SBV/p1699383629372049?thread_ts=1699377908.018899&cid=C05EA8Z0SBV

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to replace the hard-coded string value "e2e-test" with the constant `AA_SDK_TESTS_SIGNER_TYPE` in multiple files.
- The constant `AA_SDK_TESTS_SIGNER_TYPE` is exported from `packages/core/src/signer/types.ts` and imported in various files to replace the hard-coded string value.
- The changes are made in the following files:
  - `packages/alchemy/src/__tests__/provider.test.ts`
  - `packages/core/src/index.ts`
  - `packages/accounts/src/kernel-zerodev/__tests__/mocks/mock-signer.ts`
  - `packages/accounts/src/kernel-zerodev/e2e-tests/mocks/mock-signer.ts`
  - `packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts`
  - `packages/accounts/src/kernel-zerodev/validator/__tests__/mocks/mock-signer-validator.ts`
  - `packages/alchemy/e2e-tests/simple-account.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->