### PR TITLE
feat: aa-sdk with native arb sepolia support

### DIFF
--- a/packages/accounts/src/light-account/utils.ts
+++ b/packages/accounts/src/light-account/utils.ts
@@ -2,6 +2,7 @@ import type { Address, Chain } from "viem";
 import {
   arbitrum,
   arbitrumGoerli,
+  arbitrumSepolia,
   base,
   baseGoerli,
   goerli,
@@ -31,6 +32,7 @@ export const getDefaultLightAccountFactoryAddress = (chain: Chain): Address => {
     case optimismGoerli.id:
     case arbitrum.id:
     case arbitrumGoerli.id:
+    case arbitrumSepolia.id:
     case base.id:
     case baseGoerli.id:
       return "0x00000055C0b4fA41dde26A74435ff03692292FBD";

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -59,6 +59,7 @@ export const getDefaultSimpleAccountFactoryAddress = (
     case arbitrum.id:
     case base.id:
     case baseGoerli.id:
+    case arbitrumSepolia.id:
       return "0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232";
     case sepolia.id:
     case goerli.id:
@@ -66,8 +67,6 @@ export const getDefaultSimpleAccountFactoryAddress = (
     case optimismGoerli.id:
     case arbitrumGoerli.id:
       return "0x9406Cc6185a346906296840746125a0E44976454";
-    case arbitrumSepolia.id:
-      return "0x8d4CCBaa194ED721AC3e231a1A3863966c2D7921";
   }
 
   throw new Error(

--- a/site/smart-accounts/accounts/deployment-addresses.md
+++ b/site/smart-accounts/accounts/deployment-addresses.md
@@ -18,32 +18,34 @@ The following tables list the deployed factory and account implementation contra
 
 ## [Light Account](https://github.com/alchemyplatform/light-account/blob/v1.0.2/Deployments.md)
 
-| Chain           | Factory Address                            | Account Implementation                     |
-| --------------- | ------------------------------------------ | ------------------------------------------ |
-| Eth Mainnet     | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Eth Sepolia     | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Eth Goerli      | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Polygon Mainnet | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Polygon Mumbai  | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Optimism        | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Optimism Goerli | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Base            | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Base Goerli     | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Arbitrum        | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
-| Arbitrum Goerli | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Chain            | Factory Address                            | Account Implementation                     |
+| ---------------- | ------------------------------------------ | ------------------------------------------ |
+| Eth Mainnet      | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Eth Sepolia      | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Eth Goerli       | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Polygon Mainnet  | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Polygon Mumbai   | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Optimism         | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Optimism Goerli  | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Base             | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Base Goerli      | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Arbitrum         | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Arbitrum Goerli  | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
+| Arbitrum Sepolia | 0x00000055C0b4fA41dde26A74435ff03692292FBD | 0x5467b1947F47d0646704EB801E075e72aeAe8113 |
 
 ## Simple Account
 
-| Chain           | Factory Address                            |
-| --------------- | ------------------------------------------ |
-| Eth Mainnet     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Eth Sepolia     | 0x9406cc6185a346906296840746125a0e44976454 |
-| Eth Goerli      | 0x9406cc6185a346906296840746125a0e44976454 |
-| Polygon Mainnet | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Polygon Mumbai  | 0x9406Cc6185a346906296840746125a0E44976454 |
-| Optimism        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Optimism Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
-| Base            | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Base Goerli     | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Arbitrum        | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
-| Arbitrum Goerli | 0x9406cc6185a346906296840746125a0e44976454 |
+| Chain            | Factory Address                            |
+| ---------------- | ------------------------------------------ |
+| Eth Mainnet      | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Eth Sepolia      | 0x9406cc6185a346906296840746125a0e44976454 |
+| Eth Goerli       | 0x9406cc6185a346906296840746125a0e44976454 |
+| Polygon Mainnet  | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Polygon Mumbai   | 0x9406Cc6185a346906296840746125a0E44976454 |
+| Optimism         | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Optimism Goerli  | 0x9406cc6185a346906296840746125a0e44976454 |
+| Base             | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Base Goerli      | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Arbitrum         | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |
+| Arbitrum Goerli  | 0x9406cc6185a346906296840746125a0e44976454 |
+| Arbitrum Sepolia | 0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232 |


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the `arbitrumSepolia` chain in the `getDefaultLightAccountFactoryAddress` and `getDefaultSimpleAccountFactoryAddress` functions.

### Detailed summary
- Added `arbitrumSepolia` to the `getDefaultLightAccountFactoryAddress` function.
- Added `arbitrumSepolia` to the `getDefaultSimpleAccountFactoryAddress` function.
- Updated the deployment addresses documentation to include `arbitrumSepolia` in the `Light Account` and `Simple Account` sections.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->