### PR TITLE
feat: remove AA_SDK_TESTS_SIGNER_TYPE constant exported from aa-core

### DIFF
--- a/packages/accounts/src/kernel-zerodev/__tests__/mocks/mock-signer.ts
+++ b/packages/accounts/src/kernel-zerodev/__tests__/mocks/mock-signer.ts
@@ -4,12 +4,11 @@ import type {
   SignTypedDataParams,
   SmartAccountSigner,
 } from "@alchemy/aa-core";
-import { AA_SDK_TESTS_SIGNER_TYPE } from "@alchemy/aa-core";
 
 export class MockSigner implements SmartAccountSigner {
   inner: any;
 
-  signerType = AA_SDK_TESTS_SIGNER_TYPE;
+  signerType = "aa-sdk-tests";
 
   getAddress(): Promise<Address> {
     return Promise.resolve("0x48D4d3536cDe7A257087206870c6B6E76e3D4ff4");

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts
@@ -1,5 +1,4 @@
 import {
-  AA_SDK_TESTS_SIGNER_TYPE,
   getDefaultEntryPointAddress,
   type BatchUserOperationCallData,
   type SmartAccountSigner,
@@ -39,7 +38,7 @@ describe("Kernel Account Tests", () => {
   const ownerAccount = mnemonicToAccount(OWNER_MNEMONIC);
   const owner: SmartAccountSigner<HDAccount> = {
     inner: ownerAccount,
-    signerType: AA_SDK_TESTS_SIGNER_TYPE,
+    signerType: "aa-sdk-tests",
     signMessage: async (msg) =>
       ownerAccount.signMessage({
         message: { raw: toHex(msg) },

--- a/packages/accounts/src/kernel-zerodev/e2e-tests/mocks/mock-signer.ts
+++ b/packages/accounts/src/kernel-zerodev/e2e-tests/mocks/mock-signer.ts
@@ -1,5 +1,4 @@
 import {
-  AA_SDK_TESTS_SIGNER_TYPE,
   type Address,
   type Hex,
   type SignTypedDataParams,
@@ -11,7 +10,7 @@ import { OWNER_MNEMONIC } from "../constants.js";
 export class MockSigner implements SmartAccountSigner<HDAccount> {
   inner = mnemonicToAccount(OWNER_MNEMONIC);
 
-  signerType = AA_SDK_TESTS_SIGNER_TYPE;
+  signerType = "aa-sdk-tests";
 
   getAddress(): Promise<Address> {
     return Promise.resolve("0x48D4d3536cDe7A257087206870c6B6E76e3D4ff4");

--- a/packages/accounts/src/kernel-zerodev/validator/__tests__/mocks/mock-signer-validator.ts
+++ b/packages/accounts/src/kernel-zerodev/validator/__tests__/mocks/mock-signer-validator.ts
@@ -1,5 +1,4 @@
 import {
-  AA_SDK_TESTS_SIGNER_TYPE,
   type Address,
   type Hex,
   type SignTypedDataParams,
@@ -9,7 +8,7 @@ import {
 export class MockSignerValidator implements SmartAccountSigner {
   inner: any;
 
-  signerType = AA_SDK_TESTS_SIGNER_TYPE;
+  signerType = "aa-sdk-tests";
 
   signTypedData(_params: SignTypedDataParams): Promise<`0x${string}`> {
     return Promise.resolve("0xMOCK_SIGN_TYPED_DATA");

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -2,7 +2,6 @@ import {
   SimpleSmartContractAccount,
   getDefaultSimpleAccountFactoryAddress,
   type SmartAccountSigner,
-  AA_SDK_TESTS_SIGNER_TYPE,
 } from "@alchemy/aa-core";
 import { Alchemy, Network } from "alchemy-sdk";
 import { toHex, type Address, type Chain, type Hash } from "viem";
@@ -23,7 +22,7 @@ describe("Simple Account Tests", () => {
       }),
     signTypedData: async () => "0xHash",
     getAddress: async () => ownerAccount.address,
-    signerType: AA_SDK_TESTS_SIGNER_TYPE,
+    signerType: "aa-sdk-tests",
   };
 
   it("should successfully get counterfactual address", async () => {

--- a/packages/alchemy/src/__tests__/provider.test.ts
+++ b/packages/alchemy/src/__tests__/provider.test.ts
@@ -23,7 +23,7 @@ describe("Alchemy Provider Tests", () => {
       }),
     signTypedData: async () => "0xHash",
     getAddress: async () => ownerAccount.address,
-    signerType: AACoreModule.AA_SDK_TESTS_SIGNER_TYPE,
+    signerType: "aa-sdk-tests",
   };
   const chain = polygonMumbai;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,6 @@ export type {
   SmartAccountSigner,
   SmartAccountAuthenticator,
 } from "./signer/types.js";
-export { AA_SDK_TESTS_SIGNER_TYPE } from "./signer/types.js";
 export {
   verifyEIP6492Signature,
   wrapSignatureWith6492,

--- a/packages/core/src/signer/types.ts
+++ b/packages/core/src/signer/types.ts
@@ -41,5 +41,3 @@ export interface SmartAccountSigner<Inner = any> {
 
   signTypedData: (params: SignTypedDataParams) => Promise<Hex>;
 }
-
-export const AA_SDK_TESTS_SIGNER_TYPE = "aa-sdk-tests";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The focus of this PR is to replace the constant `AA_SDK_TESTS_SIGNER_TYPE` with the string value `"aa-sdk-tests"` in multiple files.
- The changes include replacing `AA_SDK_TESTS_SIGNER_TYPE` with `"aa-sdk-tests"` in the following files:
  - `packages/core/src/signer/types.ts`
  - `packages/core/src/index.ts`
  - `packages/alchemy/src/__tests__/provider.test.ts`
  - `packages/accounts/src/kernel-zerodev/__tests__/mocks/mock-signer.ts`
  - `packages/accounts/src/kernel-zerodev/validator/__tests__/mocks/mock-signer-validator.ts`
  - `packages/accounts/src/kernel-zerodev/e2e-tests/mocks/mock-signer.ts`
  - `packages/accounts/src/kernel-zerodev/e2e-tests/kernel-account.test.ts`
  - `packages/alchemy/e2e-tests/simple-account.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->