### PR TITLE
feat: support overrides for all user operation methods on smart accont provider

### DIFF
--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -4,7 +4,13 @@ import {
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
 import { Alchemy, Network } from "alchemy-sdk";
-import { toHex, type Address, type Chain, type Hash } from "viem";
+import {
+  toHex,
+  type Address,
+  type Chain,
+  type Hash,
+  type HDAccount,
+} from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 import { AlchemyProvider } from "../src/provider.js";
@@ -15,7 +21,7 @@ const network = Network.ETH_SEPOLIA;
 
 describe("Simple Account Tests", () => {
   const ownerAccount = mnemonicToAccount(OWNER_MNEMONIC);
-  const owner: SmartAccountSigner = {
+  const owner: SmartAccountSigner<HDAccount> = {
     signMessage: async (msg) =>
       ownerAccount.signMessage({
         message: { raw: toHex(msg) },
@@ -23,6 +29,7 @@ describe("Simple Account Tests", () => {
     signTypedData: async () => "0xHash",
     getAddress: async () => ownerAccount.address,
     signerType: "aa-sdk-tests",
+    inner: ownerAccount,
   };
 
   it("should successfully get counterfactual address", async () => {
@@ -90,6 +97,34 @@ describe("Simple Account Tests", () => {
           data: "0x",
         })
     ).rejects.toThrow();
+  }, 50000);
+
+  it("should support overrides for buildUserOperation", async () => {
+    const signer = givenConnectedProvider({
+      owner,
+      chain,
+    }).withAlchemyGasManager({
+      policyId: PAYMASTER_POLICY_ID,
+    });
+
+    const overrides = {
+      maxFeePerGas: 100000000n,
+      maxPriorityFeePerGas: 100000000n,
+      paymasterAndData: "0x",
+    };
+    const uoStruct = await signer.buildUserOperation(
+      {
+        target: await signer.getAddress(),
+        data: "0x",
+      },
+      overrides
+    );
+
+    expect(uoStruct.maxFeePerGas).toEqual(overrides.maxFeePerGas);
+    expect(uoStruct.maxPriorityFeePerGas).toEqual(
+      overrides.maxPriorityFeePerGas
+    );
+    expect(uoStruct.paymasterAndData).toEqual(overrides.paymasterAndData);
   }, 50000);
 
   it("should successfully use paymaster with fee opts", async () => {

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -198,8 +198,11 @@ export class SmartAccountProvider<
     return this.account.signTypedDataWith6492(params);
   };
 
-  sendTransaction = async (request: RpcTransactionRequest): Promise<Hash> => {
-    const uoStruct = await this.buildUserOperationFromTx(request);
+  sendTransaction = async (
+    request: RpcTransactionRequest,
+    overrides?: UserOperationOverrides
+  ): Promise<Hash> => {
+    const uoStruct = await this.buildUserOperationFromTx(request, overrides);
 
     const { hash } = await this._sendUserOperation(uoStruct);
 
@@ -207,19 +210,22 @@ export class SmartAccountProvider<
   };
 
   buildUserOperationFromTx = async (
-    request: RpcTransactionRequest
+    request: RpcTransactionRequest,
+    overrides?: UserOperationOverrides
   ): Promise<UserOperationStruct> => {
     if (!request.to) {
       throw new Error("transaction is missing to address");
     }
 
-    const overrides: UserOperationOverrides = {};
-    if (request.maxFeePerGas) {
-      overrides.maxFeePerGas = request.maxFeePerGas;
+    const _overrides: UserOperationOverrides = {};
+    if (overrides?.maxFeePerGas || request.maxFeePerGas) {
+      _overrides.maxFeePerGas = overrides?.maxFeePerGas ?? request.maxFeePerGas;
     }
-    if (request.maxPriorityFeePerGas) {
-      overrides.maxPriorityFeePerGas = request.maxPriorityFeePerGas;
+    if (overrides?.maxPriorityFeePerGas || request.maxPriorityFeePerGas) {
+      _overrides.maxPriorityFeePerGas =
+        overrides?.maxPriorityFeePerGas ?? request.maxPriorityFeePerGas;
     }
+    _overrides.paymasterAndData = overrides?.paymasterAndData;
 
     return this.buildUserOperation(
       {
@@ -227,11 +233,14 @@ export class SmartAccountProvider<
         data: request.data ?? "0x",
         value: request.value ? fromHex(request.value, "bigint") : 0n,
       },
-      overrides
+      _overrides
     );
   };
 
-  sendTransactions = async (requests: RpcTransactionRequest[]) => {
+  sendTransactions = async (
+    requests: RpcTransactionRequest[],
+    overrides?: UserOperationOverrides
+  ) => {
     const batch = requests.map((request) => {
       if (!request.to) {
         throw new Error(
@@ -257,16 +266,17 @@ export class SmartAccountProvider<
         .filter((x) => x.maxPriorityFeePerGas != null)
         .map((x) => fromHex(x.maxPriorityFeePerGas!, "bigint"))
     );
-    const overrides: UserOperationOverrides = {};
-    if (maxFeePerGas != null) {
-      overrides.maxFeePerGas = maxFeePerGas;
+    const _overrides: UserOperationOverrides = {};
+    if (overrides?.maxFeePerGas || maxFeePerGas != null) {
+      _overrides.maxFeePerGas = overrides?.maxFeePerGas ?? maxFeePerGas;
     }
 
-    if (maxPriorityFeePerGas != null) {
-      overrides.maxPriorityFeePerGas = maxPriorityFeePerGas;
+    if (overrides?.maxPriorityFeePerGas || maxPriorityFeePerGas != null) {
+      _overrides.maxPriorityFeePerGas =
+        overrides?.maxPriorityFeePerGas ?? maxPriorityFeePerGas;
     }
 
-    const { hash } = await this.sendUserOperation(batch, overrides);
+    const { hash } = await this.sendUserOperation(batch, _overrides);
 
     return await this.waitForUserOperationTransaction(hash as Hash);
   };
@@ -349,7 +359,8 @@ export class SmartAccountProvider<
   };
 
   dropAndReplaceUserOperation = async (
-    uoToDrop: UserOperationRequest
+    uoToDrop: UserOperationRequest,
+    overrides?: UserOperationOverrides
   ): Promise<SendUserOperationResult> => {
     const uoToSubmit = {
       initCode: uoToDrop.initCode,
@@ -362,9 +373,9 @@ export class SmartAccountProvider<
     // Run once to get the fee estimates
     // This can happen at any part of the middleware stack, so we want to run it all
     const { maxFeePerGas, maxPriorityFeePerGas } =
-      await this._runMiddlewareStack(uoToSubmit);
+      await this._runMiddlewareStack(uoToSubmit, overrides);
 
-    const overrides: UserOperationOverrides = {
+    const _overrides: UserOperationOverrides = {
       maxFeePerGas: bigIntMax(
         BigInt(maxFeePerGas ?? 0n),
         bigIntPercent(uoToDrop.maxFeePerGas, 110n)
@@ -373,9 +384,10 @@ export class SmartAccountProvider<
         BigInt(maxPriorityFeePerGas ?? 0n),
         bigIntPercent(uoToDrop.maxPriorityFeePerGas, 110n)
       ),
+      paymasterAndData: uoToDrop.paymasterAndData,
     };
 
-    const uoToSend = await this._runMiddlewareStack(uoToSubmit, overrides);
+    const uoToSend = await this._runMiddlewareStack(uoToSubmit, _overrides);
     return this._sendUserOperation(uoToSend);
   };
 

--- a/site/packages/aa-core/provider/buildUserOperation.md
+++ b/site/packages/aa-core/provider/buildUserOperation.md
@@ -77,4 +77,4 @@ A Promise containing the _unsigned_ UserOperation struct resulting from the midd
 
 ### `overrides?: UserOperationOverrides`
 
-Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/buildUserOperation.md
+++ b/site/packages/aa-core/provider/buildUserOperation.md
@@ -74,3 +74,7 @@ A Promise containing the _unsigned_ UserOperation struct resulting from the midd
 - `target: Address` - the target of the call (equivalent to `to` in a transaction)
 - `data: Hex` - can be either `0x` or a call data string
 - `value?: bigint` - optionally, set the value in wei you want to send to the target
+
+### `overrides?: UserOperationOverrides`
+
+Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/buildUserOperationFromTx.md
+++ b/site/packages/aa-core/provider/buildUserOperationFromTx.md
@@ -59,3 +59,7 @@ A Promise containing the _unsigned_ UserOperation struct converted from the inpu
 ### `tx: RpcTransactionRequest`
 
 The `RpcTransactionRequest` object representing a traditional ethereum transaction
+
+### `overrides?: UserOperationOverrides`
+
+Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/buildUserOperationFromTx.md
+++ b/site/packages/aa-core/provider/buildUserOperationFromTx.md
@@ -62,4 +62,4 @@ The `RpcTransactionRequest` object representing a traditional ethereum transacti
 
 ### `overrides?: UserOperationOverrides`
 
-Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/dropAndReplaceUserOperation.md
+++ b/site/packages/aa-core/provider/dropAndReplaceUserOperation.md
@@ -50,3 +50,7 @@ A Promise containing the hash of the user operation and the request that was sen
 ### `UserOperationRequest`
 
 A previously submitted UserOperation.
+
+### `overrides?: UserOperationOverrides`
+
+Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/dropAndReplaceUserOperation.md
+++ b/site/packages/aa-core/provider/dropAndReplaceUserOperation.md
@@ -53,4 +53,4 @@ A previously submitted UserOperation.
 
 ### `overrides?: UserOperationOverrides`
 
-Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/sendTransaction.md
+++ b/site/packages/aa-core/provider/sendTransaction.md
@@ -53,3 +53,7 @@ A Promise containing the transaction hash
 ### `request: RpcTransactionRequest`
 
 The `RpcTransactionRequest` object representing a traditional ethereum transaction
+
+### `overrides?: UserOperationOverrides`
+
+Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/sendTransaction.md
+++ b/site/packages/aa-core/provider/sendTransaction.md
@@ -56,4 +56,4 @@ The `RpcTransactionRequest` object representing a traditional ethereum transacti
 
 ### `overrides?: UserOperationOverrides`
 
-Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/sendTransactions.md
+++ b/site/packages/aa-core/provider/sendTransactions.md
@@ -77,4 +77,4 @@ An `RpcTransactionRequest` array representing a traditional ethereum transaction
 
 ### `overrides?: UserOperationOverrides`
 
-Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/sendTransactions.md
+++ b/site/packages/aa-core/provider/sendTransactions.md
@@ -74,3 +74,7 @@ A Promise containing the transaction hash
 ### `request: RpcTransactionRequest[]`
 
 An `RpcTransactionRequest` array representing a traditional ethereum transaction
+
+### `overrides?: UserOperationOverrides`
+
+Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/sendUserOperation.md
+++ b/site/packages/aa-core/provider/sendUserOperation.md
@@ -70,3 +70,7 @@ A Promise containing the hash of the user operation and the request that was sen
 - `target: Address` - the target of the call (equivalent to `to` in a transaction)
 - `data: Hex` - can be either `0x` or a call data string
 - `value?: bigint` - optionally, set the value in wei you want to send to the target
+
+### `overrides?: UserOperationOverrides`
+
+Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request

--- a/site/packages/aa-core/provider/sendUserOperation.md
+++ b/site/packages/aa-core/provider/sendUserOperation.md
@@ -73,4 +73,4 @@ A Promise containing the hash of the user operation and the request that was sen
 
 ### `overrides?: UserOperationOverrides`
 
-Optional paramter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas` or `paymasterAndData` on the user operation request


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `overrides` parameter to `dropAndReplaceUserOperation`, `sendUserOperation`, `sendTransactions`, `buildUserOperationFromTx`, `sendTransaction`, `buildUserOperation` functions in `SmartAccountProvider` class.
- The `overrides` parameter allows specifying override values for `maxFeePerGas`, `maxPriorityFeePerGas`, and `paymasterAndData` on the user operation request.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->