### PR TITLE
fix: fix e2e tests

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@alchemy/aa-alchemy": "^1.0.0",
-    "@alchemy/aa-core": "^0.2.0",
+    "@alchemy/aa-core": "^1.0.0",
     "typescript": "^5.0.4",
     "typescript-template": "*",
     "vitest": "^0.31.0"

--- a/packages/alchemy/e2e-tests/simple-account.test.ts
+++ b/packages/alchemy/e2e-tests/simple-account.test.ts
@@ -4,7 +4,13 @@ import {
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
 import { Alchemy, Network } from "alchemy-sdk";
-import { toHex, type Address, type Chain, type Hash } from "viem";
+import {
+  toHex,
+  type Address,
+  type Chain,
+  type Hash,
+  type HDAccount,
+} from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 import { AlchemyProvider } from "../src/provider.js";
@@ -15,7 +21,7 @@ const network = Network.ETH_SEPOLIA;
 
 describe("Simple Account Tests", () => {
   const ownerAccount = mnemonicToAccount(OWNER_MNEMONIC);
-  const owner: SmartAccountSigner = {
+  const owner: SmartAccountSigner<HDAccount> = {
     signMessage: async (msg) =>
       ownerAccount.signMessage({
         message: { raw: toHex(msg) },
@@ -23,6 +29,7 @@ describe("Simple Account Tests", () => {
     signTypedData: async () => "0xHash",
     getAddress: async () => ownerAccount.address,
     signerType: "aa-sdk-tests",
+    inner: ownerAccount,
   };
 
   it("should successfully get counterfactual address", async () => {
@@ -180,6 +187,10 @@ describe("Simple Account Tests", () => {
           "contractAddress": "0xdcf5d3e08c5007dececdb34808c49331bd82a247",
           "tokenBalance": "0x00000000000000000000000000000000000000000000000000000000000f423f",
         },
+        {
+          "contractAddress": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
+          "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        },
       ]
     `);
   }, 50000);
@@ -223,6 +234,9 @@ const givenConnectedProvider = ({
     apiKey: API_KEY!,
     chain,
     feeOpts,
+    opts: {
+      txMaxRetries: 10,
+    },
   }).connect(
     (provider) =>
       new SimpleSmartContractAccount({

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -39,7 +39,7 @@
     "test:run-e2e": "vitest run --config vitest.config.e2e.ts"
   },
   "devDependencies": {
-    "@alchemy/aa-core": "^0.2.0",
+    "@alchemy/aa-core": "^1.0.0",
     "typescript": "^5.0.4",
     "typescript-template": "*",
     "vitest": "^0.31.0"


### PR DESCRIPTION
e2e tests were failing with the update for alchemy enhanced apis and signer update. cc: @avasisht23

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated `@alchemy/aa-core` dependency to version `1.0.0` in `packages/alchemy/package.json` and `packages/accounts/package.json`.
- Imported `type HDAccount` from `viem` in `packages/alchemy/e2e-tests/simple-account.test.ts`.
- Added `opts` object with `txMaxRetries` property in the `givenConnectedProvider` function in `packages/alchemy/e2e-tests/simple-account.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->