### PR TITLE
feat: add a sign user operation hash method to allow for difference between 1271 and UO signing

### DIFF
--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -151,6 +151,17 @@ export abstract class BaseSmartContractAccount<
   // #region optional-methods
 
   /**
+   * If your account handles 1271 signatures of personal_sign differently
+   * than it does UserOperations, you can implement two different approaches to signing
+   *
+   * @param uoHash -- The hash of the UserOperation to sign
+   * @returns the signature of the UserOperation
+   */
+  async signUserOperationHash(uoHash: Hash): Promise<Hash> {
+    return this.signMessage(uoHash);
+  }
+
+  /**
    * If your contract supports signing and verifying typed data,
    * you should implement this method.
    *

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -57,6 +57,15 @@ export interface ISmartContractAccount {
   getNonce(): Promise<bigint>;
 
   /**
+   * If your account handles 1271 signatures of personal_sign differently
+   * than it does UserOperations, you can implement two different approaches to signing
+   *
+   * @param uoHash -- The hash of the UserOperation to sign
+   * @returns the signature of the UserOperation
+   */
+  signUserOperationHash(uoHash: Hash): Promise<Hash>;
+
+  /**
    * Returns a signed and prefixed message.
    *
    * @param msg - the message to sign

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -444,7 +444,7 @@ export class SmartAccountProvider<
       );
     }
 
-    request.signature = (await this.account.signMessage(
+    request.signature = (await this.account.signUserOperationHash(
       getUserOperationHash(
         request,
         this.getEntryPointAddress(),


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, see guidleines below)
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:fix`)
- [ ] Is the base branch you're merging into `development` and not `main`?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new method `signUserOperationHash` to the `Account` class. This method allows for signing user operation hashes separately from other types of signatures.

### Detailed summary
- Added `signUserOperationHash` method to the `Account` class in `base.ts`
- Updated `request.signature` to use `signUserOperationHash` in `base.ts`
- Added `signUserOperationHash` method to the `Account` interface in `types.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->