### PR TITLE
feat: use zod input for runtime validation everywhere

### DIFF
--- a/packages/alchemy/src/provider/base.ts
+++ b/packages/alchemy/src/provider/base.ts
@@ -26,8 +26,8 @@ import type { AlchemyProviderConfig } from "../type.js";
 export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {
   private rpcUrl: string;
 
-  constructor(config: AlchemyProviderConfig) {
-    AlchemyProviderConfigSchema.parse(config);
+  constructor(config_: AlchemyProviderConfig) {
+    const config = AlchemyProviderConfigSchema.parse(config_);
 
     const { chain, entryPointAddress, opts, ...connectionConfig } = config;
     const _chain =

--- a/packages/alchemy/src/type.ts
+++ b/packages/alchemy/src/type.ts
@@ -5,10 +5,10 @@ import type {
   LightAccountAlchemyProviderConfigSchema,
 } from "./schema.js";
 
-export type ConnectionConfig = z.infer<typeof ConnectionConfigSchema>;
+export type ConnectionConfig = z.input<typeof ConnectionConfigSchema>;
 
-export type AlchemyProviderConfig = z.infer<typeof AlchemyProviderConfigSchema>;
+export type AlchemyProviderConfig = z.input<typeof AlchemyProviderConfigSchema>;
 
-export type LightAccountAlchemyProviderConfig = z.infer<
+export type LightAccountAlchemyProviderConfig = z.input<
   typeof LightAccountAlchemyProviderConfigSchema
 >;

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -14,11 +14,11 @@ export type SignTypedDataParams = Omit<SignTypedDataParameters, "privateKey">;
 
 export type BaseSmartAccountParams<
   TTransport extends SupportedTransports = Transport
-> = z.infer<ReturnType<typeof createBaseSmartAccountParamsSchema<TTransport>>>;
+> = z.input<ReturnType<typeof createBaseSmartAccountParamsSchema<TTransport>>>;
 
 export type SimpleSmartAccountParams<
   TTransport extends SupportedTransports = Transport
-> = z.infer<ReturnType<typeof SimpleSmartAccountParamsSchema<TTransport>>>;
+> = z.input<ReturnType<typeof SimpleSmartAccountParamsSchema<TTransport>>>;
 
 export interface ISmartContractAccount {
   /**

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -46,7 +46,10 @@ import {
   resolveProperties,
   type Deferrable,
 } from "../utils/index.js";
-import { createSmartAccountProviderConfigSchema } from "./schema.js";
+import {
+  SmartAccountProviderOptsSchema,
+  createSmartAccountProviderConfigSchema,
+} from "./schema.js";
 import type {
   AccountMiddlewareFn,
   AccountMiddlewareOverrideFn,
@@ -85,23 +88,26 @@ export class SmartAccountProvider<
     | PublicErc4337Client<TTransport>
     | PublicErc4337Client<HttpTransport>;
 
-  constructor(config: SmartAccountProviderConfig<TTransport>) {
-    createSmartAccountProviderConfigSchema<TTransport>().parse(config);
+  constructor(config_: SmartAccountProviderConfig<TTransport>) {
+    const config =
+      createSmartAccountProviderConfigSchema<TTransport>().parse(config_);
 
-    const { rpcProvider, entryPointAddress, chain, opts } = config;
+    const { rpcProvider, entryPointAddress, chain, opts: opts_ } = config;
+
+    const opts = SmartAccountProviderOptsSchema.parse(opts_);
 
     super();
 
     this.chain = chain;
 
-    this.txMaxRetries = opts?.txMaxRetries ?? 5;
-    this.txRetryIntervalMs = opts?.txRetryIntervalMs ?? 2000;
-    this.txRetryMulitplier = opts?.txRetryMulitplier ?? 1.5;
+    this.txMaxRetries = opts.txMaxRetries;
+    this.txRetryIntervalMs = opts.txRetryIntervalMs;
+    this.txRetryMulitplier = opts.txRetryMulitplier;
     this.entryPointAddress = entryPointAddress;
 
     this.feeOptions = {
       ...getDefaultUserOperationFeeOptions(chain),
-      ...opts?.feeOptions,
+      ...opts.feeOptions,
     };
 
     this.rpcClient =

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -46,10 +46,7 @@ import {
   resolveProperties,
   type Deferrable,
 } from "../utils/index.js";
-import {
-  SmartAccountProviderOptsSchema,
-  createSmartAccountProviderConfigSchema,
-} from "./schema.js";
+import { createSmartAccountProviderConfigSchema } from "./schema.js";
 import type {
   AccountMiddlewareFn,
   AccountMiddlewareOverrideFn,
@@ -92,9 +89,7 @@ export class SmartAccountProvider<
     const config =
       createSmartAccountProviderConfigSchema<TTransport>().parse(config_);
 
-    const { rpcProvider, entryPointAddress, chain, opts: opts_ } = config;
-
-    const opts = SmartAccountProviderOptsSchema.parse(opts_);
+    const { rpcProvider, entryPointAddress, chain, opts } = config;
 
     super();
 

--- a/packages/core/src/provider/schema.ts
+++ b/packages/core/src/provider/schema.ts
@@ -65,6 +65,8 @@ export const createSmartAccountProviderConfigSchema = <
      * when using Alchemy as your RPC provider.
      */
     entryPointAddress: Address.optional(),
-    opts: SmartAccountProviderOptsSchema.optional(),
+    opts: SmartAccountProviderOptsSchema.optional().default(
+      SmartAccountProviderOptsSchema.parse({})
+    ),
   });
 };

--- a/packages/core/src/provider/schema.ts
+++ b/packages/core/src/provider/schema.ts
@@ -28,17 +28,17 @@ export const SmartAccountProviderOptsSchema = z
     /**
      * The maximum number of times to try fetching a transaction receipt before giving up (default: 5)
      */
-    txMaxRetries: z.number().min(0).optional(),
+    txMaxRetries: z.number().min(0).optional().default(5),
 
     /**
      * The interval in milliseconds to wait between retries while waiting for tx receipts (default: 2_000)
      */
-    txRetryIntervalMs: z.number().min(0).optional(),
+    txRetryIntervalMs: z.number().min(0).optional().default(2_000),
 
     /**
      * The mulitplier on interval length to wait between retries while waiting for tx receipts (default: 1.5)
      */
-    txRetryMulitplier: z.number().min(0).optional(),
+    txRetryMulitplier: z.number().min(0).optional().default(1.5),
 
     /**
      * Optional user operation fee options to be set globally at the provider level

--- a/packages/core/src/provider/types.ts
+++ b/packages/core/src/provider/types.ts
@@ -86,13 +86,13 @@ export type FeeDataMiddleware = AccountMiddlewareOverrideFn<
   "maxFeePerGas" | "maxPriorityFeePerGas"
 >;
 
-export type SmartAccountProviderOpts = z.infer<
+export type SmartAccountProviderOpts = z.input<
   typeof SmartAccountProviderOptsSchema
 >;
 
 export type SmartAccountProviderConfig<
   TTransport extends SupportedTransports = Transport
-> = z.infer<
+> = z.input<
   ReturnType<typeof createSmartAccountProviderConfigSchema<TTransport>>
 >;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,16 +11,16 @@ import type {
   PercentageSchema,
 } from "./utils";
 
-export type Hex = z.infer<typeof HexSchema>;
+export type Hex = z.input<typeof HexSchema>;
 export type EmptyHex = `0x`;
 
 // based on @account-abstraction/common
 export type PromiseOrValue<T> = T | Promise<T>;
 export type BytesLike = Uint8Array | Hex;
-export type Percentage = z.infer<typeof PercentageSchema>;
+export type Percentage = z.input<typeof PercentageSchema>;
 
-export type BigNumberish = z.infer<typeof BigNumberishSchema>;
-export type BigNumberishRange = z.infer<typeof BigNumberishRangeSchema>;
+export type BigNumberish = z.input<typeof BigNumberishSchema>;
+export type BigNumberishRange = z.input<typeof BigNumberishRangeSchema>;
 
 export type UserOperationCallData =
   | {
@@ -35,11 +35,11 @@ export type UserOperationCallData =
 
 export type BatchUserOperationCallData = Exclude<UserOperationCallData, Hex>[];
 
-export type UserOperationFeeOptionsField = z.infer<
+export type UserOperationFeeOptionsField = z.input<
   typeof UserOperationFeeOptionsFieldSchema
 >;
 
-export type UserOperationFeeOptions = z.infer<
+export type UserOperationFeeOptions = z.input<
   typeof UserOperationFeeOptionsSchema
 >;
 

--- a/packages/ethers/src/provider-adapter.ts
+++ b/packages/ethers/src/provider-adapter.ts
@@ -19,8 +19,8 @@ import type { EthersProviderAdapterOpts } from "./types.js";
 export class EthersProviderAdapter extends JsonRpcProvider {
   readonly accountProvider: SmartAccountProvider<HttpTransport>;
 
-  constructor(opts: EthersProviderAdapterOpts) {
-    EthersProviderAdapterOptsSchema.parse(opts);
+  constructor(opts_: EthersProviderAdapterOpts) {
+    const opts = EthersProviderAdapterOptsSchema.parse(opts_);
 
     super();
     if ("accountProvider" in opts) {

--- a/packages/ethers/src/types.ts
+++ b/packages/ethers/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { EthersProviderAdapterOptsSchema } from "./schema";
 
-export type EthersProviderAdapterOpts = z.infer<
+export type EthersProviderAdapterOpts = z.input<
   typeof EthersProviderAdapterOptsSchema
 >;


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the types and schemas in the codebase. 

### Detailed summary
- Updated `EthersProviderAdapterOpts` type to use `z.input` instead of `z.infer`
- Updated `SmartAccountProviderOpts` type to use `z.input` instead of `z.infer`
- Updated `SmartAccountProviderConfig` type to use `z.input` instead of `z.infer`
- Updated `ConnectionConfig` type to use `z.input` instead of `z.infer`
- Updated `AlchemyProviderConfig` type to use `z.input` instead of `z.infer`
- Updated `LightAccountAlchemyProviderConfig` type to use `z.input` instead of `z.infer`
- Updated `BaseSmartAccountParams` type to use `z.input` instead of `z.infer`
- Updated `SimpleSmartAccountParams` type to use `z.input` instead of `z.infer`
- Updated `txMaxRetries` property in `SmartAccountProvider` class to have a default value of 5
- Updated `txRetryIntervalMs` property in `SmartAccountProvider` class to have a default value of 2000
- Updated `txRetryMulitplier` property in `SmartAccountProvider` class to have a default value of 1.5
- Updated `Hex` type to use `z.input` instead of `z.infer`
- Updated `Percentage` type to use `z.input` instead of `z.infer`
- Updated `BigNumberish` type to use `z.input` instead of `z.infer`
- Updated `BigNumberishRange` type to use `z.input` instead of `z.infer`
- Updated `UserOperationFeeOptionsField` type to use `z.input` instead of `z.infer`
- Updated `UserOperationFeeOptions` type to use `z.input` instead of `z.infer`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->