### PR TITLE
feat: update eth_getUserOperationByHash response for pending status

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,11 +96,11 @@ export interface UserOperationResponse {
   userOperation: UserOperationRequest;
   /* the address of the entry point contract that executed the user operation */
   entryPoint: Address;
-  /* the block number the user operation was included in */
+  /* the block number the user operation was included in, null if UO is pending */
   blockNumber: BigNumberish | null;
-  /* the hash of the block the user operation was included in */
+  /* the hash of the block the user operation was included in, null if UO is pending */
   blockHash: Hash | null;
-  /* the hash of the transaction that included the user operation */
+  /* the hash of the transaction that included the user operation, null if UO is pending */
   transactionHash: Hash | null;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -97,11 +97,11 @@ export interface UserOperationResponse {
   /* the address of the entry point contract that executed the user operation */
   entryPoint: Address;
   /* the block number the user operation was included in */
-  blockNumber: BigNumberish;
+  blockNumber: BigNumberish | null;
   /* the hash of the block the user operation was included in */
-  blockHash: Hash;
+  blockHash: Hash | null;
   /* the hash of the transaction that included the user operation */
-  transactionHash: Hash;
+  transactionHash: Hash | null;
 }
 
 export interface UserOperationReceipt {


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `UserOperationReceipt` interface in the `types.ts` file. 

### Detailed summary
- Updated `blockNumber` property to accept `null` if the user operation is pending.
- Updated `blockHash` property to accept `null` if the user operation is pending.
- Updated `transactionHash` property to accept `null` if the user operation is pending.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->