### PR TITLE
docs: add disclaimer about UO simulations

### DIFF
--- a/site/tutorials/sim-user-operation.md
+++ b/site/tutorials/sim-user-operation.md
@@ -25,6 +25,14 @@ prev:
 
 This guide will show you how to simulate a `UserOperation` (UO) with Account Kit by adding support for UO simulation on an `AlchemyProvider` and sending a User Operation from that provider only if simulation passes. By the end of this guide, you'll have a basic understanding of how to safely send UOs with the `aa-sdk`.
 
+::: warning NOTE
+Please note that the UO simulation results are based on the blockchain's state at the time of simulation. Changes in the blockchain state, such as updates to contract variables or balances, can occur between the time of simulation and when your UO actually gets executed.
+
+This could lead to different outcomes than predicted. For instance, if a UO's effect is conditional on the current state of a contract, and this state is altered before the UO is executed, the final result may not match the simulation.
+
+Please be aware of this potential variance and consider it while using UO simulations.
+:::
+
 There are two ways that Account Kit supports UO simulation on an `AlchemyProvider`:
 
 1. using the [`withAlchemyUserOpSimulation`](/packages/aa-alchemy/provider/withAlchemyUserOpSimulation) middleware


### PR DESCRIPTION
![image](https://github.com/alchemyplatform/aa-sdk/assets/83442423/30989d28-6d29-458c-a9d7-5aca76bb0293)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for User Operation (UO) simulation on an `AlchemyProvider` in Account Kit. It includes a note on potential variances in UO simulation results and two ways to support UO simulation on an `AlchemyProvider`. 

### Detailed summary
- Added a note on potential variances in UO simulation results due to changes in blockchain state.
- Added support for UO simulation on an `AlchemyProvider` in Account Kit.
- Explained two ways to support UO simulation on an `AlchemyProvider`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->