### PR TITLE
feat: msca plugin provider decorator to support user op overrides

### DIFF
--- a/packages/accounts/scripts/plugingen.ts
+++ b/packages/accounts/scripts/plugingen.ts
@@ -135,7 +135,7 @@ export function plugingen({
           .map((n) => {
             const argsParamString =
               n.inputs.length > 0
-                ? `{ args }: GetFunctionArgs<typeof ${executionAbiConst}, "${n.name}">`
+                ? `{ args }: GetFunctionArgs<typeof ${executionAbiConst}, "${n.name}">, overrides?: UserOperationOverrides`
                 : "";
             const argsEncodeString = n.inputs.length > 0 ? "args," : "";
 
@@ -147,7 +147,7 @@ export function plugingen({
                 ${argsEncodeString}
               });
 
-              return provider.sendUserOperation(callData);
+              return provider.sendUserOperation(callData, overrides);
             }
           `;
           });
@@ -193,7 +193,7 @@ export function plugingen({
         import { type Address, type GetFunctionArgs, encodeFunctionData } from "viem";
         import type { Plugin } from "./types";
         import type { IMSCA } from "../builder";
-        import type { ISmartAccountProvider, SupportedTransports } from "@alchemy/aa-core";
+        import type { ISmartAccountProvider, SupportedTransports, UserOperationOverrides } from "@alchemy/aa-core";
       `;
 
       return {

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -51,10 +51,17 @@ export {
 
 export { pluginManagerDecorator } from "./msca/plugin-manager/decorator.js";
 export type * from "./msca/plugin-manager/installPlugin.js";
-export { installPlugin } from "./msca/plugin-manager/installPlugin.js";
+export {
+  encodeInstallPluginUserOperation,
+  installPlugin,
+} from "./msca/plugin-manager/installPlugin.js";
 export type * from "./msca/plugin-manager/types.js";
 export type * from "./msca/plugin-manager/uninstallPlugin.js";
-export { uninstallPlugin } from "./msca/plugin-manager/uninstallPlugin.js";
+export {
+  encodeUninstallPluginUserOperation,
+  uninstallPlugin,
+} from "./msca/plugin-manager/uninstallPlugin.js";
+export { type Plugin } from "./msca/plugins/types.js";
 
 export {
   MultiOwnerPlugin,
@@ -64,3 +71,7 @@ export {
   SessionKeyPlugin,
   SessionKeyPluginExecutionFunctionAbi,
 } from "./msca/plugins/session-key.js";
+export {
+  TokenReceiverPlugin,
+  TokenReceiverPluginExecutionFunctionAbi,
+} from "./msca/plugins/token-receiver.js";

--- a/packages/accounts/src/msca/account-loupe/utils.ts
+++ b/packages/accounts/src/msca/account-loupe/utils.ts
@@ -1,11 +1,11 @@
-import { encodePacked, parseAbiParameters, type Address, type Hex } from "viem";
+import { encodePacked, type Address, type Hex } from "viem";
 
 export const encodeFunctionReference = (
   pluginAddress: Address,
   functionId: Hex
 ) => {
-  return encodePacked(parseAbiParameters("address, uint8"), [
-    pluginAddress,
-    functionId,
-  ]);
+  return encodePacked(
+    ["address", "uint8"],
+    [pluginAddress, Number(functionId)]
+  );
 };

--- a/packages/accounts/src/msca/multi-owner-account.ts
+++ b/packages/accounts/src/msca/multi-owner-account.ts
@@ -126,7 +126,6 @@ export const createMultiOwnerMSCA = <
   let account = builder
     .build(params)
     .extendWithPluginMethods(MultiOwnerPlugin)
-    .extendWithPluginMethods(TokenReceiverPlugin)
     .extend(accountLoupeDecorators);
 
   if (params.excludeDefaultTokenReceiverPlugin) {

--- a/packages/accounts/src/msca/plugin-manager/installPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/installPlugin.ts
@@ -1,4 +1,7 @@
-import type { ISmartAccountProvider } from "@alchemy/aa-core";
+import type {
+  ISmartAccountProvider,
+  UserOperationOverrides,
+} from "@alchemy/aa-core";
 import {
   encodeFunctionData,
   encodeFunctionResult,
@@ -22,6 +25,17 @@ export type InstallPluginParams = {
 
 export async function installPlugin<
   P extends ISmartAccountProvider & { account: IMSCA<any, any> }
+>(
+  provider: P,
+  params: InstallPluginParams,
+  overrides?: UserOperationOverrides
+) {
+  const callData = await encodeInstallPluginUserOperation(provider, params);
+  return provider.sendUserOperation(callData, overrides);
+}
+
+export async function encodeInstallPluginUserOperation<
+  P extends ISmartAccountProvider & { account: IMSCA<any, any> }
 >(provider: P, params: InstallPluginParams) {
   const pluginManifest = await provider.rpcClient.readContract({
     abi: IPluginAbi,
@@ -38,8 +52,7 @@ export async function installPlugin<
         result: pluginManifest,
       })
     );
-
-  const callData = encodeFunctionData({
+  return encodeFunctionData({
     abi: IPluginManagerAbi,
     functionName: "installPlugin",
     args: [
@@ -50,6 +63,4 @@ export async function installPlugin<
       params.injectedHooks ?? [],
     ],
   });
-
-  return provider.sendUserOperation(callData);
 }

--- a/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
@@ -1,4 +1,7 @@
-import type { ISmartAccountProvider } from "@alchemy/aa-core";
+import type {
+  ISmartAccountProvider,
+  UserOperationOverrides,
+} from "@alchemy/aa-core";
 import { encodeFunctionData, type Address, type Hash } from "viem";
 import { IPluginManagerAbi } from "../abis/IPluginManager.js";
 import type { IMSCA } from "../builder.js";
@@ -12,8 +15,19 @@ export type UninstallPluginParams = {
 
 export async function uninstallPlugin<
   P extends ISmartAccountProvider & { account: IMSCA }
->(provider: P, params: UninstallPluginParams) {
-  const callData = encodeFunctionData({
+>(
+  provider: P,
+  params: UninstallPluginParams,
+  overrides?: UserOperationOverrides
+) {
+  const callData = await encodeUninstallPluginUserOperation(params);
+  return provider.sendUserOperation(callData, overrides);
+}
+
+export async function encodeUninstallPluginUserOperation(
+  params: UninstallPluginParams
+) {
+  return encodeFunctionData({
     abi: IPluginManagerAbi,
     functionName: "uninstallPlugin",
     args: [
@@ -23,6 +37,4 @@ export async function uninstallPlugin<
       params.hookUnapplyData ?? [],
     ],
   });
-
-  return provider.sendUserOperation(callData);
 }

--- a/packages/accounts/src/msca/plugins/multi-owner.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner.ts
@@ -4,6 +4,7 @@ import type { IMSCA } from "../builder";
 import type {
   ISmartAccountProvider,
   SupportedTransports,
+  UserOperationOverrides,
 } from "@alchemy/aa-core";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -124,19 +125,22 @@ const MultiOwnerPlugin_ = {
   >(
     provider: P
   ) => ({
-    updateOwners: ({
-      args,
-    }: GetFunctionArgs<
-      typeof MultiOwnerPluginExecutionFunctionAbi,
-      "updateOwners"
-    >) => {
+    updateOwners: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof MultiOwnerPluginExecutionFunctionAbi,
+        "updateOwners"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: MultiOwnerPluginExecutionFunctionAbi,
         functionName: "updateOwners",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
   }),
 };

--- a/packages/accounts/src/msca/plugins/session-key.ts
+++ b/packages/accounts/src/msca/plugins/session-key.ts
@@ -4,6 +4,7 @@ import type { IMSCA } from "../builder";
 import type {
   ISmartAccountProvider,
   SupportedTransports,
+  UserOperationOverrides,
 } from "@alchemy/aa-core";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -95,34 +96,40 @@ const SessionKeyPlugin_ = {
   >(
     provider: P
   ) => ({
-    executeWithSessionKey: ({
-      args,
-    }: GetFunctionArgs<
-      typeof SessionKeyPluginExecutionFunctionAbi,
-      "executeWithSessionKey"
-    >) => {
+    executeWithSessionKey: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof SessionKeyPluginExecutionFunctionAbi,
+        "executeWithSessionKey"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: SessionKeyPluginExecutionFunctionAbi,
         functionName: "executeWithSessionKey",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
 
-    updateSessionKeys: ({
-      args,
-    }: GetFunctionArgs<
-      typeof SessionKeyPluginExecutionFunctionAbi,
-      "updateSessionKeys"
-    >) => {
+    updateSessionKeys: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof SessionKeyPluginExecutionFunctionAbi,
+        "updateSessionKeys"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: SessionKeyPluginExecutionFunctionAbi,
         functionName: "updateSessionKeys",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
   }),
 };

--- a/packages/accounts/src/msca/plugins/token-receiver.ts
+++ b/packages/accounts/src/msca/plugins/token-receiver.ts
@@ -4,6 +4,7 @@ import type { IMSCA } from "../builder";
 import type {
   ISmartAccountProvider,
   SupportedTransports,
+  UserOperationOverrides,
 } from "@alchemy/aa-core";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -79,64 +80,76 @@ const TokenReceiverPlugin_ = {
   >(
     provider: P
   ) => ({
-    tokensReceived: ({
-      args,
-    }: GetFunctionArgs<
-      typeof TokenReceiverPluginExecutionFunctionAbi,
-      "tokensReceived"
-    >) => {
+    tokensReceived: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof TokenReceiverPluginExecutionFunctionAbi,
+        "tokensReceived"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: TokenReceiverPluginExecutionFunctionAbi,
         functionName: "tokensReceived",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
 
-    onErc721Received: ({
-      args,
-    }: GetFunctionArgs<
-      typeof TokenReceiverPluginExecutionFunctionAbi,
-      "onERC721Received"
-    >) => {
+    onErc721Received: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof TokenReceiverPluginExecutionFunctionAbi,
+        "onERC721Received"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: TokenReceiverPluginExecutionFunctionAbi,
         functionName: "onERC721Received",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
 
-    onErc1155Received: ({
-      args,
-    }: GetFunctionArgs<
-      typeof TokenReceiverPluginExecutionFunctionAbi,
-      "onERC1155Received"
-    >) => {
+    onErc1155Received: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof TokenReceiverPluginExecutionFunctionAbi,
+        "onERC1155Received"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: TokenReceiverPluginExecutionFunctionAbi,
         functionName: "onERC1155Received",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
 
-    onErc1155BatchReceived: ({
-      args,
-    }: GetFunctionArgs<
-      typeof TokenReceiverPluginExecutionFunctionAbi,
-      "onERC1155BatchReceived"
-    >) => {
+    onErc1155BatchReceived: (
+      {
+        args,
+      }: GetFunctionArgs<
+        typeof TokenReceiverPluginExecutionFunctionAbi,
+        "onERC1155BatchReceived"
+      >,
+      overrides?: UserOperationOverrides
+    ) => {
       const callData = encodeFunctionData({
         abi: TokenReceiverPluginExecutionFunctionAbi,
         functionName: "onERC1155BatchReceived",
         args,
       });
 
-      return provider.sendUserOperation(callData);
+      return provider.sendUserOperation(callData, overrides);
     },
   }),
 };


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding support for `UserOperationOverrides` in various plugin functions.

### Detailed summary:
- Added `overrides?: UserOperationOverrides` parameter to the `updateOwners`, `executeWithSessionKey`, `updateSessionKeys`, `tokensReceived`, `onERC721Received`, `onERC1155Received`, and `onERC1155BatchReceived` functions in the `MultiOwnerPlugin`, `SessionKeyPlugin`, and `TokenReceiverPlugin` plugins.
- Modified the `plugingen.ts` script to include the `overrides` parameter in the generated code for the `sendUserOperation` function.
- Modified the `uninstallPlugin.ts` and `installPlugin.ts` files to include the `overrides` parameter in the `sendUserOperation` function calls.
- Updated the type imports in various files to include the `UserOperationOverrides` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->