### PR TITLE
feat: implement persistent account state capabilities

### DIFF
--- a/packages/signers/src/particle/__tests__/signer.test.ts
+++ b/packages/signers/src/particle/__tests__/signer.test.ts
@@ -38,6 +38,23 @@ describe("Particle Signer Tests", () => {
     `);
   });
 
+  it("should correctly get auth details if unauthenticated but has active account state", async () => {
+    const signer = await givenSigner(false, true);
+
+    const details = await signer.getAuthDetails();
+    expect(details).toMatchInlineSnapshot(`
+      {
+        "avatar": "test.png",
+        "email": "test@gmail.com",
+        "name": "test",
+        "phone": "1234567890",
+        "token": "test",
+        "uuid": "test",
+        "wallets": [],
+      }
+    `);
+  });
+
   it("should correctly fail to get auth details if unauthenticated", async () => {
     const signer = await givenSigner(false);
 
@@ -80,7 +97,7 @@ describe("Particle Signer Tests", () => {
   });
 });
 
-const givenSigner = async (auth = true) => {
+const givenSigner = async (auth = true, isLogin = false) => {
   const inner = new ParticleNetwork({
     projectId: "test",
     clientKey: "test",
@@ -88,6 +105,8 @@ const givenSigner = async (auth = true) => {
     chainName: "polygon",
     chainId: 80001,
   });
+
+  inner.auth.isLogin = () => isLogin;
 
   inner.auth.getUserInfo = vi.fn().mockResolvedValue({
     uuid: "test",

--- a/packages/signers/src/particle/signer.ts
+++ b/packages/signers/src/particle/signer.ts
@@ -49,6 +49,15 @@ export class ParticleSigner
 
     this.inner = new ParticleNetwork(params);
     this.provider = new ParticleProvider(this.inner.auth);
+
+    if (this.inner.auth.isLogin()) {
+      this.signer = new WalletClientSigner(
+        createWalletClient({
+          transport: custom(this.provider),
+        }),
+        this.signerType
+      );
+    };
   }
 
   readonly signerType = `${signerTypePrefix}particle`;

--- a/packages/signers/src/particle/signer.ts
+++ b/packages/signers/src/particle/signer.ts
@@ -57,7 +57,7 @@ export class ParticleSigner
         }),
         this.signerType
       );
-    };
+    }
   }
 
   readonly signerType = `${signerTypePrefix}particle`;

--- a/packages/signers/src/particle/signer.ts
+++ b/packages/signers/src/particle/signer.ts
@@ -44,6 +44,15 @@ export class ParticleSigner
           ? params.provider
           : new ParticleProvider(this.inner.auth);
 
+      if (this.inner.auth.isLogin()) {
+        this.signer = new WalletClientSigner(
+          createWalletClient({
+            transport: custom(this.provider),
+          }),
+          this.signerType
+        );
+      }
+
       return;
     }
 

--- a/site/packages/aa-signers/particle/authenticate.md
+++ b/site/packages/aa-signers/particle/authenticate.md
@@ -16,7 +16,7 @@ head:
 
 `authenticate` is a method on the `ParticleSigner` which leverages the `Particle` SDK to initiate login and authenticate a user.
 
-You must call this method before accessing the other methods available on the `ParticleSigner`, such as signing messages or typed data or accessing user details.
+You must call this method before accessing the other methods available on the `ParticleSigner`, such as signing messages or typed data or accessing user details. Although, once a user has logged in through `authenticate`, this state will remain constant and `authenticate` will no longer need to be called for access to the other methods; unless the account state is disrupted, upon which `authenticate` will be required once again.
 
 ## Usage
 


### PR DESCRIPTION
# Explanation
This PR adds persistent account state to the Particle Network `aa-signers` package. Particle Network has built-in account persistence (through `isLogin`), although the `aa-signers` package doesn't take advantage of this feature and requires `authenticate` to be called regardless of account state, meaning users need to re-login after every refresh. Now, instead, `signer` will be defined immediately if the user has already been logged in.

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a condition to check if the user is logged in before creating a `WalletClientSigner` in the `ParticleSigner` class. 

### Detailed summary
- Added a condition to check if the user is logged in before creating a `WalletClientSigner` in the `ParticleSigner` class.
- Updated the `authenticate` method documentation in the `ParticleSigner` class to clarify that it only needs to be called once unless the account state is disrupted.
- Added a new test case to verify that the `getAuthDetails` method returns the correct details when the user is unauthenticated but has an active account state.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->