### PR TITLE
fix:  throw better error message when connecting account if invalid rpc url

### DIFF
--- a/packages/core/e2e-tests/simple-account.test.ts
+++ b/packages/core/e2e-tests/simple-account.test.ts
@@ -10,6 +10,8 @@ import { generatePrivateKey } from "viem/accounts";
 import { polygonMumbai } from "viem/chains";
 import { SimpleSmartContractAccount } from "../src/account/simple.js";
 import {
+  createPublicErc4337Client,
+  getDefaultEntryPointAddress,
   getDefaultSimpleAccountFactoryAddress,
   type SmartAccountSigner,
   type UserOperationFeeOptions,
@@ -66,6 +68,23 @@ describe("Simple Account Tests", () => {
     const address = provider.getAddress();
     await expect(address).resolves.not.toThrowError();
     expect(isAddress(await address)).toBe(true);
+  });
+
+  it("should correctly fail to get address if rpc url is invalid", async () => {
+    const addresslessAccount = new SimpleSmartContractAccount({
+      entryPointAddress: getDefaultEntryPointAddress(chain),
+      chain,
+      owner,
+      factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
+      rpcClient: createPublicErc4337Client({
+        chain,
+        rpcUrl: "ALCHEMY_RPC_URL",
+      }),
+    });
+
+    await expect(() =>
+      addresslessAccount.getAddress()
+    ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
 
   it("should correctly handle percentage overrides for buildUserOperation", async () => {

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -1,15 +1,11 @@
 import type { Address } from "viem";
 import { polygonMumbai, sepolia, type Chain } from "viem/chains";
 import { describe, it } from "vitest";
-import { createPublicErc4337Client } from "../../client/create-client.js";
 import { SmartAccountProvider } from "../../provider/base.js";
 import { LocalAccountSigner } from "../../signer/local-account.js";
 import { type SmartAccountSigner } from "../../signer/types.js";
 import type { BatchUserOperationCallData } from "../../types.js";
-import {
-  getDefaultEntryPointAddress,
-  getDefaultSimpleAccountFactoryAddress,
-} from "../../utils/index.js";
+import { getDefaultSimpleAccountFactoryAddress } from "../../utils/index.js";
 import { SimpleSmartContractAccount } from "../simple.js";
 
 describe("Account Simple Tests", () => {
@@ -127,23 +123,6 @@ describe("Account Simple Tests", () => {
 
     const initCode = await account.getInitCode();
     expect(initCode).toMatchInlineSnapshot('"0xdeadbeef"');
-  });
-
-  it("should correctly fail if rpc url is invalid", async () => {
-    const addresslessAccount = new SimpleSmartContractAccount({
-      entryPointAddress: getDefaultEntryPointAddress(chain),
-      chain,
-      owner,
-      factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
-      rpcClient: createPublicErc4337Client({
-        chain,
-        rpcUrl: "ALCHEMY_RPC_URL",
-      }),
-    });
-
-    await expect(() =>
-      addresslessAccount.getAddress()
-    ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
 
   const givenConnectedProvider = ({

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -145,6 +145,7 @@ describe("Account Simple Tests", () => {
       addresslessAccount.getAddress()
     ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
+
   const givenConnectedProvider = ({
     owner,
     chain,

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -1,11 +1,15 @@
 import type { Address } from "viem";
 import { polygonMumbai, sepolia, type Chain } from "viem/chains";
 import { describe, it } from "vitest";
-import { getDefaultSimpleAccountFactoryAddress } from "../../index.js";
+import { createPublicErc4337Client } from "../../client/create-client.js";
 import { SmartAccountProvider } from "../../provider/base.js";
 import { LocalAccountSigner } from "../../signer/local-account.js";
 import { type SmartAccountSigner } from "../../signer/types.js";
 import type { BatchUserOperationCallData } from "../../types.js";
+import {
+  getDefaultEntryPointAddress,
+  getDefaultSimpleAccountFactoryAddress,
+} from "../../utils/index.js";
 import { SimpleSmartContractAccount } from "../simple.js";
 
 describe("Account Simple Tests", () => {
@@ -123,6 +127,23 @@ describe("Account Simple Tests", () => {
 
     const initCode = await account.getInitCode();
     expect(initCode).toMatchInlineSnapshot('"0xdeadbeef"');
+  });
+
+  it("should correctly fail if rpc url is invalid", async () => {
+    const addresslessAccount = new SimpleSmartContractAccount({
+      entryPointAddress: getDefaultEntryPointAddress(chain),
+      chain,
+      owner,
+      factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
+      rpcClient: createPublicErc4337Client({
+        chain,
+        rpcUrl: "ALCHEMY_RPC_URL",
+      }),
+    });
+
+    await expect(() =>
+      addresslessAccount.getAddress()
+    ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
 
   const givenConnectedProvider = ({

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -145,7 +145,6 @@ describe("Account Simple Tests", () => {
       addresslessAccount.getAddress()
     ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
-
   const givenConnectedProvider = ({
     owner,
     chain,

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -265,6 +265,10 @@ export abstract class BaseSmartContractAccount<
           );
           return this.accountAddress;
         }
+
+        if (err.details === "Invalid URL") {
+          throw new Error("Invalid RPC URL.");
+        }
       }
 
       throw new Error("getCounterFactualAddress failed");

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -37,14 +37,6 @@ describe("Base Tests", () => {
   const dummyAccountAddress =
     "0x1234567890123456789012345678901234567890" as Address;
 
-  const addresslessAccount = new SimpleSmartContractAccount({
-    entryPointAddress,
-    chain,
-    owner,
-    factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
-    rpcClient: providerMock.rpcClient,
-  });
-
   const account = new SimpleSmartContractAccount({
     entryPointAddress,
     chain,
@@ -215,12 +207,6 @@ describe("Base Tests", () => {
     }));
 
     expect(newProvider.testMethod()).toEqual("test");
-  });
-
-  it("should correctly fail if rpc url is invalid", async () => {
-    await expect(() =>
-      addresslessAccount.getAddress()
-    ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
 
   it("should correctly do runtime validation when entrypoint is invalid", () => {

--- a/packages/core/src/provider/__tests__/base.test.ts
+++ b/packages/core/src/provider/__tests__/base.test.ts
@@ -37,6 +37,14 @@ describe("Base Tests", () => {
   const dummyAccountAddress =
     "0x1234567890123456789012345678901234567890" as Address;
 
+  const addresslessAccount = new SimpleSmartContractAccount({
+    entryPointAddress,
+    chain,
+    owner,
+    factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
+    rpcClient: providerMock.rpcClient,
+  });
+
   const account = new SimpleSmartContractAccount({
     entryPointAddress,
     chain,
@@ -207,6 +215,12 @@ describe("Base Tests", () => {
     }));
 
     expect(newProvider.testMethod()).toEqual("test");
+  });
+
+  it("should correctly fail if rpc url is invalid", async () => {
+    await expect(() =>
+      addresslessAccount.getAddress()
+    ).rejects.toThrowErrorMatchingInlineSnapshot('"Invalid RPC URL."');
   });
 
   it("should correctly do runtime validation when entrypoint is invalid", () => {

--- a/packages/signers/src/arcana-auth/__tests__/signer.test.ts
+++ b/packages/signers/src/arcana-auth/__tests__/signer.test.ts
@@ -105,7 +105,7 @@ const givenSigner = async (auth = true) => {
           return Promise.reject(new Error("Method not found"));
       }
     },
-  });
+  } as any);
 
   const signer = new ArcanaAuthSigner({ inner });
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling and code organization in the signers and account modules. 

### Detailed summary
- In `packages/signers/src/arcana-auth/__tests__/signer.test.ts`, an object is cast to `any` to fix a type error.
- In `packages/core/src/account/base.ts`, an error is thrown when the RPC URL is invalid.
- In `packages/core/src/account/__tests__/simple.test.ts`, an import statement is updated to use the `utils` module instead of the `index` module.
- In `packages/core/e2e-tests/simple-account.test.ts`, a test case is added to verify that an error is thrown when the RPC URL is invalid.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->