### PR TITLE
fix: correct typos in docs

### DIFF
--- a/site/packages/aa-accounts/utils/getDefaultLightAccountFactoryAddress.md
+++ b/site/packages/aa-accounts/utils/getDefaultLightAccountFactoryAddress.md
@@ -34,7 +34,7 @@ const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
 ### `Address`
 
-The Address of the default Light Account Factory contrafct address for the input chain
+The Address of the default Light Account Factory contract address for the input chain
 
 ## Parameters
 

--- a/site/packages/aa-accounts/utils/getDefaultLightAccountFactoryAddress.md
+++ b/site/packages/aa-accounts/utils/getDefaultLightAccountFactoryAddress.md
@@ -36,7 +36,7 @@ const factoryAddress = getDefaultLightAccountFactoryAddress(chain);
 
 The Address of the default Light Account Factory contrafct address for the input chain
 
-## Paramters
+## Parameters
 
 ### `chain: Chain`
 

--- a/site/packages/aa-alchemy/utils/supportedChains.md
+++ b/site/packages/aa-alchemy/utils/supportedChains.md
@@ -42,4 +42,4 @@ the associated viem `Chain` object.
 
 ## Parameters
 
-### `chainId: number` -- the struct containig UserOperation fields, where each field may be asychronously returned from the middleware used to generate its final value.
+### `chainId: number` -- the struct containing UserOperation fields, where each field may be asychronously returned from the middleware used to generate its final value.

--- a/site/packages/aa-core/provider/withPaymasterMiddleware.md
+++ b/site/packages/aa-core/provider/withPaymasterMiddleware.md
@@ -32,7 +32,7 @@ import { provider } from "./provider";
 // Define the DummyPaymasterDataMiddlewareOverrideFunction // [!code focus:99]
 const DummyPaymasterDataMiddlewareOverrideFunction = async (uoStruct) => {
   // Return an object like {paymasterAndData: "0x..."} where "0x..." is the valid paymasterAndData for your paymaster contract (used in gas estimation)
-  // You can even hardcode these dummy singatures
+  // You can even hardcode these dummy signatures
   // You can read up more on dummy signatures here: https://www.alchemy.com/blog/dummy-signatures-and-gas-token-transfers
   const paymasterAndData = await someFunctionToFetchDummyPaymasterAndData();
 

--- a/site/packages/aa-core/signers/utils/wrapSignatureWith6492.md
+++ b/site/packages/aa-core/signers/utils/wrapSignatureWith6492.md
@@ -38,7 +38,7 @@ const signature = await wrapSignatureWith6492({
 
 The original signature wrapped in ERC-6492 format
 
-## Paramters
+## Parameters
 
 ### `SignWith6492Params`
 

--- a/site/packages/aa-core/utils/getDefaultEntryPointAddress.md
+++ b/site/packages/aa-core/utils/getDefaultEntryPointAddress.md
@@ -34,7 +34,7 @@ const entryPointAddress = getDefaultEntryPointAddress(chain);
 
 ### `Address`
 
-The Address of the default EntryPoint contrafct for the input chain
+The Address of the default EntryPoint contract for the input chain
 
 ## Parameters
 

--- a/site/packages/aa-core/utils/getDefaultEntryPointAddress.md
+++ b/site/packages/aa-core/utils/getDefaultEntryPointAddress.md
@@ -36,7 +36,7 @@ const entryPointAddress = getDefaultEntryPointAddress(chain);
 
 The Address of the default EntryPoint contrafct for the input chain
 
-## Paramters
+## Parameters
 
 ### `chain: Chain`
 

--- a/site/packages/aa-core/utils/getDefaultSimpleAccountFactoryAddress.md
+++ b/site/packages/aa-core/utils/getDefaultSimpleAccountFactoryAddress.md
@@ -36,7 +36,7 @@ const factoryAddress = getDefaultSimpleAccountFactoryAddress(chain);
 
 The Address of the default Simple Account Factory contrafct address for the input chain
 
-## Paramters
+## Parameters
 
 ### `chain: Chain`
 

--- a/site/packages/aa-core/utils/getDefaultSimpleAccountFactoryAddress.md
+++ b/site/packages/aa-core/utils/getDefaultSimpleAccountFactoryAddress.md
@@ -34,7 +34,7 @@ const factoryAddress = getDefaultSimpleAccountFactoryAddress(chain);
 
 ### `Address`
 
-The Address of the default Simple Account Factory contrafct address for the input chain
+The Address of the default Simple Account Factory contract address for the input chain
 
 ## Parameters
 

--- a/site/packages/aa-core/utils/getUserOperationHash.md
+++ b/site/packages/aa-core/utils/getUserOperationHash.md
@@ -41,7 +41,7 @@ const result = getUserOperationHash(
 
 The hash of the user operation
 
-## Paramters
+## Parameters
 
 ### `request: UserOperationRequest`
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Fixed typos in parameter names in multiple files
- Corrected spelling of "contract" in multiple files
- Updated comments to use "signatures" instead of "singatures"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->