### PR TITLE
feat: add session key permissions builder for session key plugin

### DIFF
--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -85,6 +85,7 @@ export {
   MultiOwnerPluginExecutionFunctionAbi,
 } from "./msca/plugins/multi-owner/plugin.js";
 export { SessionKeyExecutor } from "./msca/plugins/session-key/executor.js";
+export { SessionKeyPermissionsBuilder } from "./msca/plugins/session-key/permissions.js";
 export {
   SessionKeyPlugin,
   SessionKeyPluginAbi,

--- a/packages/accounts/src/msca/plugins/session-key/SessionKeyPermissionsUpdatesAbi.ts
+++ b/packages/accounts/src/msca/plugins/session-key/SessionKeyPermissionsUpdatesAbi.ts
@@ -1,0 +1,152 @@
+export const SessionKeyPermissionsUpdatesAbi = [
+  {
+    inputs: [
+      {
+        internalType:
+          "enum ISessionKeyPermissionsPlugin.ContractAccessControlType",
+        name: "contractAccessControlType",
+        type: "uint8",
+      },
+    ],
+    name: "setAccessListType",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "spendLimit",
+        type: "uint256",
+      },
+      {
+        internalType: "uint48",
+        name: "refreshInterval",
+        type: "uint48",
+      },
+    ],
+    name: "setERC20SpendLimit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "spendLimit",
+        type: "uint256",
+      },
+      {
+        internalType: "uint48",
+        name: "refreshInterval",
+        type: "uint48",
+      },
+    ],
+    name: "setGasSpendLimit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "spendLimit",
+        type: "uint256",
+      },
+      {
+        internalType: "uint48",
+        name: "refreshInterval",
+        type: "uint48",
+      },
+    ],
+    name: "setNativeTokenSpendLimit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "requiredPaymaster",
+        type: "address",
+      },
+    ],
+    name: "setRequiredPaymaster",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "contractAddress",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "isOnList",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "checkSelectors",
+        type: "bool",
+      },
+    ],
+    name: "updateAccessListAddressEntry",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "contractAddress",
+        type: "address",
+      },
+      {
+        internalType: "bytes4",
+        name: "selector",
+        type: "bytes4",
+      },
+      {
+        internalType: "bool",
+        name: "isOnList",
+        type: "bool",
+      },
+    ],
+    name: "updateAccessListFunctionEntry",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint48",
+        name: "validAfter",
+        type: "uint48",
+      },
+      {
+        internalType: "uint48",
+        name: "validUntil",
+        type: "uint48",
+      },
+    ],
+    name: "updateTimeRange",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;

--- a/packages/accounts/src/msca/plugins/session-key/permissions.ts
+++ b/packages/accounts/src/msca/plugins/session-key/permissions.ts
@@ -1,0 +1,186 @@
+import { encodeFunctionData, type Address, type Hex } from "viem";
+import { SessionKeyPermissionsUpdatesAbi } from "./SessionKeyPermissionsUpdatesAbi.js";
+
+enum SessionKeyAccessListType {
+  ALLOWLIST = 0,
+  DENYLIST = 1,
+  NONE = 2,
+}
+
+type ContractAccessEntry = {
+  // The contract address to add or remove.
+  contractAddress: Address;
+  // Whether the contract address should be on the list.
+  isOnList: boolean;
+  // Whether to check selectors for the contract address.
+  checkSelectors: boolean;
+};
+
+type ContractMethodEntry = {
+  // The contract address to add or remove.
+  contractAddress: Address;
+  // The function selector to add or remove.
+  methodSelector: Hex;
+  // Whether the function selector should be on the list.
+  isOnList: boolean;
+};
+
+type TimeRange = {
+  validFrom: number;
+  validUntil: number;
+};
+
+type NativeTokenLimit = {
+  spendLimit: bigint;
+  // The time interval over which the spend limit is enforced. If unset, there is no time
+  /// interval by which the limit is refreshed.
+  refreshInterval?: number;
+};
+
+type Erc20TokenLimit = {
+  tokenAddress: Address;
+  spendLimit: bigint;
+  // The time interval over which the spend limit is enforced. If unset, there is no time
+  /// interval by which the limit is refreshed.
+  refreshInterval?: number;
+};
+
+// uint256 spendLimit, uint48 refreshInterval
+type GasSpendLimit = {
+  spendLimit: bigint;
+  // The time interval over which the spend limit is enforced. If unset, there is no time
+  /// interval by which the limit is refreshed.
+  refreshInterval?: number;
+};
+
+export class SessionKeyPermissionsBuilder {
+  private _contractAccessControlType: SessionKeyAccessListType =
+    SessionKeyAccessListType.ALLOWLIST;
+  private _contractAddressAccessEntrys: ContractAccessEntry[] = [];
+  private _contractMethodAccessEntrys: ContractMethodEntry[] = [];
+  private _timeRange?: TimeRange;
+  private _nativeTokenSpendLimit?: NativeTokenLimit;
+  private _erc20TokenSpendLimits: Erc20TokenLimit[] = [];
+  private _gasSpendLimit?: GasSpendLimit;
+  private _requiredPaymaster?: Address;
+
+  public setContractAccessControlType(aclType: SessionKeyAccessListType) {
+    this._contractAccessControlType = aclType;
+    return this;
+  }
+
+  public addContractAddressAccessEntry(entry: ContractAccessEntry) {
+    this._contractAddressAccessEntrys.push(entry);
+    return this;
+  }
+
+  public addContractFunctionAccessEntry(entry: ContractMethodEntry) {
+    this._contractMethodAccessEntrys.push(entry);
+    return this;
+  }
+
+  public setTimeRange(timeRange: TimeRange) {
+    this._timeRange = timeRange;
+    return this;
+  }
+
+  public setNativeTokenSpendLimit(limit: NativeTokenLimit) {
+    this._nativeTokenSpendLimit = limit;
+    return this;
+  }
+
+  public addErc20TokenSpendLimit(limit: Erc20TokenLimit) {
+    this._erc20TokenSpendLimits.push(limit);
+    return this;
+  }
+
+  public setGasSpendLimit(limit: GasSpendLimit) {
+    this._gasSpendLimit = limit;
+    return this;
+  }
+
+  public setRequiredPaymaster(paymaster: Address) {
+    this._requiredPaymaster = paymaster;
+    return this;
+  }
+
+  public encode(): Hex[] {
+    return [
+      encodeFunctionData({
+        abi: SessionKeyPermissionsUpdatesAbi,
+        functionName: "setAccessListType",
+        args: [this._contractAccessControlType],
+      }),
+      ...this._contractAddressAccessEntrys.map((entry) =>
+        encodeFunctionData({
+          abi: SessionKeyPermissionsUpdatesAbi,
+          functionName: "updateAccessListAddressEntry",
+          args: [entry.contractAddress, entry.isOnList, entry.checkSelectors],
+        })
+      ),
+      ...this._contractMethodAccessEntrys.map((entry) =>
+        encodeFunctionData({
+          abi: SessionKeyPermissionsUpdatesAbi,
+          functionName: "updateAccessListFunctionEntry",
+          args: [entry.contractAddress, entry.methodSelector, entry.isOnList],
+        })
+      ),
+      this.encodeIfDefined(
+        (timeRange) =>
+          encodeFunctionData({
+            abi: SessionKeyPermissionsUpdatesAbi,
+            functionName: "updateTimeRange",
+            args: [timeRange.validFrom, timeRange.validUntil],
+          }),
+        this._timeRange
+      ),
+      this.encodeIfDefined(
+        (nativeSpendLimit) =>
+          encodeFunctionData({
+            abi: SessionKeyPermissionsUpdatesAbi,
+            functionName: "setNativeTokenSpendLimit",
+            args: [
+              nativeSpendLimit.spendLimit,
+              nativeSpendLimit.refreshInterval ?? 0,
+            ],
+          }),
+        this._nativeTokenSpendLimit
+      ),
+      ...this._erc20TokenSpendLimits.map((erc20SpendLimit) =>
+        encodeFunctionData({
+          abi: SessionKeyPermissionsUpdatesAbi,
+          functionName: "setERC20SpendLimit",
+          args: [
+            erc20SpendLimit.tokenAddress,
+            erc20SpendLimit.spendLimit,
+            erc20SpendLimit.refreshInterval ?? 0,
+          ],
+        })
+      ),
+      this.encodeIfDefined(
+        (spendLimit) =>
+          encodeFunctionData({
+            abi: SessionKeyPermissionsUpdatesAbi,
+            functionName: "setGasSpendLimit",
+            args: [spendLimit.spendLimit, spendLimit.refreshInterval ?? 0],
+          }),
+        this._gasSpendLimit
+      ),
+      this.encodeIfDefined(
+        (paymaster) =>
+          encodeFunctionData({
+            abi: SessionKeyPermissionsUpdatesAbi,
+            functionName: "setRequiredPaymaster",
+            args: [paymaster],
+          }),
+        this._requiredPaymaster
+      ),
+    ].filter((x) => x === "0x");
+  }
+
+  private encodeIfDefined<T>(encode: (param: T) => Hex, param?: T): Hex {
+    if (!param) return "0x";
+
+    return encode(param);
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to add a new class `SessionKeyPermissionsBuilder` in the `accounts` package. This class allows building and encoding session key permission updates.

### Detailed summary:
- Added `SessionKeyPermissionsBuilder` class in `accounts/src/msca/plugins/session-key/permissions.ts`.
- Added `SessionKeyPermissionsUpdatesAbi` array in `accounts/src/msca/plugins/session-key/SessionKeyPermissionsUpdatesAbi.ts`.
- Added enums, types, and interfaces related to session key permissions.
- Implemented methods in `SessionKeyPermissionsBuilder` to set contract access control type, add contract address access entry, add contract function access entry, set time range, set native token spend limit, add ERC20 token spend limit, set gas spend limit, and set required paymaster.
- Implemented `encode` method in `SessionKeyPermissionsBuilder` to encode the session key permission updates.
- Added utility methods in `SessionKeyPermissionsBuilder` to encode values if they are defined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->