### PR TITLE
feat: add session key executor

### DIFF
--- a/packages/accounts/plugingen/index.ts
+++ b/packages/accounts/plugingen/index.ts
@@ -8,12 +8,19 @@ import dedent from "dedent";
 import { createPublicClient, getContract, http, type Chain } from "viem";
 import type { PluginGenConfig } from "../plugindefs/types.js";
 import { IPluginAbi } from "../src/msca/abis/IPlugin.js";
+import { ContractAbiGenPhase } from "./phases/contract-abi-gen.js";
+import { ContractAddressesGenPhase } from "./phases/contract-addresses-gen.js";
 import { ExecutionAbiGenPhase } from "./phases/execution-abi-gen.js";
 import { PluginGeneratorPhase } from "./phases/plugin-generator/index.js";
 import type { Phase, PhaseInput } from "./types.js";
 
 // Add more phases here if needed
-const phases: Phase[] = [PluginGeneratorPhase, ExecutionAbiGenPhase];
+const phases: Phase[] = [
+  ContractAddressesGenPhase,
+  PluginGeneratorPhase,
+  ExecutionAbiGenPhase,
+  ContractAbiGenPhase,
+];
 
 export function plugingen({
   chain,

--- a/packages/accounts/plugingen/phases/contract-abi-gen.ts
+++ b/packages/accounts/plugingen/phases/contract-abi-gen.ts
@@ -1,0 +1,10 @@
+import dedent from "dedent";
+import type { Phase } from "../types";
+
+export const ContractAbiGenPhase: Phase = async (input) => {
+  const { contract, content } = input;
+  content.push(dedent`
+    export const ${contract.name}Abi = ${JSON.stringify(contract.abi)} as const;
+  `);
+  return input;
+};

--- a/packages/accounts/plugingen/phases/contract-addresses-gen.ts
+++ b/packages/accounts/plugingen/phases/contract-addresses-gen.ts
@@ -1,0 +1,18 @@
+import dedent from "dedent";
+import type { Address } from "viem";
+import type { Phase } from "../types";
+
+export const ContractAddressesGenPhase: Phase = async (input) => {
+  const { contract, content, addImport } = input;
+
+  addImport("viem", { name: "Address", isType: true });
+  content.push(dedent`
+    const addresses = {${Object.entries(
+      contract.address as Record<number, Address>
+    ).reduce(
+      (prev, [chainId, addr]) => (prev += `${chainId}: "${addr}" as Address, `),
+      ""
+    )}} as Record<number, Address>;
+  `);
+  return input;
+};

--- a/packages/accounts/plugingen/phases/plugin-generator/get-contract-gen.ts
+++ b/packages/accounts/plugingen/phases/plugin-generator/get-contract-gen.ts
@@ -1,0 +1,23 @@
+import dedent from "dedent";
+import type { Phase } from "../../types";
+
+export const GetContractGenPhase: Phase = async (input) => {
+  const { content, contract, addImport } = input;
+
+  addImport("viem", { name: "getContract", isType: false });
+  addImport("viem", { name: "GetContractReturnType", isType: true });
+  addImport("viem", { name: "Address", isType: true });
+  content.push(dedent`
+  getContract: (
+    provider: ISmartAccountProvider,
+    address?: Address
+  ): GetContractReturnType<typeof ${contract.name}Abi, typeof provider.rpcClient, undefined, Address> =>
+    getContract({
+      address: address || addresses[provider.rpcClient.chain.id],
+      abi: ${contract.name}Abi,
+      publicClient: provider.rpcClient,
+    })
+  `);
+
+  return input;
+};

--- a/packages/accounts/plugingen/phases/plugin-generator/index.ts
+++ b/packages/accounts/plugingen/phases/plugin-generator/index.ts
@@ -2,12 +2,14 @@ import { asyncPipe } from "@alchemy/aa-core";
 import dedent from "dedent";
 import type { Phase } from "../../types";
 import { AccountMethodGenPhase } from "./account-method-gen.js";
+import { GetContractGenPhase } from "./get-contract-gen.js";
 import { MetaGenPhase } from "./meta-gen.js";
 import { ProviderMethodGenPhase } from "./provider-method-gen/index.js";
 
 export const PluginGeneratorPhase: Phase = async (input) => {
   const pluginPhases: Phase[] = [
     MetaGenPhase,
+    GetContractGenPhase,
     AccountMethodGenPhase,
     ProviderMethodGenPhase,
   ];
@@ -22,13 +24,13 @@ export const PluginGeneratorPhase: Phase = async (input) => {
   input.content.push(dedent`
     const ${contract.name}_ = {
         ${result.content.join(",\n")}
-    }; 
+    };
 
     export const ${contract.name}: Plugin<ReturnType<typeof ${
     contract.name
   }_["accountMethods"]>, ReturnType<typeof ${
     contract.name
-  }_["providerMethods"]>> = ${contract.name}_;
+  }_["providerMethods"]>, typeof ${contract.name}Abi> = ${contract.name}_;
   `);
 
   return input;

--- a/packages/accounts/plugingen/phases/plugin-generator/meta-gen.ts
+++ b/packages/accounts/plugingen/phases/plugin-generator/meta-gen.ts
@@ -1,23 +1,15 @@
 import dedent from "dedent";
-import type { Address } from "viem";
 import type { Phase } from "../../types";
 
 export const MetaGenPhase: Phase = async (input) => {
-  const { plugin, content, contract, addImport } = input;
+  const { plugin, content } = input;
   const { name, version } = await plugin.read.pluginMetadata();
 
-  addImport("viem", { name: "Address", isType: true });
   content.push(dedent`
     meta: {
         name: "${name}",
         version: "${version}",
-        addresses: {${Object.entries(
-          contract.address as Record<number, Address>
-        ).reduce(
-          (prev, [chainId, addr]) =>
-            (prev += `${chainId}: "${addr}" as Address, `),
-          ""
-        )}} as Record<number, Address>,
+        addresses,
     }
   `);
 

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -83,6 +83,7 @@ export {
   MultiOwnerPluginAbi,
   MultiOwnerPluginExecutionFunctionAbi,
 } from "./msca/plugins/multi-owner/plugin.js";
+export { SessionKeyExecutor } from "./msca/plugins/session-key/executor.js";
 export {
   SessionKeyPlugin,
   SessionKeyPluginAbi,

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -80,13 +80,16 @@ export { type Plugin } from "./msca/plugins/types.js";
 
 export {
   MultiOwnerPlugin,
+  MultiOwnerPluginAbi,
   MultiOwnerPluginExecutionFunctionAbi,
 } from "./msca/plugins/multi-owner/plugin.js";
 export {
   SessionKeyPlugin,
+  SessionKeyPluginAbi,
   SessionKeyPluginExecutionFunctionAbi,
 } from "./msca/plugins/session-key/plugin.js";
 export {
   TokenReceiverPlugin,
+  TokenReceiverPluginAbi,
   TokenReceiverPluginExecutionFunctionAbi,
 } from "./msca/plugins/token-receiver/plugin.js";

--- a/packages/accounts/src/msca/builder/index.ts
+++ b/packages/accounts/src/msca/builder/index.ts
@@ -6,7 +6,7 @@ import {
   type SignTypedDataParams,
   type SupportedTransports,
 } from "@alchemy/aa-core";
-import { type Transport } from "viem";
+import { type Abi, type Transport } from "viem";
 import { z } from "zod";
 import { pluginManagerDecorator } from "../plugin-manager/decorator.js";
 import type { Plugin } from "../plugins/types";
@@ -105,8 +105,8 @@ export class MSCABuilder {
         return factory(this);
       }
 
-      extendWithPluginMethods = <AD, PD>(
-        plugin: Plugin<AD, PD>
+      extendWithPluginMethods = <AD, PD, TAbi extends Abi>(
+        plugin: Plugin<AD, PD, TAbi>
       ): DynamicMSCA<TProviderDecorators & PD> & AD => {
         const methods = plugin.accountMethods(this);
         const result = Object.assign(this, methods) as unknown as DynamicMSCA<

--- a/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
@@ -1,10 +1,12 @@
-import { type Plugin } from "../types.js";
 import {
+  getContract,
   encodeFunctionData,
   encodeAbiParameters,
   type Address,
+  type GetContractReturnType,
   type GetFunctionArgs,
 } from "viem";
+import { type Plugin } from "../types.js";
 import { type IMSCA } from "../../types.js";
 import {
   type UserOperationOverrides,
@@ -27,14 +29,30 @@ export type InstallMultiOwnerPluginParams = {
   dependencyOverrides?: FunctionReference[];
 };
 
+const addresses = {
+  11155111: "0x56bC629F342821FBe91C5273880792dFECBE7920" as Address,
+} as Record<number, Address>;
+
 const MultiOwnerPlugin_ = {
   meta: {
     name: "Multi Owner Plugin",
     version: "1.0.0",
-    addresses: {
-      11155111: "0x56bC629F342821FBe91C5273880792dFECBE7920" as Address,
-    } as Record<number, Address>,
+    addresses,
   },
+  getContract: (
+    provider: ISmartAccountProvider,
+    address?: Address
+  ): GetContractReturnType<
+    typeof MultiOwnerPluginAbi,
+    typeof provider.rpcClient,
+    undefined,
+    Address
+  > =>
+    getContract({
+      address: address || addresses[provider.rpcClient.chain.id],
+      abi: MultiOwnerPluginAbi,
+      publicClient: provider.rpcClient,
+    }),
   accountMethods: (account: IMSCA<any, any>) => ({
     encodeUpdateOwnersData: ({
       args,
@@ -193,7 +211,8 @@ const MultiOwnerPlugin_ = {
 
 export const MultiOwnerPlugin: Plugin<
   ReturnType<(typeof MultiOwnerPlugin_)["accountMethods"]>,
-  ReturnType<(typeof MultiOwnerPlugin_)["providerMethods"]>
+  ReturnType<(typeof MultiOwnerPlugin_)["providerMethods"]>,
+  typeof MultiOwnerPluginAbi
 > = MultiOwnerPlugin_;
 
 export const MultiOwnerPluginExecutionFunctionAbi = [
@@ -247,5 +266,651 @@ export const MultiOwnerPluginExecutionFunctionAbi = [
     ],
     name: "isValidSignature",
     outputs: [{ name: "", internalType: "bytes4", type: "bytes4" }],
+  },
+] as const;
+
+export const MultiOwnerPluginAbi = [
+  { stateMutability: "nonpayable", type: "constructor", inputs: [] },
+  { type: "error", inputs: [], name: "AlreadyInitialized" },
+  { type: "error", inputs: [], name: "EmptyOwnersNotAllowed" },
+  { type: "error", inputs: [], name: "InvalidAction" },
+  { type: "error", inputs: [], name: "InvalidShortString" },
+  { type: "error", inputs: [], name: "NotAuthorized" },
+  { type: "error", inputs: [], name: "NotContractCaller" },
+  { type: "error", inputs: [], name: "NotImplemented" },
+  { type: "error", inputs: [], name: "NotInitialized" },
+  {
+    type: "error",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "OwnerAlreadyExists",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "owner", internalType: "address", type: "address" }],
+    name: "OwnerDoesNotExist",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "str", internalType: "string", type: "string" }],
+    name: "StringTooLong",
+  },
+  { type: "event", anonymous: false, inputs: [], name: "EIP712DomainChanged" },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "account",
+        internalType: "address",
+        type: "address",
+        indexed: true,
+      },
+      {
+        name: "addedOwners",
+        internalType: "address[]",
+        type: "address[]",
+        indexed: false,
+      },
+      {
+        name: "removedOwners",
+        internalType: "address[]",
+        type: "address[]",
+        indexed: false,
+      },
+    ],
+    name: "OwnerUpdated",
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [],
+    name: "eip712Domain",
+    outputs: [
+      { name: "fields", internalType: "bytes1", type: "bytes1" },
+      { name: "name", internalType: "string", type: "string" },
+      { name: "version", internalType: "string", type: "string" },
+      { name: "chainId", internalType: "uint256", type: "uint256" },
+      { name: "verifyingContract", internalType: "address", type: "address" },
+      { name: "salt", internalType: "bytes32", type: "bytes32" },
+      { name: "extensions", internalType: "uint256[]", type: "uint256[]" },
+    ],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "message", internalType: "bytes", type: "bytes" },
+    ],
+    name: "encodeMessageData",
+    outputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "message", internalType: "bytes", type: "bytes" },
+    ],
+    name: "getMessageHash",
+    outputs: [{ name: "", internalType: "bytes32", type: "bytes32" }],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "ownerToCheck", internalType: "address", type: "address" },
+    ],
+    name: "isOwner",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "account", internalType: "address", type: "address" },
+      { name: "ownerToCheck", internalType: "address", type: "address" },
+    ],
+    name: "isOwnerOf",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "digest", internalType: "bytes32", type: "bytes32" },
+      { name: "signature", internalType: "bytes", type: "bytes" },
+    ],
+    name: "isValidSignature",
+    outputs: [{ name: "", internalType: "bytes4", type: "bytes4" }],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "pluginAppliedOn", internalType: "address", type: "address" },
+      {
+        name: "injectedHooksInfo",
+        internalType: "struct IPluginManager.InjectedHooksInfo",
+        type: "tuple",
+        components: [
+          {
+            name: "preExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+          { name: "isPostHookUsed", internalType: "bool", type: "bool" },
+          {
+            name: "postExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+        ],
+      },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onHookApply",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "pluginAppliedOn", internalType: "address", type: "address" },
+      {
+        name: "injectedHooksInfo",
+        internalType: "struct IPluginManager.InjectedHooksInfo",
+        type: "tuple",
+        components: [
+          {
+            name: "preExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+          { name: "isPostHookUsed", internalType: "bool", type: "bool" },
+          {
+            name: "postExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+        ],
+      },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onHookUnapply",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [{ name: "data", internalType: "bytes", type: "bytes" }],
+    name: "onInstall",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+    name: "onUninstall",
+    outputs: [],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [],
+    name: "owners",
+    outputs: [{ name: "", internalType: "address[]", type: "address[]" }],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [{ name: "account", internalType: "address", type: "address" }],
+    name: "ownersOf",
+    outputs: [{ name: "", internalType: "address[]", type: "address[]" }],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [],
+    name: "pluginManifest",
+    outputs: [
+      {
+        name: "",
+        internalType: "struct PluginManifest",
+        type: "tuple",
+        components: [
+          { name: "interfaceIds", internalType: "bytes4[]", type: "bytes4[]" },
+          {
+            name: "dependencyInterfaceIds",
+            internalType: "bytes4[]",
+            type: "bytes4[]",
+          },
+          {
+            name: "executionFunctions",
+            internalType: "bytes4[]",
+            type: "bytes4[]",
+          },
+          {
+            name: "permittedExecutionSelectors",
+            internalType: "bytes4[]",
+            type: "bytes4[]",
+          },
+          {
+            name: "permitAnyExternalAddress",
+            internalType: "bool",
+            type: "bool",
+          },
+          { name: "canSpendNativeToken", internalType: "bool", type: "bool" },
+          {
+            name: "permittedExternalCalls",
+            internalType: "struct ManifestExternalCallPermission[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "externalAddress",
+                internalType: "address",
+                type: "address",
+              },
+              { name: "permitAnySelector", internalType: "bool", type: "bool" },
+              { name: "selectors", internalType: "bytes4[]", type: "bytes4[]" },
+            ],
+          },
+          {
+            name: "userOpValidationFunctions",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "runtimeValidationFunctions",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "preUserOpValidationHooks",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "preRuntimeValidationHooks",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            internalType: "struct ManifestExecutionHook[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "preExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+              {
+                name: "postExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "permittedCallHooks",
+            internalType: "struct ManifestExecutionHook[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "preExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+              {
+                name: "postExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [],
+    name: "pluginMetadata",
+    outputs: [
+      {
+        name: "",
+        internalType: "struct PluginMetadata",
+        type: "tuple",
+        components: [
+          { name: "name", internalType: "string", type: "string" },
+          { name: "version", internalType: "string", type: "string" },
+          { name: "author", internalType: "string", type: "string" },
+          {
+            name: "permissionDescriptors",
+            internalType: "struct SelectorPermission[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "functionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "permissionDescription",
+                internalType: "string",
+                type: "string",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "preExecHookData", internalType: "bytes", type: "bytes" },
+    ],
+    name: "postExecutionHook",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "value", internalType: "uint256", type: "uint256" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "preExecutionHook",
+    outputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "value", internalType: "uint256", type: "uint256" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "preRuntimeValidationHook",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      {
+        name: "userOp",
+        internalType: "struct UserOperation",
+        type: "tuple",
+        components: [
+          { name: "sender", internalType: "address", type: "address" },
+          { name: "nonce", internalType: "uint256", type: "uint256" },
+          { name: "initCode", internalType: "bytes", type: "bytes" },
+          { name: "callData", internalType: "bytes", type: "bytes" },
+          { name: "callGasLimit", internalType: "uint256", type: "uint256" },
+          {
+            name: "verificationGasLimit",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "preVerificationGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "maxFeePerGas", internalType: "uint256", type: "uint256" },
+          {
+            name: "maxPriorityFeePerGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "paymasterAndData", internalType: "bytes", type: "bytes" },
+          { name: "signature", internalType: "bytes", type: "bytes" },
+        ],
+      },
+      { name: "userOpHash", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "preUserOpValidationHook",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "runtimeValidationFunction",
+    outputs: [],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [{ name: "interfaceId", internalType: "bytes4", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "ownersToAdd", internalType: "address[]", type: "address[]" },
+      { name: "ownersToRemove", internalType: "address[]", type: "address[]" },
+    ],
+    name: "updateOwners",
+    outputs: [],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      {
+        name: "userOp",
+        internalType: "struct UserOperation",
+        type: "tuple",
+        components: [
+          { name: "sender", internalType: "address", type: "address" },
+          { name: "nonce", internalType: "uint256", type: "uint256" },
+          { name: "initCode", internalType: "bytes", type: "bytes" },
+          { name: "callData", internalType: "bytes", type: "bytes" },
+          { name: "callGasLimit", internalType: "uint256", type: "uint256" },
+          {
+            name: "verificationGasLimit",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "preVerificationGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "maxFeePerGas", internalType: "uint256", type: "uint256" },
+          {
+            name: "maxPriorityFeePerGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "paymasterAndData", internalType: "bytes", type: "bytes" },
+          { name: "signature", internalType: "bytes", type: "bytes" },
+        ],
+      },
+      { name: "userOpHash", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "userOpValidationFunction",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
   },
 ] as const;

--- a/packages/accounts/src/msca/plugins/session-key/executor.ts
+++ b/packages/accounts/src/msca/plugins/session-key/executor.ts
@@ -1,0 +1,42 @@
+import type { Address, BatchUserOperationCallData } from "@alchemy/aa-core";
+import { encodeFunctionData, type Hex } from "viem";
+import type { Executor } from "../../builder/types";
+import { SessionKeyPluginAbi } from "./plugin.js";
+
+export const SessionKeyExecutor: Executor = (acct) => {
+  const owner = acct.getOwner();
+  if (!owner) {
+    throw new Error("Account must be connected to an owner");
+  }
+
+  return {
+    async encodeExecute(
+      target: Address,
+      value: bigint,
+      data: Hex
+    ): Promise<`0x${string}`> {
+      return encodeFunctionData({
+        abi: SessionKeyPluginAbi,
+        functionName: "executeWithSessionKey",
+        args: [[{ target, value, data }], await owner.getAddress()],
+      });
+    },
+
+    async encodeBatchExecute(
+      txs: BatchUserOperationCallData
+    ): Promise<`0x${string}`> {
+      return encodeFunctionData({
+        abi: SessionKeyPluginAbi,
+        functionName: "executeWithSessionKey",
+        args: [
+          txs.map((tx) => ({
+            target: tx.target,
+            data: tx.data,
+            value: tx.value ?? 0n,
+          })),
+          await owner.getAddress(),
+        ],
+      });
+    },
+  };
+};

--- a/packages/accounts/src/msca/plugins/token-receiver/plugin.ts
+++ b/packages/accounts/src/msca/plugins/token-receiver/plugin.ts
@@ -1,10 +1,12 @@
-import { type Plugin } from "../types.js";
 import {
+  getContract,
   encodeFunctionData,
   encodeAbiParameters,
   type Address,
+  type GetContractReturnType,
   type GetFunctionArgs,
 } from "viem";
+import { type Plugin } from "../types.js";
 import { type IMSCA } from "../../types.js";
 import {
   type UserOperationOverrides,
@@ -27,14 +29,30 @@ export type InstallTokenReceiverPluginParams = {
   dependencyOverrides?: FunctionReference[];
 };
 
+const addresses = {
+  11155111: "0xa81C0AEaB22b21b4da8d8728063f6570384b48C9" as Address,
+} as Record<number, Address>;
+
 const TokenReceiverPlugin_ = {
   meta: {
     name: "Token Receiver Plugin",
     version: "1.0.0",
-    addresses: {
-      11155111: "0xa81C0AEaB22b21b4da8d8728063f6570384b48C9" as Address,
-    } as Record<number, Address>,
+    addresses,
   },
+  getContract: (
+    provider: ISmartAccountProvider,
+    address?: Address
+  ): GetContractReturnType<
+    typeof TokenReceiverPluginAbi,
+    typeof provider.rpcClient,
+    undefined,
+    Address
+  > =>
+    getContract({
+      address: address || addresses[provider.rpcClient.chain.id],
+      abi: TokenReceiverPluginAbi,
+      publicClient: provider.rpcClient,
+    }),
   accountMethods: (_account: IMSCA<any, any>) => ({
     encodeTokensReceivedData: ({
       args,
@@ -199,7 +217,8 @@ const TokenReceiverPlugin_ = {
 
 export const TokenReceiverPlugin: Plugin<
   ReturnType<(typeof TokenReceiverPlugin_)["accountMethods"]>,
-  ReturnType<(typeof TokenReceiverPlugin_)["providerMethods"]>
+  ReturnType<(typeof TokenReceiverPlugin_)["providerMethods"]>,
+  typeof TokenReceiverPluginAbi
 > = TokenReceiverPlugin_;
 
 export const TokenReceiverPluginExecutionFunctionAbi = [
@@ -254,5 +273,570 @@ export const TokenReceiverPluginExecutionFunctionAbi = [
     ],
     name: "onERC1155BatchReceived",
     outputs: [{ name: "", internalType: "bytes4", type: "bytes4" }],
+  },
+] as const;
+
+export const TokenReceiverPluginAbi = [
+  { type: "error", inputs: [], name: "AlreadyInitialized" },
+  { type: "error", inputs: [], name: "InvalidAction" },
+  { type: "error", inputs: [], name: "NotContractCaller" },
+  { type: "error", inputs: [], name: "NotImplemented" },
+  { type: "error", inputs: [], name: "NotInitialized" },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256[]", type: "uint256[]" },
+      { name: "", internalType: "uint256[]", type: "uint256[]" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onERC1155BatchReceived",
+    outputs: [{ name: "", internalType: "bytes4", type: "bytes4" }],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onERC1155Received",
+    outputs: [{ name: "", internalType: "bytes4", type: "bytes4" }],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onERC721Received",
+    outputs: [{ name: "", internalType: "bytes4", type: "bytes4" }],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "pluginAppliedOn", internalType: "address", type: "address" },
+      {
+        name: "injectedHooksInfo",
+        internalType: "struct IPluginManager.InjectedHooksInfo",
+        type: "tuple",
+        components: [
+          {
+            name: "preExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+          { name: "isPostHookUsed", internalType: "bool", type: "bool" },
+          {
+            name: "postExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+        ],
+      },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onHookApply",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "pluginAppliedOn", internalType: "address", type: "address" },
+      {
+        name: "injectedHooksInfo",
+        internalType: "struct IPluginManager.InjectedHooksInfo",
+        type: "tuple",
+        components: [
+          {
+            name: "preExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+          { name: "isPostHookUsed", internalType: "bool", type: "bool" },
+          {
+            name: "postExecHookFunctionId",
+            internalType: "uint8",
+            type: "uint8",
+          },
+        ],
+      },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "onHookUnapply",
+    outputs: [],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+    name: "onInstall",
+    outputs: [],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+    name: "onUninstall",
+    outputs: [],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [],
+    name: "pluginManifest",
+    outputs: [
+      {
+        name: "",
+        internalType: "struct PluginManifest",
+        type: "tuple",
+        components: [
+          { name: "interfaceIds", internalType: "bytes4[]", type: "bytes4[]" },
+          {
+            name: "dependencyInterfaceIds",
+            internalType: "bytes4[]",
+            type: "bytes4[]",
+          },
+          {
+            name: "executionFunctions",
+            internalType: "bytes4[]",
+            type: "bytes4[]",
+          },
+          {
+            name: "permittedExecutionSelectors",
+            internalType: "bytes4[]",
+            type: "bytes4[]",
+          },
+          {
+            name: "permitAnyExternalAddress",
+            internalType: "bool",
+            type: "bool",
+          },
+          { name: "canSpendNativeToken", internalType: "bool", type: "bool" },
+          {
+            name: "permittedExternalCalls",
+            internalType: "struct ManifestExternalCallPermission[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "externalAddress",
+                internalType: "address",
+                type: "address",
+              },
+              { name: "permitAnySelector", internalType: "bool", type: "bool" },
+              { name: "selectors", internalType: "bytes4[]", type: "bytes4[]" },
+            ],
+          },
+          {
+            name: "userOpValidationFunctions",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "runtimeValidationFunctions",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "preUserOpValidationHooks",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "preRuntimeValidationHooks",
+            internalType: "struct ManifestAssociatedFunction[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "associatedFunction",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            internalType: "struct ManifestExecutionHook[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "preExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+              {
+                name: "postExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "permittedCallHooks",
+            internalType: "struct ManifestExecutionHook[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "executionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "preExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+              {
+                name: "postExecHook",
+                internalType: "struct ManifestFunction",
+                type: "tuple",
+                components: [
+                  {
+                    name: "functionType",
+                    internalType: "enum ManifestAssociatedFunctionType",
+                    type: "uint8",
+                  },
+                  { name: "functionId", internalType: "uint8", type: "uint8" },
+                  {
+                    name: "dependencyIndex",
+                    internalType: "uint256",
+                    type: "uint256",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [],
+    name: "pluginMetadata",
+    outputs: [
+      {
+        name: "",
+        internalType: "struct PluginMetadata",
+        type: "tuple",
+        components: [
+          { name: "name", internalType: "string", type: "string" },
+          { name: "version", internalType: "string", type: "string" },
+          { name: "author", internalType: "string", type: "string" },
+          {
+            name: "permissionDescriptors",
+            internalType: "struct SelectorPermission[]",
+            type: "tuple[]",
+            components: [
+              {
+                name: "functionSelector",
+                internalType: "bytes4",
+                type: "bytes4",
+              },
+              {
+                name: "permissionDescription",
+                internalType: "string",
+                type: "string",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "preExecHookData", internalType: "bytes", type: "bytes" },
+    ],
+    name: "postExecutionHook",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "value", internalType: "uint256", type: "uint256" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "preExecutionHook",
+    outputs: [{ name: "", internalType: "bytes", type: "bytes" }],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "value", internalType: "uint256", type: "uint256" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "preRuntimeValidationHook",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      {
+        name: "userOp",
+        internalType: "struct UserOperation",
+        type: "tuple",
+        components: [
+          { name: "sender", internalType: "address", type: "address" },
+          { name: "nonce", internalType: "uint256", type: "uint256" },
+          { name: "initCode", internalType: "bytes", type: "bytes" },
+          { name: "callData", internalType: "bytes", type: "bytes" },
+          { name: "callGasLimit", internalType: "uint256", type: "uint256" },
+          {
+            name: "verificationGasLimit",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "preVerificationGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "maxFeePerGas", internalType: "uint256", type: "uint256" },
+          {
+            name: "maxPriorityFeePerGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "paymasterAndData", internalType: "bytes", type: "bytes" },
+          { name: "signature", internalType: "bytes", type: "bytes" },
+        ],
+      },
+      { name: "userOpHash", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "preUserOpValidationHook",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      { name: "sender", internalType: "address", type: "address" },
+      { name: "value", internalType: "uint256", type: "uint256" },
+      { name: "data", internalType: "bytes", type: "bytes" },
+    ],
+    name: "runtimeValidationFunction",
+    outputs: [],
+  },
+  {
+    stateMutability: "view",
+    type: "function",
+    inputs: [{ name: "interfaceId", internalType: "bytes4", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ name: "", internalType: "bool", type: "bool" }],
+  },
+  {
+    stateMutability: "pure",
+    type: "function",
+    inputs: [
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "address", type: "address" },
+      { name: "", internalType: "uint256", type: "uint256" },
+      { name: "", internalType: "bytes", type: "bytes" },
+      { name: "", internalType: "bytes", type: "bytes" },
+    ],
+    name: "tokensReceived",
+    outputs: [],
+  },
+  {
+    stateMutability: "nonpayable",
+    type: "function",
+    inputs: [
+      { name: "functionId", internalType: "uint8", type: "uint8" },
+      {
+        name: "userOp",
+        internalType: "struct UserOperation",
+        type: "tuple",
+        components: [
+          { name: "sender", internalType: "address", type: "address" },
+          { name: "nonce", internalType: "uint256", type: "uint256" },
+          { name: "initCode", internalType: "bytes", type: "bytes" },
+          { name: "callData", internalType: "bytes", type: "bytes" },
+          { name: "callGasLimit", internalType: "uint256", type: "uint256" },
+          {
+            name: "verificationGasLimit",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          {
+            name: "preVerificationGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "maxFeePerGas", internalType: "uint256", type: "uint256" },
+          {
+            name: "maxPriorityFeePerGas",
+            internalType: "uint256",
+            type: "uint256",
+          },
+          { name: "paymasterAndData", internalType: "bytes", type: "bytes" },
+          { name: "signature", internalType: "bytes", type: "bytes" },
+        ],
+      },
+      { name: "userOpHash", internalType: "bytes32", type: "bytes32" },
+    ],
+    name: "userOpValidationFunction",
+    outputs: [{ name: "", internalType: "uint256", type: "uint256" }],
   },
 ] as const;

--- a/packages/accounts/src/msca/plugins/types.ts
+++ b/packages/accounts/src/msca/plugins/types.ts
@@ -1,12 +1,29 @@
 import type {
+  Abi,
   Address,
   ISmartAccountProvider,
   SupportedTransports,
 } from "@alchemy/aa-core";
+import type { GetContractReturnType } from "viem";
 import type { IMSCA } from "../types";
 
-export interface Plugin<AD, PD> {
+export interface Plugin<AD, PD, TAbi extends Abi> {
   meta: { name: string; version: string; addresses: Record<number, Address> };
+  /**
+   * helper functions that can be used to get contract instance of the plugin
+   *
+   * @param p - a provider instance to provide public client instance to fetch the contract with
+   * @returns the plugin contract instance
+   */
+  getContract: (
+    provider: ISmartAccountProvider,
+    address?: Address
+  ) => GetContractReturnType<
+    TAbi,
+    typeof provider.rpcClient,
+    undefined,
+    Address
+  >;
   /**
    * Decorator functions that can be used to read data from an MSCA contract instance
    * These methods can be used on their own or with the `account.extend` method to add them to the account instance

--- a/packages/accounts/src/msca/types.ts
+++ b/packages/accounts/src/msca/types.ts
@@ -3,7 +3,7 @@ import type {
   ISmartContractAccount,
   SupportedTransports,
 } from "@alchemy/aa-core";
-import type { Transport } from "viem";
+import type { Abi, Transport } from "viem";
 import type { Plugin } from "./plugins/types";
 
 export interface IMSCA<
@@ -14,7 +14,7 @@ export interface IMSCA<
     p: ISmartAccountProvider<TTransport>
   ) => TProviderDecorators;
 
-  extendWithPluginMethods: <AD, PD>(
-    plugin: Plugin<AD, PD>
+  extendWithPluginMethods: <AD, PD, TAbi extends Abi>(
+    plugin: Plugin<AD, PD, TAbi>
   ) => this & IMSCA<TTransport, TProviderDecorators & PD> & AD;
 }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a `SessionKeyExecutor` to the `accounts` package.

### Detailed summary:
- Added `SessionKeyExecutor` to `index.ts` in the `accounts` package.
- Imported necessary types from `@alchemy/aa-core` and `viem`.
- Exported `SessionKeyExecutor` as an `Executor` function.
- Implemented `encodeExecute` and `encodeBatchExecute` functions in `SessionKeyExecutor`.
- Used `encodeFunctionData` to encode function data with the `SessionKeyPluginAbi`.
- Handled the case when the account is not connected to an owner.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->