### PR TITLE
fix(buildUserOperationFromTx): handle the case where no TX has fee fields set

### DIFF
--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -265,22 +265,27 @@ export class SmartAccountProvider<
       };
     });
 
+    const mfpgOverridesInTx = () =>
+      requests
+        .filter((x) => x.maxFeePerGas != null)
+        .map((x) => fromHex(x.maxFeePerGas!, "bigint"));
     const maxFeePerGas =
       overrides?.maxFeePerGas != null
         ? overrides?.maxFeePerGas
-        : bigIntMax(
-            ...requests
-              .filter((x) => x.maxFeePerGas != null)
-              .map((x) => fromHex(x.maxFeePerGas!, "bigint"))
-          );
+        : mfpgOverridesInTx().length > 0
+        ? bigIntMax(...mfpgOverridesInTx())
+        : undefined;
+
+    const mpfpgOverridesInTx = () =>
+      requests
+        .filter((x) => x.maxPriorityFeePerGas != null)
+        .map((x) => fromHex(x.maxPriorityFeePerGas!, "bigint"));
     const maxPriorityFeePerGas =
       overrides?.maxPriorityFeePerGas != null
         ? overrides?.maxPriorityFeePerGas
-        : bigIntMax(
-            ...requests
-              .filter((x) => x.maxPriorityFeePerGas != null)
-              .map((x) => fromHex(x.maxPriorityFeePerGas!, "bigint"))
-          );
+        : mpfpgOverridesInTx().length > 0
+        ? bigIntMax(...mpfpgOverridesInTx())
+        : undefined;
 
     const _overrides: UserOperationOverrides = {
       maxFeePerGas,


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the calculation of `maxFeePerGas` and `maxPriorityFeePerGas` in the `base.ts` file. 

### Detailed summary
- Extracted the logic for calculating `maxFeePerGas` and `maxPriorityFeePerGas` into separate functions `mfpgOverridesInTx()` and `mpfpgOverridesInTx()`.
- Replaced the previous calculation logic with calls to these functions.
- Improved readability and maintainability of the code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->