### PR TITLE
fix: a few misspellings which got multiplied

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@ This package contains the core interfaces and components for interacting with 43
 
 The `SmartAccountProvider` is an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compliant Provider that wraps JSON RPC methods and some Wallet Methods (signing, sendTransaction, etc). With this Provider, you can submit User Operations to RPC providers, estimate gas, configure a Paymaster, send standard JSON RPC requests, and more. It is not opinionated about which RPC provider you are using and is configurable to work with any RPC provider. Because it implements EIP-1193, it can be used with any web3 library.
 
-The `BaseSmartContractAccount` interface defines how you would interact with your Smart Contract Account. Any class that extends `BaseSmartContractAccount` may also expose additional methods that allow its connecting `SmartAccountProvider` to provide ergonic utilities for building and submitting `User Operation`s.
+The `BaseSmartContractAccount` interface defines how you would interact with your Smart Contract Account. Any class that extends `BaseSmartContractAccount` may also expose additional methods that allow its connecting `SmartAccountProvider` to provide ergonomic utilities for building and submitting `User Operation`s.
 
 ## Getting Started
 

--- a/packages/core/src/provider/base.ts
+++ b/packages/core/src/provider/base.ts
@@ -76,7 +76,7 @@ export class SmartAccountProvider<
 {
   private txMaxRetries: number;
   private txRetryIntervalMs: number;
-  private txRetryMulitplier: number;
+  private txRetryMultiplier: number;
   private feeOptions: UserOperationFeeOptions;
 
   readonly account?: ISmartContractAccount;
@@ -100,7 +100,7 @@ export class SmartAccountProvider<
 
     this.txMaxRetries = opts.txMaxRetries;
     this.txRetryIntervalMs = opts.txRetryIntervalMs;
-    this.txRetryMulitplier = opts.txRetryMulitplier;
+    this.txRetryMultiplier = opts.txRetryMultiplier;
     this.entryPointAddress = entryPointAddress;
 
     this.feeOptions = {
@@ -311,7 +311,7 @@ export class SmartAccountProvider<
   waitForUserOperationTransaction = async (hash: Hash): Promise<Hash> => {
     for (let i = 0; i < this.txMaxRetries; i++) {
       const txRetryIntervalWithJitterMs =
-        this.txRetryIntervalMs * Math.pow(this.txRetryMulitplier, i) +
+        this.txRetryIntervalMs * Math.pow(this.txRetryMultiplier, i) +
         Math.random() * 100;
 
       await new Promise((resolve) =>

--- a/packages/core/src/provider/schema.ts
+++ b/packages/core/src/provider/schema.ts
@@ -59,9 +59,9 @@ export const SmartAccountProviderOptsSchema = z
     txRetryIntervalMs: z.number().min(0).optional().default(2_000),
 
     /**
-     * The mulitplier on interval length to wait between retries while waiting for tx receipts (default: 1.5)
+     * The multiplier on interval length to wait between retries while waiting for tx receipts (default: 1.5)
      */
-    txRetryMulitplier: z.number().min(0).optional().default(1.5),
+    txRetryMultiplier: z.number().min(0).optional().default(1.5),
 
     /**
      * Optional user operation fee options to be set globally at the provider level

--- a/site/overview/package-overview.md
+++ b/site/overview/package-overview.md
@@ -33,7 +33,7 @@ This package contains the core interfaces and components for interacting with 43
 
 The `SmartAccountProvider` is an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compliant Provider that wraps JSON RPC methods and some Wallet Methods (signing, sendTransaction, etc). With this Provider, you can submit User Operations to RPC providers, estimate gas, configure a Paymaster and more. It is not opinionated about which RPC provider you are using and is configurable to work with any RPC provider. Because it implements EIP-1193, it can be used with any web3 library.
 
-The `BaseSmartContractAccount` interface is used to define how you would interact with your Smart Contract Account. The methods exposed and implemented by a class the implements `BaseSmartContractAccount` allow the `SmartAccountProvider` to provide ergonic utilities for building and submitting User Operations.
+The `BaseSmartContractAccount` interface is used to define how you would interact with your Smart Contract Account. The methods exposed and implemented by a class the implements `BaseSmartContractAccount` allow the `SmartAccountProvider` to provide ergonomic utilities for building and submitting User Operations.
 
 For more details on all the utilities exported by `aa-core` see the [aa-core documentation](/packages/aa-core/).
 

--- a/site/packages/aa-accounts/light-account/provider.md
+++ b/site/packages/aa-accounts/light-account/provider.md
@@ -47,7 +47,7 @@ A Promise containing a new `SmartAccountProvider` connected to a Light Account.
 
   - `txRetryIntervalMs: string | undefined` -- [optional] the interval in milliseconds to wait between retries while waiting for transaction receipts (default: 2_000).
 
-  - `txRetryMulitplier: string | undefined` -- [optional] the mulitplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
+  - `txRetryMultiplier: string | undefined` -- [optional] the multiplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
 
   - `feeOptions:` [`UserOperationFeeOptions`](/packages/aa-core/provider/types/userOperationFeeOptions.md) `| undefined` --[optional] user operation fee options to be used for gas estimation, set at the global level on the provider.
     If not set, default fee options for the chain are used. Available fields in `feeOptions` include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit` where each field is of type [`UserOperationFeeOptionsField`](/packages/aa-core/provider/types/userOperationFeeOptionsField.md).

--- a/site/packages/aa-alchemy/provider/constructor.md
+++ b/site/packages/aa-alchemy/provider/constructor.md
@@ -33,7 +33,7 @@ export const provider = new AlchemyProvider({
   opts: {
     txMaxRetries: 10,
     txRetryIntervalMs: 2_000,
-    txRetryMulitplier: 1.5,
+    txRetryMultiplier: 1.5,
     minPriorityFeePerBid: 100_000_000n,
   },
   feeOpts: {
@@ -72,7 +72,7 @@ A new instance of an `AlchemyProvider`.
 
   - `txRetryIntervalMs: string | undefined` -- [optional] the interval in milliseconds to wait between retries while waiting for transaction receipts (default: 2_000).
 
-  - `txRetryMulitplier: string | undefined` -- [optional] the mulitplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
+  - `txRetryMultiplier: string | undefined` -- [optional] the multiplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
 
   - `feeOptions:` [`UserOperationFeeOptions`](/packages/aa-core/provider/types/userOperationFeeOptions.md) `| undefined` --[optional] user operation fee options to be used for gas estimation, set at the global level on the provider.
     If not set, default fee options for the chain are used. Available fields in `feeOptions` include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit` where each field is of type [`UserOperationFeeOptionsField`](/packages/aa-core/provider/types/userOperationFeeOptionsField.md).

--- a/site/packages/aa-alchemy/provider/light-account-factory.md
+++ b/site/packages/aa-alchemy/provider/light-account-factory.md
@@ -51,7 +51,7 @@ A Promise containing a new `AlchemyProvider` connected to a Light Account.
 
   - `txRetryIntervalMs: string | undefined` -- [optional] the interval in milliseconds to wait between retries while waiting for transaction receipts (default: 2_000).
 
-  - `txRetryMulitplier: string | undefined` -- [optional] the mulitplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
+  - `txRetryMultiplier: string | undefined` -- [optional] the multiplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
 
   - `feeOptions:` [`UserOperationFeeOptions`](/packages/aa-core/provider/types/userOperationFeeOptions.md) `| undefined` --[optional] user operation fee options to be used for gas estimation, set at the global level on the provider.
     If not set, default fee options for the chain are used. Available fields in `feeOptions` include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit` where each field is of type [`UserOperationFeeOptionsField`](/packages/aa-core/provider/types/userOperationFeeOptionsField.md).

--- a/site/packages/aa-core/index.md
+++ b/site/packages/aa-core/index.md
@@ -20,7 +20,7 @@ This package contains the core interfaces and components for interacting with 43
 
 The `SmartAccountProvider` is an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compliant Provider that wraps JSON RPC methods and some Wallet Methods (signing, sendTransaction, etc). With this Provider, you can submit User Operations to RPC providers, estimate gas, configure a Paymaster, send standard JSON RPC requests, and more. It is not opinionated about which RPC provider you are using and is configurable to work with any RPC provider. Because it implements EIP-1193, it can be used with any web3 library.
 
-The `BaseSmartContractAccount` interface defines how you would interact with your Smart Contract Account. Any class that extends `BaseSmartContractAccount` may also expose additional methods that allow its connecting `SmartAccountProvider` to provide ergonic utilities for building and submitting `User Operation`s.
+The `BaseSmartContractAccount` interface defines how you would interact with your Smart Contract Account. Any class that extends `BaseSmartContractAccount` may also expose additional methods that allow its connecting `SmartAccountProvider` to provide ergonomic utilities for building and submitting `User Operation`s.
 
 ## Getting Started
 

--- a/site/packages/aa-core/provider/constructor.md
+++ b/site/packages/aa-core/provider/constructor.md
@@ -33,7 +33,7 @@ export const provider = new SmartAccountProvider({
   opts: {
     txMaxRetries: 10,
     txRetryIntervalMs: 2_000,
-    txRetryMulitplier: 1.5,
+    txRetryMultiplier: 1.5,
     minPriorityFeePerBid: 100_000_000n,
   },
 });
@@ -63,7 +63,7 @@ A new instance of a `SmartAccountProvider`.
 
   - `txRetryIntervalMs: string | undefined` -- [optional] the interval in milliseconds to wait between retries while waiting for transaction receipts (default: 2_000).
 
-  - `txRetryMulitplier: string | undefined` -- [optional] the mulitplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
+  - `txRetryMultiplier: string | undefined` -- [optional] the multiplier on interval length to wait between retries while waiting for transaction receipts (default: 1.5).
 
   - `feeOptions:` [`UserOperationFeeOptions`](/packages/aa-core/provider/types/userOperationFeeOptions.md) `| undefined` --[optional] user operation fee options to be used for gas estimation, set at the global level on the provider.
     If not set, default fee options for the chain are used. Available fields in `feeOptions` include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit` where each field is of type [`UserOperationFeeOptionsField`](/packages/aa-core/provider/types/userOperationFeeOptionsField.md).

--- a/site/packages/aa-core/provider/waitForUserOperationTransaction.md
+++ b/site/packages/aa-core/provider/waitForUserOperationTransaction.md
@@ -14,7 +14,7 @@ head:
 
 # waitForUserOperationTransaction
 
-Attempts to fetch for UserOperationReceipt `txMaxRetries` amount of times, at an interval of `txRetryIntervalMs` milliseconds (with a multiplier of `txRetryMulitplier`) using the connected account.
+Attempts to fetch for UserOperationReceipt `txMaxRetries` amount of times, at an interval of `txRetryIntervalMs` milliseconds (with a multiplier of `txRetryMultiplier`) using the connected account.
 
 Note: For more details on how to modify the retry configurations for this method, see the [constructor](/packages/aa-core/provider/constructor.md) parameters.
 

--- a/site/packages/aa-ethers/provider-adapter/constructor.md
+++ b/site/packages/aa-ethers/provider-adapter/constructor.md
@@ -42,7 +42,7 @@ const accountProvider = new AlchemyProvider({
   opts: {
     txMaxRetries: 10,
     txRetryIntervalMs: 2_000,
-    txRetryMulitplier: 1.5,
+    txRetryMultiplier: 1.5,
     minPriorityFeePerBid: 100_000_000n,
   },
   feeOpts: {


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

## Couple Typo Fixes

The `txRetryMultiplier` was spelled correctly in a few places in docs, but the variable itself had a typo which was copied to many areas. Not sure if we care enough that we'd want to fix this breaking change, otherwise feel free to close this.

Also have a small readme typo in here for `ergonomic`


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a typo in the variable name `txRetryMulitplier` to `txRetryMultiplier`. 

### Detailed summary
- Renamed `txRetryMulitplier` to `txRetryMultiplier` in multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->