### PR TITLE
refactor: change entrypoint to be a type that encapsulates address and packing

### DIFF
--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -3,6 +3,7 @@ import {
   createBundlerClient,
   getAccountAddress,
   getDefaultEntryPointAddress,
+  getVersion060EntryPoint,
   toSmartContractAccount,
   type Address,
   type Hex,
@@ -169,7 +170,7 @@ export async function createLightAccount({
   const account = await toSmartContractAccount({
     transport,
     chain,
-    entryPointAddress,
+    entryPoint: getVersion060EntryPoint(chain, entryPointAddress),
     accountAddress: address,
     source: "LightAccount",
     getAccountInitCode,

--- a/packages/accounts/src/msca/account/multiOwnerAccount.ts
+++ b/packages/accounts/src/msca/account/multiOwnerAccount.ts
@@ -1,11 +1,13 @@
+import type { EntryPointDef } from "@alchemy/aa-core";
 import {
   createBundlerClient,
   getAccountAddress,
-  getDefaultEntryPointAddress,
+  getVersion060EntryPoint,
   toSmartContractAccount,
   type Address,
   type OwnedSmartContractAccount,
   type SmartAccountSigner,
+  type UserOperationRequest,
 } from "@alchemy/aa-core";
 import {
   concatHex,
@@ -34,7 +36,7 @@ export type CreateMultiOwnerModularAccountParams<
   index?: bigint;
   factoryAddress?: Address;
   owners?: Address[];
-  entryPointAddress?: Address;
+  entryPoint?: EntryPointDef<UserOperationRequest>;
   accountAddress?: Address;
   initCode?: Hex;
 };
@@ -52,7 +54,7 @@ export async function createMultiOwnerModularAccount({
   owner: owner_,
   accountAddress,
   initCode,
-  entryPointAddress = getDefaultEntryPointAddress(chain),
+  entryPoint = getVersion060EntryPoint(chain),
   factoryAddress = getDefaultMultiOwnerModularAccountFactoryAddress(chain),
   owners = [],
   index = 0n,
@@ -90,7 +92,7 @@ export async function createMultiOwnerModularAccount({
 
   accountAddress = await getAccountAddress({
     client,
-    entryPointAddress,
+    entryPointAddress: entryPoint.address,
     accountAddress: accountAddress,
     getAccountInitCode,
   });
@@ -98,7 +100,7 @@ export async function createMultiOwnerModularAccount({
   const baseAccount = await toSmartContractAccount({
     transport,
     chain,
-    entryPointAddress,
+    entryPoint,
     accountAddress,
     source: `MultiOwnerModularAccount`,
     getAccountInitCode,

--- a/packages/accounts/src/nani-account/account.ts
+++ b/packages/accounts/src/nani-account/account.ts
@@ -1,6 +1,7 @@
 import {
   BaseSmartContractAccount,
   createBundlerClient,
+  getVersion060EntryPoint,
   toSmartContractAccount,
   type BaseSmartAccountParams,
   type BatchUserOperationCallData,
@@ -242,7 +243,10 @@ export const createNaniAccount = async <TTransport extends Transport>(
     transport: params.transport,
     chain: params.chain,
     accountAddress: params.accountAddress as Address | undefined,
-    entryPointAddress: naniAccount.getEntryPointAddress(),
+    entryPoint: getVersion060EntryPoint(
+      params.chain,
+      naniAccount.getEntryPointAddress()
+    ),
     encodeBatchExecute: naniAccount.encodeBatchExecute.bind(naniAccount),
     encodeExecute: (tx) =>
       naniAccount.encodeExecute(tx.target, tx.value ?? 0n, tx.data),

--- a/packages/alchemy/src/actions/simulateUserOperationChanges.ts
+++ b/packages/alchemy/src/actions/simulateUserOperationChanges.ts
@@ -43,6 +43,6 @@ export const simulateUserOperationChanges: <
 
   return client.request({
     method: "alchemy_simulateUserOperationAssetChanges",
-    params: [uoStruct, account.getEntrypoint()],
+    params: [uoStruct, account.getEntryPoint().address],
   });
 };

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -181,7 +181,7 @@ const requestGasAndPaymasterData: <C extends ClientWithAlchemyMethods>(
       params: [
         {
           policyId: config.policyId,
-          entryPoint: account.getEntrypoint(),
+          entryPoint: account.getEntryPoint().address,
           userOperation: userOperation,
           dummySignature: userOperation.signature,
           overrides:
@@ -208,7 +208,7 @@ const requestPaymasterAndData: <C extends ClientWithAlchemyMethods>(
       params: [
         {
           policyId: config.policyId,
-          entryPoint: account.getEntrypoint(),
+          entryPoint: account.getEntryPoint().address,
           userOperation: deepHexlify(await resolveProperties(struct)),
         },
       ],

--- a/packages/alchemy/src/middleware/userOperationSimulator.ts
+++ b/packages/alchemy/src/middleware/userOperationSimulator.ts
@@ -17,7 +17,7 @@ export const alchemyUserOperationSimulator: <
       method: "alchemy_simulateUserOperationAssetChanges",
       params: [
         deepHexlify(await resolveProperties(struct)) as UserOperationStruct,
-        account.getEntrypoint(),
+        account.getEntryPoint().address,
       ],
     });
 

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -10,6 +10,7 @@ import {
 import { SimpleAccountAbi } from "../abis/SimpleAccountAbi.js";
 import { SimpleAccountFactoryAbi } from "../abis/SimpleAccountFactoryAbi.js";
 import { createBundlerClient } from "../client/bundlerClient.js";
+import { getVersion060EntryPoint } from "../entrypoint/0.6.js";
 import { AccountRequiresOwnerError } from "../errors/account.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import type { BatchUserOperationCallData } from "../types.js";
@@ -136,7 +137,10 @@ export const createSimpleSmartAccount = async <
         tx.value ?? 0n,
         tx.data
       ),
-    entryPointAddress: simpleAccount.getEntryPointAddress(),
+    entryPoint: getVersion060EntryPoint(
+      params.chain,
+      simpleAccount.getEntryPointAddress()
+    ),
     getAccountInitCode: async () => {
       if (parsedParams.initCode) return parsedParams.initCode;
       return simpleAccount.getAccountInitCode();

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -9,11 +9,7 @@ import { AccountNotFoundError } from "../../../errors/account.js";
 import { ChainNotFoundError } from "../../../errors/client.js";
 import { InvalidUserOperationError } from "../../../errors/useroperation.js";
 import type { UserOperationStruct } from "../../../types";
-import {
-  deepHexlify,
-  getUserOperationHash,
-  isValidRequest,
-} from "../../../utils/index.js";
+import { deepHexlify, isValidRequest } from "../../../utils/index.js";
 
 export const _sendUserOperation: <
   TTransport extends Transport = Transport,
@@ -40,11 +36,14 @@ export const _sendUserOperation: <
   }
 
   request.signature = await account.signUserOperationHash(
-    getUserOperationHash(request, account.getEntrypoint(), client.chain.id)
+    account.getEntryPoint().getUserOperationHash(request)
   );
 
   return {
-    hash: await client.sendRawUserOperation(request, account.getEntrypoint()),
+    hash: await client.sendRawUserOperation(
+      request,
+      account.getEntryPoint().address
+    ),
     request,
   };
 };

--- a/packages/core/src/entrypoint/0.6.ts
+++ b/packages/core/src/entrypoint/0.6.ts
@@ -1,0 +1,28 @@
+import type { Address, Chain } from "viem";
+import type { UserOperationRequest } from "../types";
+import {
+  getDefaultEntryPointAddress,
+  getUserOperationHash,
+  packUo,
+} from "../utils/index.js";
+import type { EntryPointDef } from "./types";
+
+export const getVersion060EntryPoint: (
+  chain: Chain,
+  address?: Address
+) => EntryPointDef<UserOperationRequest> = (
+  chain: Chain,
+  address = getDefaultEntryPointAddress(chain)
+) => {
+  return {
+    version: "0.6.0",
+    address,
+    chain,
+    packUserOperation: (userOperation: UserOperationRequest) => {
+      return packUo(userOperation);
+    },
+    getUserOperationHash: (userOperation: UserOperationRequest) => {
+      return getUserOperationHash(userOperation, address, chain.id);
+    },
+  } satisfies EntryPointDef<UserOperationRequest>;
+};

--- a/packages/core/src/entrypoint/types.ts
+++ b/packages/core/src/entrypoint/types.ts
@@ -1,0 +1,9 @@
+import type { Address, Chain, Hex } from "viem";
+
+export type EntryPointDef<EntryPointUserOperation> = {
+  version: string;
+  address: Address;
+  chain: Chain;
+  packUserOperation: (userOperation: EntryPointUserOperation) => Hex;
+  getUserOperationHash: (userOperation: EntryPointUserOperation) => Hex;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,8 @@ export {
   convertCoinTypeToChain,
   convertCoinTypeToChainId,
 } from "./ens/utils.js";
+export { getVersion060EntryPoint } from "./entrypoint/0.6.js";
+export { type EntryPointDef } from "./entrypoint/types.js";
 export {
   AccountNotFoundError,
   DefaultFactoryNotDefinedError,

--- a/packages/core/src/middleware/defaults/gasEstimator.ts
+++ b/packages/core/src/middleware/defaults/gasEstimator.ts
@@ -12,7 +12,7 @@ export const defaultGasEstimator: <C extends MiddlewareClient>(
 
     const estimates = await client.estimateUserOperationGas(
       request,
-      account.getEntrypoint()
+      account.getEntryPoint().address
     );
 
     const callGasLimit = applyUserOpOverrideOrFeeOption(

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -121,7 +121,7 @@ export function getUserOperationHash(
   return keccak256(encoded);
 }
 
-function packUo(request: UserOperationRequest): Hex {
+export function packUo(request: UserOperationRequest): Hex {
   const hashedInitCode = keccak256(request.initCode);
   const hashedCallData = keccak256(request.callData);
   const hashedPaymasterAndData = keccak256(request.paymasterAndData);

--- a/packages/core/src/utils/testUtils.ts
+++ b/packages/core/src/utils/testUtils.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, custom, type Address, type Chain } from "viem";
+import { createPublicClient, custom, type Chain } from "viem";
 import {
   toSmartContractAccount,
   type SmartContractAccount,
@@ -7,15 +7,15 @@ import {
   createBundlerClientFromExisting,
   type BundlerClient,
 } from "../client/bundlerClient.js";
+import { getVersion060EntryPoint } from "../entrypoint/0.6.js";
 
 export const createDummySmartContractAccount = async <C extends BundlerClient>(
-  client: C,
-  entryPoint: Address
+  client: C
 ): Promise<SmartContractAccount> => {
   return toSmartContractAccount({
     source: "dummy",
     accountAddress: "0x1234567890123456789012345678901234567890",
-    entryPointAddress: entryPoint,
+    entryPoint: getVersion060EntryPoint(client.chain),
     chain: client.chain,
     transport: custom(client),
     signMessage: async () => "0xdeadbeef",


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the code to use the new `getEntryPoint()` method instead of `getEntrypoint()` in multiple files. 

### Detailed summary
- Updated `userOperationSimulator.ts` to use `getEntryPoint().address` instead of `getEntrypoint()`.
- Updated `gasEstimator.ts` to use `getEntryPoint().address` instead of `getEntrypoint()`.
- Updated `simulateUserOperationChanges.ts` to use `getEntryPoint().address` instead of `getEntrypoint()`.
- Updated `gasManager.ts` to use `getEntryPoint().address` instead of `getEntrypoint()`.
- Updated `requestPaymasterAndData` in `gasManager.ts` to use `getEntryPoint().address` instead of `getEntrypoint()`.
- Updated `createNaniAccount` in `account.ts` to use `getVersion060EntryPoint()` instead of `getEntryPointAddress()`.
- Updated `createLightAccount` in `account.ts` to use `getVersion060EntryPoint()` instead of `getEntryPointAddress()`.
- Updated `createDummySmartContractAccount` in `testUtils.ts` to use `getVersion060EntryPoint()` instead of `getEntrypoint()`.
- Updated `createMultiOwnerModularAccount` in `multiOwnerAccount.ts` to use `getVersion060EntryPoint()` instead of `getDefaultEntryPointAddress()`.
- Updated `createSimpleSmartAccount` in `smartContractAccount.ts` to use `getVersion060EntryPoint()` instead of `getEntryPointAddress()`.
- Updated `packUo` in `utils/index.ts` to be exported.
- Added `getVersion060EntryPoint` in `entrypoint/0.6.ts` to export the new entry point definition.

> The following files were skipped due to too many changes: `packages/core/src/account/smartContractAccount.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->