### PR TITLE
refactor: change index to be called salt

### DIFF
--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -50,7 +50,7 @@ export type CreateLightAccountParams<
   "transport" | "chain" | "entryPoint" | "accountAddress"
 > & {
   owner: TOwner;
-  index?: bigint;
+  salt?: bigint;
   factoryAddress?: Address;
   initCode?: Hex;
   version?: LightAccountVersion;
@@ -72,7 +72,7 @@ export async function createLightAccount({
   entryPoint = getVersion060EntryPoint(chain),
   accountAddress,
   factoryAddress = getDefaultLightAccountFactoryAddress(chain, version),
-  index: index_ = 0n,
+  salt: salt_ = 0n,
 }: CreateLightAccountParams): Promise<LightAccount> {
   let owner = owner_;
   const client = createBundlerClient({
@@ -83,18 +83,18 @@ export async function createLightAccount({
   const getAccountInitCode = async () => {
     if (initCode) return initCode;
 
-    const index = LightAccountUnsupported1271Factories.has(
+    const salt = LightAccountUnsupported1271Factories.has(
       factoryAddress.toLowerCase() as Address
     )
       ? 0n
-      : index_;
+      : salt_;
 
     return concatHex([
       factoryAddress,
       encodeFunctionData({
         abi: LightAccountFactoryAbi,
         functionName: "createAccount",
-        args: [await owner.getAddress(), index],
+        args: [await owner.getAddress(), salt],
       }),
     ]);
   };

--- a/packages/accounts/src/msca/account/multiOwnerAccount.ts
+++ b/packages/accounts/src/msca/account/multiOwnerAccount.ts
@@ -33,7 +33,7 @@ export type CreateMultiOwnerModularAccountParams<
   transport: TTransport;
   chain: Chain;
   owner: TOwner;
-  index?: bigint;
+  salt?: bigint;
   factoryAddress?: Address;
   owners?: Address[];
   entryPoint?: EntryPointDef<UserOperationRequest>;
@@ -57,7 +57,7 @@ export async function createMultiOwnerModularAccount({
   entryPoint = getVersion060EntryPoint(chain),
   factoryAddress = getDefaultMultiOwnerModularAccountFactoryAddress(chain),
   owners = [],
-  index = 0n,
+  salt = 0n,
 }: CreateMultiOwnerModularAccountParams): Promise<MultiOwnerModularAccount> {
   let owner = owner_;
   const client = createBundlerClient({
@@ -85,7 +85,7 @@ export async function createMultiOwnerModularAccount({
       encodeFunctionData({
         abi: MultiOwnerModularAccountFactoryAbi,
         functionName: "createAccount",
-        args: [index, owners_],
+        args: [salt, owners_],
       }),
     ]);
   };

--- a/packages/core/src/account/schema.ts
+++ b/packages/core/src/account/schema.ts
@@ -42,5 +42,5 @@ export const SimpleSmartAccountParamsSchema = <
     .extend({
       transport: z.custom<TTransport>(),
       owner: z.custom<TOwner>(isSigner),
-      index: z.bigint().optional(),
+      salt: z.bigint().optional(),
     });

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -39,7 +39,7 @@ class SimpleSmartContractAccount<
     });
     super({ ...params, rpcClient: client });
     this.owner = params.owner as TOwner;
-    this.index = params.index ?? 0n;
+    this.index = params.salt ?? 0n;
   }
 
   getDummySignature(): `0x${string}` {

--- a/site/migration-guide.md
+++ b/site/migration-guide.md
@@ -237,6 +237,10 @@ type toSmartContractAccount = <
 
 `chain` and `transport` have been added to the constructor and `rpcClient` has been removed.
 
+### Account: SimpleAccount and LightAccount intialization params
+
+`index` is now called `salt`
+
 ### Signer: `signTypedData` signature change
 
 The `signTypedData` method found on `SmartAccountSigner` has been updated to match the signature found on `SmartContractAccount` and viem's `Account`.


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the initialization parameters and variable names in the `Account` and `MultiOwnerAccount` classes. The `index` parameter is renamed to `salt` for better clarity.

### Detailed summary:
- In `schema.ts`:
  - The `index` property is renamed to `salt`.
- In `simple.ts`:
  - The `index` property is renamed to `salt`.
- In `migration-guide.md`:
  - The `index` parameter is renamed to `salt` in the `Account` initialization params section.
- In `multiOwnerAccount.ts`:
  - The `index` property is renamed to `salt` in the `createMultiOwnerModularAccount` function.
- In `account.ts`:
  - The `index` property is renamed to `salt` in the `createLightAccount` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->