### PR TITLE
docs: signer guides switch from la to ma

### DIFF
--- a/site/signers/guides/arcana-auth.md
+++ b/site/signers/guides/arcana-auth.md
@@ -50,9 +50,9 @@ Use the **clientId** assigned to your app via the dashboard and integrate with t
 
 <<< @/snippets/signers/arcana-auth.ts
 
-### Use it with LightAccount
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
 
 ::: code-group
 

--- a/site/signers/guides/capsule.md
+++ b/site/signers/guides/capsule.md
@@ -71,9 +71,10 @@ Next, setup the Capsule SDK and create an authenticated `CapsuleSigner` using th
 
 <<< @/snippets/signers/capsule.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
+
 ::: code-group
 
 ```ts [alchemy.ts]

--- a/site/signers/guides/dynamic.md
+++ b/site/signers/guides/dynamic.md
@@ -76,9 +76,9 @@ Next, inside any component which is wrapped by the above DynamicContextProvider,
 
 <<< @/snippets/signers/dynamic.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
 ::: code-group
 
 ```ts [example.ts]

--- a/site/signers/guides/fireblocks.md
+++ b/site/signers/guides/fireblocks.md
@@ -52,9 +52,10 @@ Next, setup the Fireblocks SDK and create an authenticated `FireblocksSigner` us
 
 <<< @/snippets/signers/fireblocks.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
+
 ::: code-group
 
 ```ts [example.ts]

--- a/site/signers/guides/lit.md
+++ b/site/signers/guides/lit.md
@@ -73,9 +73,10 @@ See documentation [here](https://developer.litprotocol.com/v3/sdk/wallets/mintin
 
 <<< @/snippets/signers/lit.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-We can link our `SmartAccountSigner` to a `LightSmartContractAccount` from `aa-accounts`:
+We can link our `SmartAccountSigner` to a Modular Account using `createModularAccountAlchemyClient` from `aa-alchemy`:
+
 ::: code-group
 
 ```ts [example.ts]

--- a/site/signers/guides/magic.md
+++ b/site/signers/guides/magic.md
@@ -50,9 +50,10 @@ Next, setup the magic sdk and create an authenticated `MagicSigner` using the `a
 
 <<< @/snippets/signers/magic.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
+
 ::: code-group
 
 ```ts [example.ts]

--- a/site/signers/guides/portal.md
+++ b/site/signers/guides/portal.md
@@ -50,9 +50,10 @@ Next, setup the Portal SDK and create an authenticated `PortalSigner` using the 
 
 <<< @/snippets/signers/portal.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
+
 ::: code-group
 
 ```ts [example.ts]

--- a/site/signers/guides/web3auth.md
+++ b/site/signers/guides/web3auth.md
@@ -50,9 +50,10 @@ Next, setup the web3auth sdk and create a `SmartAccountSigner` using the `aa-sig
 
 <<< @/snippets/signers/web3auth.ts
 
-### Use it with Light Account
+### Use it with Modular Account
 
-Let's see it in action with `aa-alchemy` and `LightSmartContractAccount` from `aa-accounts`:
+Let's see it in action with `aa-alchemy`:
+
 ::: code-group
 
 ```ts [example.ts]


### PR DESCRIPTION
We switched to using modular accounts on these guides. This PR just switches the language for consistency

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed "Light Account" to "Modular Account" in multiple files.
- Removed references to "LightSmartContractAccount" from `aa-accounts` in multiple files.
- Updated code examples to use `aa-alchemy` instead of `aa-accounts` in multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->