### PR TITLE
refactor: use signable message everywhere

### DIFF
--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -196,15 +196,13 @@ export async function createLightAccount({
       });
     },
     signUserOperationHash: async (uoHash: Hex) => {
-      return owner.signMessage(uoHash);
+      return owner.signMessage({ raw: uoHash });
     },
     async signMessage({ message }) {
       const version = await getLightAccountVersion(account);
       switch (version) {
         case "v1.0.1":
-          return owner.signMessage(
-            typeof message === "string" ? message : message.raw
-          );
+          return owner.signMessage(message);
         case "v1.0.2":
           throw new Error(
             `Version ${version} of LightAccount doesn't support 1271`

--- a/packages/accounts/src/msca/plugins/multi-owner/signer.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/signer.ts
@@ -6,7 +6,6 @@ import type {
 import {
   hashMessage,
   hashTypedData,
-  hexToBytes,
   type Hash,
   type Hex,
   type SignableMessage,
@@ -58,7 +57,7 @@ export const multiOwnerMessageSigner = <
     },
 
     signUserOperationHash: (uoHash: `0x${string}`): Promise<`0x${string}`> => {
-      return owner().signMessage(hexToBytes(uoHash));
+      return owner().signMessage({ raw: uoHash });
     },
 
     signMessage({

--- a/packages/accounts/src/msca/plugins/session-key/signer.ts
+++ b/packages/accounts/src/msca/plugins/session-key/signer.ts
@@ -2,6 +2,7 @@ import { LocalAccountSigner, type SmartAccountSigner } from "@alchemy/aa-core";
 import type {
   Hex,
   PrivateKeyAccount,
+  SignableMessage,
   TypedData,
   TypedDataDefinition,
 } from "viem";
@@ -61,7 +62,7 @@ export class SessionKeySigner
     return this.inner.getAddress();
   };
 
-  signMessage: (msg: string | Uint8Array) => Promise<`0x${string}`> = async (
+  signMessage: (msg: SignableMessage) => Promise<`0x${string}`> = async (
     msg
   ) => {
     return this.inner.signMessage(msg);

--- a/packages/accounts/src/nani-account/account.ts
+++ b/packages/accounts/src/nani-account/account.ts
@@ -15,7 +15,7 @@ import {
   concatHex,
   decodeFunctionResult,
   encodeFunctionData,
-  hexToBytes,
+  isHex,
   numberToHex,
   type Address,
   type Chain,
@@ -128,13 +128,9 @@ class NaniAccount_<
   }
 
   signMessage(msg: Uint8Array | string): Promise<Hex> {
-    if (typeof msg === "string" && msg.startsWith("0x")) {
-      msg = hexToBytes(msg as Hex);
-    } else if (typeof msg === "string") {
-      msg = new TextEncoder().encode(msg);
-    }
-
-    return this.owner.signMessage(msg);
+    return this.owner.signMessage(
+      typeof msg === "string" && !isHex(msg) ? msg : { raw: msg }
+    );
   }
 
   async encodeExecute(target: Hex, value: bigint, data: Hex): Promise<Hex> {

--- a/packages/alchemy/src/signer/signer.ts
+++ b/packages/alchemy/src/signer/signer.ts
@@ -2,9 +2,8 @@ import type { SmartAccountAuthenticator } from "@alchemy/aa-core";
 import {
   hashMessage,
   hashTypedData,
-  isHex,
-  toHex,
   type Hex,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -112,16 +111,10 @@ export class AlchemySigner
     return address;
   };
 
-  signMessage: (msg: string | Uint8Array) => Promise<`0x${string}`> = async (
+  signMessage: (msg: SignableMessage) => Promise<`0x${string}`> = async (
     msg
   ) => {
-    const messageHash = hashMessage(
-      typeof msg === "string" && !isHex(msg)
-        ? msg
-        : {
-            raw: isHex(msg) ? msg : toHex(msg),
-          }
-    );
+    const messageHash = hashMessage(msg);
 
     return this.inner.signRawMessage(messageHash);
   };

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -2,7 +2,7 @@ import type { Address } from "abitype";
 import {
   concatHex,
   encodeFunctionData,
-  hexToBytes,
+  isHex,
   type FallbackTransport,
   type Hex,
   type Transport,
@@ -79,13 +79,9 @@ class SimpleSmartContractAccount<
   }
 
   signMessage(msg: Uint8Array | string): Promise<`0x${string}`> {
-    if (typeof msg === "string" && msg.startsWith("0x")) {
-      msg = hexToBytes(msg as Hex);
-    } else if (typeof msg === "string") {
-      msg = new TextEncoder().encode(msg);
-    }
-
-    return this.owner.signMessage(msg);
+    return this.owner.signMessage(
+      typeof msg === "string" && !isHex(msg) ? msg : { raw: msg }
+    );
   }
 
   setOwner(owner: TOwner): void {

--- a/packages/core/src/signer/__tests__/local-account.test.ts
+++ b/packages/core/src/signer/__tests__/local-account.test.ts
@@ -8,7 +8,9 @@ describe("Local Account Signer Tests", () => {
     it("should sign a hex message properly", async () => {
       const signer = LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
       expect(
-        await signer.signMessage("0xabcfC3DB1e0f5023F5a4f40c03D149f316E6A5cc")
+        await signer.signMessage({
+          raw: "0xabcfC3DB1e0f5023F5a4f40c03D149f316E6A5cc",
+        })
       ).toMatchInlineSnapshot(
         '"0x35761512143ffd8da07c93c5a0136424fe935b48e77076f501a57745c16268bf0d9a5d6209b12d5f8b62f96f0991372e046092fd6b1e3bfa610eb51607a28f7e1b"'
       );
@@ -32,7 +34,9 @@ describe("Local Account Signer Tests", () => {
     it("should sign a byte array correctly", async () => {
       const signer = LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
       expect(
-        await signer.signMessage(new TextEncoder().encode("hello, I'm moldy"))
+        await signer.signMessage({
+          raw: new TextEncoder().encode("hello, I'm moldy"),
+        })
       ).toEqual(await signer.signMessage("hello, I'm moldy"));
     });
   });
@@ -45,7 +49,9 @@ describe("Local Account Signer Tests", () => {
       const signer =
         LocalAccountSigner.privateKeyToAccountSigner(dummyPrivateKey);
       expect(
-        await signer.signMessage("0xabcfC3DB1e0f5023F5a4f40c03D149f316E6A5cc")
+        await signer.signMessage({
+          raw: "0xabcfC3DB1e0f5023F5a4f40c03D149f316E6A5cc",
+        })
       ).toMatchInlineSnapshot(
         '"0x91b6680c8f442f46ca71fee15cdd8c9e25693baeb4006d1908a453fd145315ce21a5e7f2ce9760fc993d65e8450fa5225d8dee12972886bdacbb989ca0b09c6c1b"'
       );
@@ -71,7 +77,9 @@ describe("Local Account Signer Tests", () => {
       const signer =
         LocalAccountSigner.privateKeyToAccountSigner(dummyPrivateKey);
       expect(
-        await signer.signMessage(new TextEncoder().encode("hello, I'm moldy"))
+        await signer.signMessage({
+          raw: new TextEncoder().encode("hello, I'm moldy"),
+        })
       ).toEqual(await signer.signMessage("hello, I'm moldy"));
     });
   });

--- a/packages/core/src/signer/local-account.ts
+++ b/packages/core/src/signer/local-account.ts
@@ -1,9 +1,9 @@
 import {
-  isHex,
   type HDAccount,
   type Hex,
   type LocalAccount,
   type PrivateKeyAccount,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -22,20 +22,10 @@ export class LocalAccountSigner<
     this.signerType = inner.type; //  type: "local"
   }
 
-  readonly signMessage: (msg: string | Uint8Array) => Promise<`0x${string}`> = (
-    msg
+  readonly signMessage: (message: SignableMessage) => Promise<`0x${string}`> = (
+    message
   ) => {
-    if (typeof msg === "string" && !isHex(msg)) {
-      return this.inner.signMessage({
-        message: msg,
-      });
-    } else {
-      return this.inner.signMessage({
-        message: {
-          raw: msg,
-        },
-      });
-    }
+    return this.inner.signMessage({ message });
   };
 
   readonly signTypedData = async <

--- a/packages/core/src/signer/types.ts
+++ b/packages/core/src/signer/types.ts
@@ -1,5 +1,10 @@
 import type { Address } from "abitype";
-import type { Hex, TypedData, TypedDataDefinition } from "viem";
+import type {
+  Hex,
+  SignableMessage,
+  TypedData,
+  TypedDataDefinition,
+} from "viem";
 
 /**
  * Extends the @interface SmartAccountSigner interface with authentication.
@@ -36,7 +41,7 @@ export interface SmartAccountSigner<Inner = any> {
 
   getAddress: () => Promise<Address>;
 
-  signMessage: (msg: Uint8Array | Hex | string) => Promise<Hex>;
+  signMessage: (message: SignableMessage) => Promise<Hex>;
 
   signTypedData: <
     const TTypedData extends TypedData | { [key: string]: unknown },

--- a/packages/core/src/signer/wallet-client.ts
+++ b/packages/core/src/signer/wallet-client.ts
@@ -1,8 +1,7 @@
 import {
   getAddress,
-  isHex,
-  type ByteArray,
   type Hex,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
   type WalletClient,
@@ -27,23 +26,12 @@ export class WalletClientSigner implements SmartAccountSigner<WalletClient> {
     return getAddress(addresses[0]);
   };
 
-  readonly signMessage: (
-    message: string | Hex | ByteArray
-  ) => Promise<`0x${string}`> = async (message) => {
-    const account = this.inner.account ?? (await this.getAddress());
+  readonly signMessage: (message: SignableMessage) => Promise<`0x${string}`> =
+    async (message) => {
+      const account = this.inner.account ?? (await this.getAddress());
 
-    if (typeof message === "string" && !isHex(message)) {
-      return this.inner.signMessage({
-        account,
-        message,
-      });
-    } else {
-      return this.inner.signMessage({
-        account,
-        message: { raw: message },
-      });
-    }
-  };
+      return this.inner.signMessage({ message, account });
+    };
 
   signTypedData = async <
     const TTypedData extends TypedData | { [key: string]: unknown },

--- a/packages/ethers/src/account-signer.ts
+++ b/packages/ethers/src/account-signer.ts
@@ -14,7 +14,7 @@ import {
   type TransactionRequest,
   type TransactionResponse,
 } from "@ethersproject/providers";
-import { isHex } from "viem";
+import { isHex, toBytes } from "viem";
 import { EthersProviderAdapter } from "./provider-adapter.js";
 
 const hexlifyOptional = (value: any): `0x${string}` | undefined => {
@@ -70,7 +70,7 @@ export class AccountSigner<
       message:
         typeof message === "string" && !isHex(message)
           ? message
-          : { raw: message },
+          : { raw: isHex(message) ? toBytes(message) : message },
     });
   }
 

--- a/packages/ethers/src/utils.ts
+++ b/packages/ethers/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Address, SmartAccountSigner } from "@alchemy/aa-core";
 import type { Signer } from "@ethersproject/abstract-signer";
 import { Wallet } from "@ethersproject/wallet";
-import type { TypedData, TypedDataDefinition } from "viem";
+import type { SignableMessage, TypedData, TypedDataDefinition } from "viem";
 
 /**
  * Converts a ethersjs Wallet to a SmartAccountSigner
@@ -15,8 +15,10 @@ export const convertWalletToAccountSigner = (
     inner: wallet,
     signerType: "local",
     getAddress: async () => Promise.resolve(wallet.address as `0x${string}`),
-    signMessage: async (msg: Uint8Array | string) =>
-      (await wallet.signMessage(msg)) as `0x${string}`,
+    signMessage: async (msg: SignableMessage) =>
+      (await wallet.signMessage(
+        typeof msg === "string" ? msg : msg.raw
+      )) as `0x${string}`,
     signTypedData: async <
       const TTypedData extends TypedData | { [key: string]: unknown },
       TPrimaryType extends string = string
@@ -45,8 +47,10 @@ export const convertEthersSignerToAccountSigner = (
     inner: signer,
     signerType: "json-rpc",
     getAddress: async () => signer.getAddress() as Promise<Address>,
-    signMessage: async (msg: Uint8Array | string) =>
-      (await signer.signMessage(msg)) as `0x${string}`,
+    signMessage: async (msg: SignableMessage) =>
+      (await signer.signMessage(
+        typeof msg === "string" ? msg : msg.raw
+      )) as `0x${string}`,
     signTypedData: async <
       const TTypedData extends TypedData | { [key: string]: unknown },
       TPrimaryType extends string = string

--- a/packages/signers/src/arcana-auth/signer.ts
+++ b/packages/signers/src/arcana-auth/signer.ts
@@ -11,6 +11,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -57,7 +58,7 @@ export class ArcanaAuthSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/capsule/signer.ts
+++ b/packages/signers/src/capsule/signer.ts
@@ -7,6 +7,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
   type WalletClient,
@@ -64,7 +65,7 @@ export class CapsuleSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/fireblocks/signer.ts
+++ b/packages/signers/src/fireblocks/signer.ts
@@ -10,6 +10,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -58,7 +59,7 @@ export class FireblocksSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/lit-protocol/signer.ts
+++ b/packages/signers/src/lit-protocol/signer.ts
@@ -9,12 +9,13 @@ import {
   type LITEVMChain,
   type SessionSigsMap,
 } from "@lit-protocol/types";
-import type {
-  Address,
-  Hex,
-  TypedData,
-  TypedDataDefinition,
-  TypedDataDomain,
+import {
+  type Address,
+  type Hex,
+  type SignableMessage,
+  type TypedData,
+  type TypedDataDefinition,
+  type TypedDataDomain,
 } from "viem";
 import { signerTypePrefix } from "../constants.js";
 import {
@@ -92,10 +93,12 @@ export class LitSigner<C extends LitAuthMethod | LitSessionSigsMap>
     return this.signer?.getAddress() as Promise<Address>;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     this._checkInternals();
 
-    return this.signer?.signMessage(msg) as Promise<Hex>;
+    return this.signer?.signMessage(
+      typeof msg === "string" ? msg : msg.raw
+    ) as Promise<Hex>;
   };
 
   signTypedData = async <

--- a/packages/signers/src/magic/signer.ts
+++ b/packages/signers/src/magic/signer.ts
@@ -7,6 +7,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -46,7 +47,7 @@ export class MagicSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/particle/signer.ts
+++ b/packages/signers/src/particle/signer.ts
@@ -12,6 +12,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -85,7 +86,7 @@ export class ParticleSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/portal/signer.ts
+++ b/packages/signers/src/portal/signer.ts
@@ -7,6 +7,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -50,7 +51,7 @@ export class PortalSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/turnkey/signer.ts
+++ b/packages/signers/src/turnkey/signer.ts
@@ -7,6 +7,7 @@ import { createAccount } from "@turnkey/viem";
 import {
   createWalletClient,
   type LocalAccount,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -54,7 +55,7 @@ export class TurnkeySigner
     return this.signer.getAddress();
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);

--- a/packages/signers/src/web3auth/signer.ts
+++ b/packages/signers/src/web3auth/signer.ts
@@ -7,6 +7,7 @@ import {
   createWalletClient,
   custom,
   type Hash,
+  type SignableMessage,
   type TypedData,
   type TypedDataDefinition,
 } from "viem";
@@ -54,7 +55,7 @@ export class Web3AuthSigner
     return address as Hash;
   };
 
-  signMessage = async (msg: Uint8Array | string) => {
+  signMessage = async (msg: SignableMessage) => {
     if (!this.signer) throw new Error("Not authenticated");
 
     return this.signer.signMessage(msg);


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the signMessage function in various signers to accept a SignableMessage object instead of a Uint8Array or string. 

### Detailed summary
- Updated signUserOperationHash function in multi-owner signer to use SignableMessage object
- Updated signMessage function in magic, portal, particle, web3auth, capsule, fireblocks, arcana-auth, session-key, turnkey, alchemy, nani-account, local-account, lit-protocol, wallet-client signers to use SignableMessage object
- Updated signMessage function in account-signer to handle both string and SignableMessage inputs
- Updated signMessage function in ethers/utils to use SignableMessage object
- Added import for SignableMessage type in core/signer/types.ts

> The following files were skipped due to too many changes: `packages/ethers/src/utils.ts`, `packages/core/src/signer/__tests__/local-account.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->