### PR TITLE
feat!: breaking change transition percent to multiplier for feeOverrides and dropAndReplace

### DIFF
--- a/packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts
+++ b/packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts
@@ -287,8 +287,8 @@ const givenConnectedProvider = async ({
     opts: {
       feeOptions: {
         ...feeOptions,
-        maxFeePerGas: { percentage: 50 },
-        maxPriorityFeePerGas: { percentage: 50 },
+        maxFeePerGas: { multiplier: 1.5 },
+        maxPriorityFeePerGas: { multiplier: 1.5 },
       },
       txMaxRetries: 100,
     },

--- a/packages/alchemy/e2e-tests/light-account.e2e.test.ts
+++ b/packages/alchemy/e2e-tests/light-account.e2e.test.ts
@@ -144,9 +144,9 @@ describe("Light Account Tests", () => {
       },
       opts: {
         feeOptions: {
-          maxFeePerGas: { percentage: 50 },
-          maxPriorityFeePerGas: { percentage: 50 },
-          preVerificationGas: { percentage: 50 },
+          maxFeePerGas: { multiplier: 1.5 },
+          maxPriorityFeePerGas: { multiplier: 1.5 },
+          preVerificationGas: { multiplier: 1.5 },
         },
       },
     });
@@ -320,8 +320,8 @@ const givenConnectedProvider = async ({
       txMaxRetries: 10,
       ...opts,
       feeOptions: {
-        maxFeePerGas: { percentage: 50 },
-        maxPriorityFeePerGas: { percentage: 50 },
+        maxFeePerGas: { multiplier: 1.5 },
+        maxPriorityFeePerGas: { multiplier: 1.5 },
         ...opts?.feeOptions,
       },
     },

--- a/packages/alchemy/src/defaults.ts
+++ b/packages/alchemy/src/defaults.ts
@@ -13,8 +13,8 @@ export const getDefaultUserOperationFeeOptions = (
   chain: Chain
 ): UserOperationFeeOptions => {
   const feeOptions: UserOperationFeeOptions = {
-    maxFeePerGas: { percentage: 50 },
-    maxPriorityFeePerGas: { percentage: 5 },
+    maxFeePerGas: { multiplier: 1.5 },
+    maxPriorityFeePerGas: { multiplier: 1.05 },
   };
 
   if (
@@ -27,7 +27,7 @@ export const getDefaultUserOperationFeeOptions = (
       optimismSepolia.id,
     ]).has(chain.id)
   ) {
-    feeOptions.preVerificationGas = { percentage: 5 };
+    feeOptions.preVerificationGas = { multiplier: 1.05 };
   }
 
   return feeOptions;

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -7,10 +7,10 @@ import {
   defaultGasEstimator,
   filterUndefined,
   isBigNumberish,
-  isPercentage,
+  isMultiplier,
   resolveProperties,
   type Hex,
-  type Percentage,
+  type Multiplier,
   type UserOperationFeeOptions,
   type UserOperationRequest,
 } from "@alchemy/aa-core";
@@ -19,11 +19,11 @@ import type { ClientWithAlchemyMethods } from "../client/types";
 import { alchemyFeeEstimator } from "./feeEstimator.js";
 
 export type RequestGasAndPaymasterAndDataOverrides = Partial<{
-  maxFeePerGas: UserOperationRequest["maxFeePerGas"] | Percentage;
-  maxPriorityFeePerGas: UserOperationRequest["maxFeePerGas"] | Percentage;
-  callGasLimit: UserOperationRequest["maxFeePerGas"] | Percentage;
-  preVerificationGas: UserOperationRequest["maxFeePerGas"] | Percentage;
-  verificationGasLimit: UserOperationRequest["maxFeePerGas"] | Percentage;
+  maxFeePerGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
+  maxPriorityFeePerGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
+  callGasLimit: UserOperationRequest["maxFeePerGas"] | Multiplier;
+  preVerificationGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
+  verificationGasLimit: UserOperationRequest["maxFeePerGas"] | Multiplier;
 }>;
 
 export interface AlchemyGasManagerConfig {
@@ -138,26 +138,24 @@ const requestGasAndPaymasterData: <C extends ClientWithAlchemyMethods>(
 
     const overrideField = (
       field: keyof UserOperationFeeOptions
-    ): Hex | Percentage | undefined => {
+    ): Hex | Multiplier | undefined => {
       if (overrides?.[field] != null) {
         // one-off absolute override
         if (isBigNumberish(overrides[field])) {
           return deepHexlify(overrides[field]);
         }
-        // one-off percentage overrides
+        // one-off multiplier overrides
         else {
           return {
-            percentage:
-              100 + Number((overrides[field] as Percentage).percentage),
+            multiplier: Number((overrides[field] as Multiplier).multiplier),
           };
         }
       }
 
-      // provider level fee options with percentage
-      if (isPercentage(feeOptions?.[field])) {
+      // provider level fee options with multiplier
+      if (isMultiplier(feeOptions?.[field])) {
         return {
-          percentage:
-            100 + Number((feeOptions![field] as Percentage).percentage),
+          multiplier: Number((feeOptions![field] as Multiplier).multiplier),
         };
       }
 

--- a/packages/core/e2e-tests/simple-account.e2e.test.ts
+++ b/packages/core/e2e-tests/simple-account.e2e.test.ts
@@ -76,7 +76,7 @@ describe("Simple Account Tests", () => {
     expect(isAddress(address)).toBe(true);
   });
 
-  it("should correctly handle percentage overrides for buildUserOperation", async () => {
+  it("should correctly handle multiplier overrides for buildUserOperation", async () => {
     const signer = await givenConnectedProvider({
       owner,
       chain,
@@ -95,7 +95,7 @@ describe("Simple Account Tests", () => {
       owner,
       chain,
       feeOptions: {
-        preVerificationGas: { percentage: 100 },
+        preVerificationGas: { multiplier: 2 },
       },
     });
 
@@ -147,12 +147,12 @@ describe("Simple Account Tests", () => {
     expect(struct.preVerificationGas).toBe(100_000_000n);
   }, 60000);
 
-  it("should correctly handle percentage overrides for sendUserOperation", async () => {
+  it("should correctly handle multiplier overrides for sendUserOperation", async () => {
     const signer = await givenConnectedProvider({
       owner,
       chain,
       feeOptions: {
-        preVerificationGas: { percentage: 100 },
+        preVerificationGas: { multiplier: 2 },
       },
     });
 

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -5,7 +5,7 @@ import type { SendUserOperationResult } from "../../client/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import type { UserOperationOverrides, UserOperationStruct } from "../../types";
-import { bigIntMax, bigIntPercent } from "../../utils/index.js";
+import { bigIntMax, bigIntMultiply } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { DropAndReplaceUserOperationParameters } from "./types";
@@ -54,11 +54,11 @@ export const dropAndReplaceUserOperation: <
   const _overrides: UserOperationOverrides = {
     maxFeePerGas: bigIntMax(
       BigInt(maxFeePerGas ?? 0n),
-      bigIntPercent(uoToDrop.maxFeePerGas, 110n)
+      bigIntMultiply(uoToDrop.maxFeePerGas, 1.1)
     ),
     maxPriorityFeePerGas: bigIntMax(
       BigInt(maxPriorityFeePerGas ?? 0n),
-      bigIntPercent(uoToDrop.maxPriorityFeePerGas, 110n)
+      bigIntMultiply(uoToDrop.maxPriorityFeePerGas, 1.1)
     ),
   };
 

--- a/packages/core/src/client/schema.ts
+++ b/packages/core/src/client/schema.ts
@@ -1,7 +1,7 @@
 import type { Transport } from "viem";
 import { z } from "zod";
 
-import { BigNumberishRangeSchema, PercentageSchema } from "../utils/index.js";
+import { BigNumberishRangeSchema, MultiplierSchema } from "../utils/index.js";
 import type { BundlerClient } from "./bundlerClient.js";
 
 export const createPublicErc4337ClientSchema = <
@@ -42,7 +42,7 @@ export const ConnectionConfigSchema = z.union([
 ]);
 
 export const UserOperationFeeOptionsFieldSchema =
-  BigNumberishRangeSchema.merge(PercentageSchema).partial();
+  BigNumberishRangeSchema.merge(MultiplierSchema).partial();
 
 export const UserOperationFeeOptionsSchema = z
   .object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,7 +119,7 @@ export {
   applyUserOpOverrideOrFeeOption,
   asyncPipe,
   bigIntMax,
-  bigIntPercent,
+  bigIntMultiply,
   deepHexlify,
   defineReadOnly,
   filterUndefined,
@@ -129,6 +129,6 @@ export {
   getDefaultUserOperationFeeOptions,
   getUserOperationHash,
   isBigNumberish,
-  isPercentage,
+  isMultiplier,
   resolveProperties,
 } from "./utils/index.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,7 +8,7 @@ import type {
   BigNumberishRangeSchema,
   BigNumberishSchema,
   HexSchema,
-  PercentageSchema,
+  MultiplierSchema,
 } from "./utils";
 
 export type Hex = z.input<typeof HexSchema>;
@@ -17,7 +17,7 @@ export type EmptyHex = `0x`;
 // based on @account-abstraction/common
 export type PromiseOrValue<T> = T | Promise<T>;
 export type BytesLike = Uint8Array | Hex;
-export type Percentage = z.input<typeof PercentageSchema>;
+export type Multiplier = z.input<typeof MultiplierSchema>;
 
 export type BigNumberish = z.input<typeof BigNumberishSchema>;
 export type BigNumberishRange = z.input<typeof BigNumberishRangeSchema>;
@@ -44,15 +44,15 @@ export type UserOperationFeeOptions = z.input<
 >;
 
 export type UserOperationOverrides = Partial<{
-  callGasLimit: UserOperationStruct["callGasLimit"] | Percentage;
-  maxFeePerGas: UserOperationStruct["maxFeePerGas"] | Percentage;
+  callGasLimit: UserOperationStruct["callGasLimit"] | Multiplier;
+  maxFeePerGas: UserOperationStruct["maxFeePerGas"] | Multiplier;
   maxPriorityFeePerGas:
     | UserOperationStruct["maxPriorityFeePerGas"]
-    | Percentage;
-  preVerificationGas: UserOperationStruct["preVerificationGas"] | Percentage;
+    | Multiplier;
+  preVerificationGas: UserOperationStruct["preVerificationGas"] | Multiplier;
   verificationGasLimit:
     | UserOperationStruct["verificationGasLimit"]
-    | Percentage;
+    | Multiplier;
   paymasterAndData: UserOperationStruct["paymasterAndData"];
 }>;
 

--- a/packages/core/src/utils/__tests__/bigint.test.ts
+++ b/packages/core/src/utils/__tests__/bigint.test.ts
@@ -1,0 +1,29 @@
+import { RoundingMode, bigIntMultiply } from "../bigint.js";
+
+describe("BigInt utility", () => {
+  describe("multiplication operations", () => {
+    it("should multiply a big int correctly with an int", async () => {
+      expect(bigIntMultiply(10n, 2, RoundingMode.ROUND_UP)).toEqual(20n);
+    });
+
+    it("should multiply a big int correctly with a float", async () => {
+      expect(bigIntMultiply(10n, 0.5, RoundingMode.ROUND_UP)).toEqual(5n);
+    });
+
+    it("should fail to multiply a big int and a float with too much precision", async () => {
+      expect(() =>
+        bigIntMultiply(10n, 0.53958491842948789, RoundingMode.ROUND_UP)
+      ).toThrowError(
+        "bigIntMultiply requires a multiplier validated number as the second argument"
+      );
+    });
+
+    it("should multiply a big int correctly when rouding up", async () => {
+      expect(bigIntMultiply(10n, 0.53, RoundingMode.ROUND_UP)).toEqual(6n);
+    });
+
+    it("should multiply a big int correctly when rouding down", async () => {
+      expect(bigIntMultiply(10n, 0.53, RoundingMode.ROUND_DOWN)).toEqual(5n);
+    });
+  });
+});

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -94,7 +94,7 @@ export const getDefaultUserOperationFeeOptions = (
   return {
     maxPriorityFeePerGas: {
       min: minPriorityFeePerBidDefaults.get(chain.id) ?? 100_000_000n,
-      percentage: 33,
+      multiplier: 1.33,
     },
   };
 };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,13 +2,7 @@ import type { Address, Chain, Hash, Hex } from "viem";
 import { encodeAbiParameters, hexToBigInt, keccak256, toHex } from "viem";
 import * as chains from "viem/chains";
 import * as alchemyChains from "../chains/index.js";
-import type {
-  BigNumberish,
-  Percentage,
-  PromiseOrValue,
-  UserOperationRequest,
-} from "../types.js";
-import { BigNumberishSchema, PercentageSchema } from "./schema.js";
+import type { PromiseOrValue, UserOperationRequest } from "../types.js";
 
 export const AlchemyChainMap = new Map<number, Chain>(
   Object.values(alchemyChains).map((c) => [c.id, c])
@@ -165,14 +159,6 @@ export function defineReadOnly<T, K extends keyof T>(
     value: value,
     writable: false,
   });
-}
-
-export function isBigNumberish(x: any): x is BigNumberish {
-  return x != null && BigNumberishSchema.safeParse(x).success;
-}
-
-export function isPercentage(x: any): x is Percentage {
-  return x != null && PercentageSchema.safeParse(x).success;
 }
 
 export function filterUndefined(

--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -1,5 +1,6 @@
 import { isHex, type Chain } from "viem";
 import { z } from "zod";
+import type { BigNumberish, Multiplier } from "../types";
 
 export const ChainSchema = z.custom<Chain>(
   (chain) =>
@@ -22,11 +23,24 @@ export const BigNumberishRangeSchema = z
   })
   .strict();
 
-export const PercentageSchema = z
+export const MultiplierSchema = z
   .object({
     /**
-     * Percent value between 1 and 1000 inclusive
+     * Multiplier value with max precision of 4 decmial places
      */
-    percentage: z.number().min(1).max(1000),
+    multiplier: z.number().refine(
+      (n) => {
+        return (n.toString().split(".")[1]?.length ?? 0) <= 4;
+      },
+      { message: "Max precision is 4 decimal places" }
+    ),
   })
   .strict();
+
+export function isBigNumberish(x: any): x is BigNumberish {
+  return x != null && BigNumberishSchema.safeParse(x).success;
+}
+
+export function isMultiplier(x: any): x is Multiplier {
+  return x != null && MultiplierSchema.safeParse(x).success;
+}

--- a/packages/core/src/utils/userop.ts
+++ b/packages/core/src/utils/userop.ts
@@ -1,11 +1,11 @@
 import type {
   BigNumberish,
-  Percentage,
+  Multiplier,
   UserOperationFeeOptionsField,
   UserOperationRequest,
   UserOperationStruct,
 } from "../types";
-import { bigIntClamp, bigIntPercent } from "./bigint.js";
+import { bigIntClamp, bigIntMultiply } from "./bigint.js";
 import { isBigNumberish } from "./index.js";
 
 /**
@@ -29,7 +29,7 @@ export function isValidRequest(
 
 export function applyUserOpOverride(
   value: BigNumberish | undefined,
-  override?: BigNumberish | Percentage
+  override?: BigNumberish | Multiplier
 ): BigNumberish | undefined {
   if (override == null) {
     return value;
@@ -39,11 +39,9 @@ export function applyUserOpOverride(
     return override;
   }
 
-  // percentage override
+  // multiplier override
   else {
-    return value != null
-      ? bigIntPercent(value, BigInt(100 + override.percentage))
-      : value;
+    return value != null ? bigIntMultiply(value, override.multiplier) : value;
   }
 }
 
@@ -56,8 +54,8 @@ export function applyUserOpFeeOption(
   }
   return value != null
     ? bigIntClamp(
-        feeOption.percentage
-          ? bigIntPercent(value, BigInt(100 + feeOption.percentage))
+        feeOption.multiplier
+          ? bigIntMultiply(value, feeOption.multiplier)
           : value,
         feeOption.min,
         feeOption.max
@@ -67,7 +65,7 @@ export function applyUserOpFeeOption(
 
 export function applyUserOpOverrideOrFeeOption(
   value: BigNumberish | undefined,
-  override?: BigNumberish | Percentage,
+  override?: BigNumberish | Multiplier,
   feeOption?: UserOperationFeeOptionsField
 ): BigNumberish {
   return value != null && override != null

--- a/site/migration-guide.md
+++ b/site/migration-guide.md
@@ -268,3 +268,25 @@ The `getPublicErc4337Client` method has been renamed to `getBundlerClient` to ma
 ### Ethers: Updated Signer Adapter constructor
 
 The `AccountSigner` now takes in a `SmartContractAccount` as a param in its constructor.
+
+### Core: Transition from ~~`Percent`~~ to `Multiplier` api and types
+
+The `Percent` type and `PercentSchema` have been removed in favor of the `Multiplier` type and `MultiplierSchema`.
+
+Going forward when using the feeOptions, you can specify the `Multiplier` type instead of a `Percent`. The `Multiplier` type is a number that represents direct multipliaction of the estimation. For example, `0.1` is 10% of the estimated value and `1` is 100% of the estimated value.
+
+```ts
+createModularAccountAlchemyClient({
+    ...
+    opts: {
+      ...
+      // The maxFeePerGas and maxPriorityFeePerGas estimated values will now be multipled by 1.5
+      feeOptions: {
+        // This was previously { percent: 50n }
+        maxFeePerGas: { multiplier: 1.5 },
+        // This was previously { percent: 25n }
+        maxPriorityFeePerGas: { multiplier: 1.25 },
+      },
+    },
+  });
+```

--- a/site/packages/aa-alchemy/smart-account-client/index.md
+++ b/site/packages/aa-alchemy/smart-account-client/index.md
@@ -37,9 +37,9 @@ export const client = createAlchemySmartAccountClient({
     txRetryMultiplier: 1.5,
     minPriorityFeePerBid: 100_000_000n,
     feeOpts: {
-      baseFeeBufferPercent: 50n,
-      maxPriorityFeeBufferPercent: 5n,
-      preVerificationGasBufferPercent: 5n,
+      baseFeeBufferMultiplier: 1.5n,
+      maxPriorityFeeBufferMultiplier: 1.05,
+      preVerificationGasBufferMultiplier: 1.05,
     },
   },
   // will simulate user operations before sending them to ensure they don't revert

--- a/site/packages/aa-core/smart-account-client/types/userOperationFeeOptions.md
+++ b/site/packages/aa-core/smart-account-client/types/userOperationFeeOptions.md
@@ -42,7 +42,7 @@ const rpcTransport = http("https://polygon-mumbai.g.alchemy.com/v2/demo");
 const userOperationFeeOptions: UserOperationFeeOptions = {
   maxPriorityFeePerGas: {
     min: 100_000_000n,
-    percentage: 50,
+    multiplier: 1.5,
   },
 };
 

--- a/site/packages/aa-core/smart-account-client/types/userOperationFeeOptionsField.md
+++ b/site/packages/aa-core/smart-account-client/types/userOperationFeeOptionsField.md
@@ -14,7 +14,7 @@ head:
 
 # UserOperationFeeOptionsField
 
-Merged type of [`BigNumberishRange`](/resources/types.md#bignumberishrange) with [`Percentage`](/resources/types.md#percentage) type that can be used as [`UserOperationFeeOptions`](./userOperationFeeOptions.md) fields for the [`SmartAccountClient`](/packages/aa-core/smart-account-client/index.md) to use during the gas fee calculation middlewares when constructing the user operation to send.
+Merged type of [`BigNumberishRange`](/resources/types.md#bignumberishrange) with [`Multiplier`](/resources/types.md#multiplier) type that can be used as [`UserOperationFeeOptions`](./userOperationFeeOptions.md) fields for the [`SmartAccountClient`](/packages/aa-core/smart-account-client/index.md) to use during the gas fee calculation middlewares when constructing the user operation to send.
 
 For example, if the below example `UserOperationFeeOptionsField` is set as the fee option for the `maxPriorityFeePerGas` field of [`UserOperationFeeOptions`](./userOperationFeeOptions.md), then the [`SmartAccountClient`](/packages/aa-core/smart-account-client/index.md) will apply 50% buffer to the estimated `maxPriorityFeePerGas`, then set the `maxPriorityFeePerGas` on the user operation as the larger value between the buffered `maxPriorityFeePerGas` fee and the min `maxPriorityFeePerGas` which is `100_000_000n` here.
 
@@ -23,10 +23,10 @@ For example, if the below example `UserOperationFeeOptionsField` is set as the f
  * {
  *   min?: BigNumberish
  *   max?: BigNumberish
- *   percentage?: number
+ *   multiplier?: number
  * }
  */
-type UserOperationFeeOptionsFieldSchema = BigNumberishRange & Percentage;
+type UserOperationFeeOptionsFieldSchema = BigNumberishRange & Multiplier;
 ```
 
 ## Usage
@@ -38,7 +38,7 @@ import { type UserOperationFeeOptionsField } from "@alchemy/aa-core";
 
 const userOperationFeeOptionsField: UserOperationFeeOptionsField = {
   min: 100_000_000n,
-  percentage: 50,
+  multiplier: 1.5,
 };
 ```
 

--- a/site/packages/aa-core/smart-account-client/types/userOperationOverrides.md
+++ b/site/packages/aa-core/smart-account-client/types/userOperationOverrides.md
@@ -20,7 +20,7 @@ Contains override values to be applied on the user operation request to be const
 
 These override values are available from each middleware of the `SmartAccountClient`. For example, the default middlewares such as `gasEstimator` or `feeEstimator` apply the overrides values to the estimated values if the override values are provided.
 
-Other than the `paymasterAndData` field, the override fields could be either the absolute value or the percentage value. In the default middlewares, if the override value is an absolute value, it simply overrides the estimated value. If the override value is a percentage value, the estimated value is _bumped_ with the indicated percentage value. For example, if the override value is `{ percentage: 10 }` for the `maxPriorityFeePerGas` field, then 10% bump is applied to the estimated `maxPriorityFeePerGas` of the user operation.
+Other than the `paymasterAndData` field, the override fields could be either the absolute value or the multiplier value. In the default middlewares, if the override value is an absolute value, it simply overrides the estimated value. If the override value is a multiplier value, the estimated value is _bumped_ with the indicated multiplier value. For example, if the override value is `{ multiplier: 1.1 }` for the `maxPriorityFeePerGas` field, then a 1.1 multiplier, or a 10% increase, is applied to the estimated `maxPriorityFeePerGas` of the user operation.
 
 The `paymasterAndData` only allows an absolute value override, and if the override value is provided, then the paymaster middleware is bypassed entirely. Refer to our guide [How to handle User Operations that are not eligible for gas sponsorship](/using-smart-accounts/sponsoring-gas/checking-eligibility.md) on the example of using the `paymasterAndData` override to bypass the paymaster middleware to fallback to the user paying the gas fee instead of the gas being subsidized by the paymaster.
 
@@ -32,15 +32,15 @@ Note that if you are using your own middleware, for example a custom `feeEstimat
 type BytesLike = Uint8Array | Hex;
 
 export type UserOperationOverrides = Partial<{
-  callGasLimit: UserOperationStruct["callGasLimit"] | Percentage;
-  maxFeePerGas: UserOperationStruct["maxFeePerGas"] | Percentage;
+  callGasLimit: UserOperationStruct["callGasLimit"] | Multiplier;
+  maxFeePerGas: UserOperationStruct["maxFeePerGas"] | Multiplier;
   maxPriorityFeePerGas:
     | UserOperationStruct["maxPriorityFeePerGas"]
-    | Percentage;
-  preVerificationGas: UserOperationStruct["preVerificationGas"] | Percentage;
+    | Multiplier;
+  preVerificationGas: UserOperationStruct["preVerificationGas"] | Multiplier;
   verificationGasLimit:
     | UserOperationStruct["verificationGasLimit"]
-    | Percentage;
+    | Multiplier;
   paymasterAndData: UserOperationStruct["paymasterAndData"];
 }>;
 ```

--- a/site/packages/aa-ethers/provider-adapter/constructor.md
+++ b/site/packages/aa-ethers/provider-adapter/constructor.md
@@ -44,9 +44,9 @@ export const accountProvider = createAlchemySmartAccountClient({
     txRetryMultiplier: 1.5,
     minPriorityFeePerBid: 100_000_000n,
     feeOpts: {
-      baseFeeBufferPercent: 50n,
-      maxPriorityFeeBufferPercent: 5n,
-      preVerificationGasBufferPercent: 5n,
+      baseFeeBufferMultiplier: 1.5,
+      maxPriorityFeeBufferMultiplier: 1.5,
+      preVerificationGasBufferMultiplier: 1.5,
     },
   },
 });

--- a/site/resources/types.md
+++ b/site/resources/types.md
@@ -146,8 +146,8 @@ An object type that may contain optional `min` and `max` fields, each of which a
 
 [See Type ↗️](https://github.com/alchemyplatform/aa-sdk/blob/main/packages/core/src/types.ts#L23)
 
-## `Percentage`
+## `Multiplier`
 
-An object type with a required `percentage` field, which is a `number` that must be within the range of 1 to 1000.
+An object type with a required `multipler` field, which is a `number` that must be within the range of 1 to 1000.
 
 [See Type ↗️](https://github.com/alchemyplatform/aa-sdk/blob/main/packages/core/src/types.ts#L20)


### PR DESCRIPTION
# High-Level Context
We're moving away from percentage-based fee overrides due to the confusing nature of how to specify them. 
"If I want to increase by 10% do I input 110% or 10%?", and instead we are introducing a multiplier field and schema for which a user would now put 1.1, .5, or 3 to specify how they would want their overrides to work. 

I've also adapted this on the user-op drop and replace works to include the concept of a multiplier as well.

# Pull Request Checklist

- [X] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [X] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [X] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [X] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [X] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [X] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [X] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR introduces a transition from using the `Percentage` type to the `Multiplier` type for fee options in the codebase.
- The `Percentage` type and `PercentageSchema` have been replaced with the `Multiplier` type and `MultiplierSchema`.
- The `Multiplier` type represents a direct multiplication of the estimation and allows for more precise control over fee calculations.
- The changes include updates to various files, such as `defaults.ts`, `index.ts`, `schema.ts`, and `utils/index.ts`.
- Tests have been added to ensure the correctness of the new `bigIntMultiply` utility function.

> The following files were skipped due to too many changes: `packages/core/src/utils/userop.ts`, `site/packages/aa-core/smart-account-client/types/userOperationFeeOptionsField.md`, `packages/core/src/utils/bigint.ts`, `packages/alchemy/src/middleware/gasManager.ts`, `site/packages/aa-core/smart-account-client/types/userOperationOverrides.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->