### PR TITLE
feat: add a nonce key override to support parallel nonces

### DIFF
--- a/packages/core/src/account/smartContractAccount.ts
+++ b/packages/core/src/account/smartContractAccount.ts
@@ -78,7 +78,7 @@ export type SmartContractAccount<
     typedDataDefinition: TypedDataDefinition<typedData, primaryType>
   ) => Promise<Hex>;
   encodeUpgradeToAndCall: (params: UpgradeToAndCallParams) => Promise<Hex>;
-  getNonce(): Promise<bigint>;
+  getNonce(nonceKey?: bigint): Promise<bigint>;
   getInitCode: () => Promise<Hex>;
   isAccountDeployed: () => Promise<boolean>;
   getFactoryAddress: () => Address;
@@ -244,12 +244,12 @@ export async function toSmartContractAccount<
     return initCode === "0x";
   };
 
-  const getNonce = async () => {
+  const getNonce = async (nonceKey = 0n) => {
     if (!(await isAccountDeployed())) {
       return 0n;
     }
 
-    return entryPointContract.read.getNonce([accountAddress_, BigInt(0)]);
+    return entryPointContract.read.getNonce([accountAddress_, nonceKey]);
   };
 
   const account = toAccount({

--- a/packages/core/src/actions/smartAccount/buildUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperation.ts
@@ -35,7 +35,7 @@ export const buildUserOperation: <
     uo: {
       initCode: account.getInitCode(),
       sender: account.address,
-      nonce: account.getNonce(),
+      nonce: account.getNonce(overrides?.nonceKey),
       callData: Array.isArray(uo)
         ? account.encodeBatchExecute(uo)
         : typeof uo === "string"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,6 +54,14 @@ export type UserOperationOverrides = Partial<{
     | UserOperationStruct["verificationGasLimit"]
     | Percentage;
   paymasterAndData: UserOperationStruct["paymasterAndData"];
+  /**
+   * This can be used to override the key used when calling `entryPoint.getNonce`
+   * It is useful when you want to use parallel nonces for user operations
+   *
+   * NOTE: not all bundlers fully support this feature and it could be that your bundler will still only include
+   * one user operation for your account in a bundle
+   */
+  nonceKey: bigint;
 }>;
 
 // represents the request as it needs to be formatted for RPC requests


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR
This PR focuses on allowing the use of parallel nonces for user operations in smart contracts.

### Detailed summary
- Added a `nonceKey` parameter to the `buildUserOperation` function in `buildUserOperation.ts`.
- Updated the `getNonce` function in `smartContractAccount.ts` to accept a `nonceKey` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->