### PR TITLE
refactor: refactor owner in smart contract account to connected signer

### DIFF
--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -30,6 +30,7 @@ export { accountLoupeActions } from "./msca/account-loupe/decorator.js";
 export type * from "./msca/account/multiOwnerAccount.js";
 export { createMultiOwnerModularAccount } from "./msca/account/multiOwnerAccount.js";
 export { standardExecutor } from "./msca/account/standardExecutor.js";
+export { createMultiOwnerModularAccountClient } from "./msca/client.js";
 export type * from "./msca/plugin-manager/decorator.js";
 export { pluginManagerActions } from "./msca/plugin-manager/decorator.js";
 export type * from "./msca/plugins/multi-owner/index.js";

--- a/packages/accounts/src/light-account/account.test.ts
+++ b/packages/accounts/src/light-account/account.test.ts
@@ -12,11 +12,11 @@ const chain = polygonMumbai;
 describe("Light Account Tests", () => {
   const dummyMnemonic =
     "test test test test test test test test test test test junk";
-  const owner: SmartAccountSigner =
+  const signer: SmartAccountSigner =
     LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
 
   it("should correctly sign the message", async () => {
-    const { account } = await givenConnectedProvider({ owner, chain });
+    const { account } = await givenConnectedProvider({ signer, chain });
     const signature = await account.signMessage({
       message:
         "0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b",
@@ -28,7 +28,7 @@ describe("Light Account Tests", () => {
   });
 
   it("should correctly sign typed data", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     const signature = await provider.account.signTypedData({
       types: {
         Request: [{ name: "hello", type: "string" }],
@@ -45,7 +45,7 @@ describe("Light Account Tests", () => {
   });
 
   it("should correctly encode transferOwnership data", async () => {
-    const { account } = await givenConnectedProvider({ owner, chain });
+    const { account } = await givenConnectedProvider({ signer, chain });
     expect(
       account.encodeTransferOwnership(
         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -56,7 +56,7 @@ describe("Light Account Tests", () => {
   });
 
   it("should correctly encode batch transaction data", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     const data = [
       {
         target: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
@@ -77,15 +77,15 @@ describe("Light Account Tests", () => {
 });
 
 const givenConnectedProvider = ({
-  owner,
+  signer,
   chain,
 }: {
-  owner: SmartAccountSigner;
+  signer: SmartAccountSigner;
   chain: Chain;
 }) =>
   createLightAccountClient({
     account: {
-      owner,
+      signer,
       accountAddress: "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4",
     },
     transport: custom({

--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -6,8 +6,8 @@ import {
   toSmartContractAccount,
   type Address,
   type Hex,
-  type OwnedSmartContractAccount,
   type SmartAccountSigner,
+  type SmartContractAccountWithSigner,
   type ToSmartContractAccountParams,
   type UpgradeToAndCallParams,
 } from "@alchemy/aa-core";
@@ -32,24 +32,21 @@ import {
 } from "./utils.js";
 
 export type LightAccount<
-  TOwner extends SmartAccountSigner = SmartAccountSigner
-> = OwnedSmartContractAccount<"LightAccount", TOwner> & {
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+> = SmartContractAccountWithSigner<"LightAccount", TSigner> & {
   getLightAccountVersion: () => Promise<LightAccountVersion>;
   encodeTransferOwnership: (newOwner: Address) => Hex;
   getOwnerAddress: () => Promise<Address>;
-  setOwner: <TOwner extends SmartAccountSigner = SmartAccountSigner>(
-    newOwner: TOwner
-  ) => void;
 };
 
 export type CreateLightAccountParams<
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = Pick<
   ToSmartContractAccountParams<"LightAccount", TTransport>,
   "transport" | "chain" | "entryPoint" | "accountAddress"
 > & {
-  owner: TOwner;
+  signer: TSigner;
   salt?: bigint;
   factoryAddress?: Address;
   initCode?: Hex;
@@ -58,15 +55,15 @@ export type CreateLightAccountParams<
 
 export async function createLightAccount<
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  config: CreateLightAccountParams<TTransport, TOwner>
-): Promise<LightAccount<TOwner>>;
+  config: CreateLightAccountParams<TTransport, TSigner>
+): Promise<LightAccount<TSigner>>;
 
 export async function createLightAccount({
   transport,
   chain,
-  owner: owner_,
+  signer: owner,
   initCode,
   version = "v1.1.0",
   entryPoint = getVersion060EntryPoint(chain),
@@ -74,7 +71,7 @@ export async function createLightAccount({
   factoryAddress = getDefaultLightAccountFactoryAddress(chain, version),
   salt: salt_ = 0n,
 }: CreateLightAccountParams): Promise<LightAccount> {
-  let owner = owner_;
+  let signer = owner;
   const client = createBundlerClient({
     transport,
     chain,
@@ -94,7 +91,7 @@ export async function createLightAccount({
       encodeFunctionData({
         abi: LightAccountFactoryAbi,
         functionName: "createAccount",
-        args: [await owner.getAddress(), salt],
+        args: [await signer.getAddress(), salt],
       }),
     ]);
   };
@@ -145,7 +142,7 @@ export async function createLightAccount({
   };
 
   const signWith1271Wrapper = async (msg: Hex): Promise<`0x${string}`> => {
-    return owner.signTypedData({
+    return signer.signTypedData({
       // EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)
       // https://github.com/alchemyplatform/light-account/blob/main/src/LightAccount.sol#L236
       domain: {
@@ -196,13 +193,13 @@ export async function createLightAccount({
       });
     },
     signUserOperationHash: async (uoHash: Hex) => {
-      return owner.signMessage({ raw: uoHash });
+      return signer.signMessage({ raw: uoHash });
     },
     async signMessage({ message }) {
       const version = await getLightAccountVersion(account);
       switch (version) {
         case "v1.0.1":
-          return owner.signMessage(message);
+          return signer.signMessage(message);
         case "v1.0.2":
           throw new Error(
             `Version ${version} of LightAccount doesn't support 1271`
@@ -215,7 +212,7 @@ export async function createLightAccount({
       const version = await getLightAccountVersion(account);
       switch (version) {
         case "v1.0.1": {
-          return owner.signTypedData(
+          return signer.signTypedData(
             params as unknown as SignTypedDataParameters
           );
         }
@@ -255,17 +252,12 @@ export async function createLightAccount({
         throw new Error("could not get on-chain owner");
       }
 
-      if (callResult !== (await owner.getAddress())) {
+      if (callResult !== (await signer.getAddress())) {
         throw new Error("on-chain owner does not match account owner");
       }
 
       return callResult;
     },
-    getOwner: () => owner,
-    setOwner: <TOwner extends SmartAccountSigner = SmartAccountSigner>(
-      newOwner: TOwner
-    ) => {
-      owner = newOwner;
-    },
+    getSigner: () => signer,
   };
 }

--- a/packages/accounts/src/light-account/actions/transferOwnership.ts
+++ b/packages/accounts/src/light-account/actions/transferOwnership.ts
@@ -10,25 +10,25 @@ import type { Chain, Client, Transport } from "viem";
 import type { LightAccount } from "../account";
 
 export type TransferLightAccountOwnershipParams<
-  TOwner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TOwner> | undefined =
-    | LightAccount<TOwner>
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 > = {
-  newOwner: TOwner;
+  newOwner: TSigner;
   waitForTxn?: boolean;
 } & GetAccountParameter<TAccount, LightAccount>;
 
 export const transferOwnership: <
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TOwner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TOwner> | undefined =
-    | LightAccount<TOwner>
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: TransferLightAccountOwnershipParams<TOwner, TAccount>
+  args: TransferLightAccountOwnershipParams<TSigner, TAccount>
 ) => Promise<Hex> = async (
   client,
   { newOwner, waitForTxn, account = client.account }
@@ -54,8 +54,6 @@ export const transferOwnership: <
     },
     account,
   });
-
-  account.setOwner(newOwner);
 
   if (waitForTxn) {
     return client.waitForUserOperationTransaction(result);

--- a/packages/accounts/src/light-account/client.ts
+++ b/packages/accounts/src/light-account/client.ts
@@ -20,12 +20,12 @@ import {
 export type CreateLightAccountClientParams<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = {
-  transport: CreateLightAccountParams<TTransport, TOwner>["transport"];
-  chain: CreateLightAccountParams<TTransport, TOwner>["chain"];
+  transport: CreateLightAccountParams<TTransport, TSigner>["transport"];
+  chain: CreateLightAccountParams<TTransport, TSigner>["chain"];
   account: Omit<
-    CreateLightAccountParams<TTransport, TOwner>,
+    CreateLightAccountParams<TTransport, TSigner>,
     "transport" | "chain"
   >;
 } & Omit<
@@ -35,16 +35,16 @@ export type CreateLightAccountClientParams<
 
 export function createLightAccountClient<
   TChain extends Chain | undefined = Chain | undefined,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateLightAccountClientParams<Transport, TChain, TOwner>
+  args: CreateLightAccountClientParams<Transport, TChain, TSigner>
 ): Promise<
   SmartAccountClient<
     CustomTransport,
     Chain,
-    LightAccount<TOwner>,
+    LightAccount<TSigner>,
     SmartAccountClientActions<Chain, SmartContractAccount> &
-      LightAccountClientActions<TOwner, LightAccount<TOwner>>
+      LightAccountClientActions<TSigner, LightAccount<TSigner>>
   >
 >;
 

--- a/packages/accounts/src/light-account/decorator.ts
+++ b/packages/accounts/src/light-account/decorator.ts
@@ -8,14 +8,14 @@ import type { LightAccount } from "./account";
 import { transferOwnership } from "./actions/transferOwnership.js";
 
 export type LightAccountClientActions<
-  TOwner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TOwner> | undefined =
-    | LightAccount<TOwner>
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 > = {
   transferOwnership: (
     args: {
-      newOwner: TOwner;
+      newOwner: TSigner;
       waitForTxn?: boolean;
     } & GetAccountParameter<TAccount, LightAccount>
   ) => Promise<Hex>;
@@ -24,12 +24,12 @@ export type LightAccountClientActions<
 export const lightAccountClientActions: <
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TOwner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TOwner> | undefined =
-    | LightAccount<TOwner>
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => LightAccountClientActions<TOwner, TAccount> = (client) => ({
+) => LightAccountClientActions<TSigner, TAccount> = (client) => ({
   transferOwnership: async (args) => transferOwnership(client, args),
 });

--- a/packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts
+++ b/packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts
@@ -33,9 +33,9 @@ const chain = sepolia;
 Logger.setLogLevel(LogLevel.DEBUG);
 
 describe("Light Account Tests", () => {
-  const owner: SmartAccountSigner<HDAccount> =
+  const signer: SmartAccountSigner<HDAccount> =
     LocalAccountSigner.mnemonicToAccountSigner(LIGHT_ACCOUNT_OWNER_MNEMONIC);
-  const undeployedOwner = LocalAccountSigner.mnemonicToAccountSigner(
+  const undeployedAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
     UNDEPLOYED_OWNER_MNEMONIC
   );
 
@@ -46,7 +46,7 @@ describe("Light Account Tests", () => {
   ])(
     "LA version $version should correctly verify 1271 signatures",
     async ({ version, expected, throws }) => {
-      const provider = await givenConnectedProvider({ owner, chain, version });
+      const provider = await givenConnectedProvider({ signer, chain, version });
       const message = "test";
 
       if (!throws) {
@@ -69,7 +69,7 @@ describe("Light Account Tests", () => {
   it("should successfully get counterfactual address", async () => {
     const {
       account: { address },
-    } = await givenConnectedProvider({ owner, chain });
+    } = await givenConnectedProvider({ signer, chain });
     expect(address).toMatchInlineSnapshot(
       '"0x86f3B0211764971Ad0Fc8C8898d31f5d792faD84"'
     );
@@ -77,7 +77,7 @@ describe("Light Account Tests", () => {
 
   it("should sign typed data with 6492 successfully for undeployed account", async () => {
     const { account } = await givenConnectedProvider({
-      owner: undeployedOwner,
+      signer: undeployedAccountSigner,
       chain,
     });
 
@@ -98,7 +98,7 @@ describe("Light Account Tests", () => {
 
   it("should sign message with 6492 successfully for undeployed account", async () => {
     const { account } = await givenConnectedProvider({
-      owner: undeployedOwner,
+      signer: undeployedAccountSigner,
       chain,
     });
     expect(
@@ -113,7 +113,7 @@ describe("Light Account Tests", () => {
    * For current balance, @see: https://sepolia.etherscan.io/address/0x7eDdc16B15259E5541aCfdebC46929873839B872
    */
   it("should execute successfully", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
 
     const result = await provider.sendUserOperation({
       uo: {
@@ -131,7 +131,7 @@ describe("Light Account Tests", () => {
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const newProvider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       accountAddress,
     });
@@ -147,42 +147,41 @@ describe("Light Account Tests", () => {
   });
 
   it("should get counterfactual for undeployed account", async () => {
-    const owner = LocalAccountSigner.privateKeyToAccountSigner(
+    const newSigner = LocalAccountSigner.privateKeyToAccountSigner(
       generatePrivateKey()
     );
     const {
       account: { address },
-    } = await givenConnectedProvider({ owner, chain });
+    } = await givenConnectedProvider({ signer: newSigner, chain });
 
     expect(isAddress(address)).toBe(true);
   });
 
-  it("should get owner successfully", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+  it("should get on-chain owner address successfully", async () => {
+    const provider = await givenConnectedProvider({ signer, chain });
     expect(await provider.account.getOwnerAddress()).toMatchInlineSnapshot(
       '"0x65eaA2AfDF6c97295bA44C458abb00FebFB3a5FA"'
     );
+    // match with current signer
     expect(await provider.account.getOwnerAddress()).toBe(
-      await owner.getAddress()
+      await signer.getAddress()
     );
   });
 
   it("should transfer ownership successfully", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
     });
 
     // create a throwaway address
-    const throwawayOwner = LocalAccountSigner.privateKeyToAccountSigner(
+    const throwawaySigner = LocalAccountSigner.privateKeyToAccountSigner(
       generatePrivateKey()
     );
     const throwawayProvider = await givenConnectedProvider({
-      owner: throwawayOwner,
+      signer: throwawaySigner,
       chain,
     });
-
-    const oldOwner = await throwawayOwner.getAddress();
 
     // fund the throwaway address
     await provider.sendTransaction({
@@ -191,41 +190,40 @@ describe("Light Account Tests", () => {
       value: 200000000000000000n,
     });
 
-    // create new owner and transfer ownership
-    const newThrowawayOwner = LocalAccountSigner.privateKeyToAccountSigner(
+    // create new signer and transfer ownership
+    const newOwner = LocalAccountSigner.privateKeyToAccountSigner(
       generatePrivateKey()
     );
 
     await throwawayProvider.transferOwnership({
-      newOwner: newThrowawayOwner,
+      newOwner,
       waitForTxn: true,
     });
 
     const newOwnerViaProvider =
       await throwawayProvider.account.getOwnerAddress();
-    const newOwner = await newThrowawayOwner.getAddress();
 
-    expect(newOwnerViaProvider).not.toBe(oldOwner);
-    expect(newOwnerViaProvider).toBe(newOwner);
+    expect(newOwnerViaProvider).not.toBe(await throwawaySigner.getAddress());
+    expect(newOwnerViaProvider).toBe(await newOwner.getAddress());
   }, 100000);
 
   it("should upgrade a deployed light account to msca successfully", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
     });
 
-    // create a throwaway address
-    const throwawayOwner = LocalAccountSigner.privateKeyToAccountSigner(
+    // create a owner signer to create the account
+    const throwawaySigner = LocalAccountSigner.privateKeyToAccountSigner(
       generatePrivateKey()
     );
     const throwawayProvider = await givenConnectedProvider({
-      owner: throwawayOwner,
+      signer: throwawaySigner,
       chain,
     });
 
     const accountAddress = throwawayProvider.getAddress();
-    const ownerAddress = await throwawayOwner.getAddress();
+    const ownerAddress = await throwawaySigner.getAddress();
 
     // fund + deploy the throwaway address
     await provider.sendTransaction({
@@ -264,13 +262,13 @@ describe("Light Account Tests", () => {
 });
 
 const givenConnectedProvider = async ({
-  owner,
+  signer,
   chain,
   accountAddress,
   feeOptions,
   version = "v1.1.0",
 }: {
-  owner: SmartAccountSigner;
+  signer: SmartAccountSigner;
   chain: Chain;
   accountAddress?: Address;
   feeOptions?: UserOperationFeeOptions;
@@ -280,7 +278,7 @@ const givenConnectedProvider = async ({
     transport: http(`${chain.rpcUrls.alchemy.http[0]}/${API_KEY!}`),
     chain: chain,
     account: {
-      owner,
+      signer,
       accountAddress,
       version,
     },

--- a/packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts
+++ b/packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts
@@ -200,11 +200,16 @@ describe("Light Account Tests", () => {
       waitForTxn: true,
     });
 
-    const newOwnerViaProvider =
-      await throwawayProvider.account.getOwnerAddress();
+    const newOwnerProvider = await givenConnectedProvider({
+      signer: newOwner,
+      chain,
+      accountAddress: throwawayProvider.getAddress(),
+    });
 
-    expect(newOwnerViaProvider).not.toBe(await throwawaySigner.getAddress());
-    expect(newOwnerViaProvider).toBe(await newOwner.getAddress());
+    const newOwnerAddress = await newOwnerProvider.account.getOwnerAddress();
+
+    expect(newOwnerAddress).not.toBe(await throwawaySigner.getAddress());
+    expect(newOwnerAddress).toBe(await newOwner.getAddress());
   }, 100000);
 
   it("should upgrade a deployed light account to msca successfully", async () => {

--- a/packages/accounts/src/light-account/schema.ts
+++ b/packages/accounts/src/light-account/schema.ts
@@ -13,7 +13,7 @@ const isLightAccountVersion = (x: unknown): x is LightAccountVersion => {
 };
 
 export const LightAccountFactoryConfigSchema = z.object({
-  owner: SignerSchema,
+  signer: SignerSchema,
   accountAddress: Address.optional().describe(
     "Optional override for the account address."
   ),

--- a/packages/accounts/src/msca/client.ts
+++ b/packages/accounts/src/msca/client.ts
@@ -1,0 +1,79 @@
+import {
+  createSmartAccountClient,
+  type SmartAccountClient,
+  type SmartAccountClientActions,
+  type SmartAccountSigner,
+} from "@alchemy/aa-core";
+import { type Chain, type CustomTransport, type Transport } from "viem";
+import type { CreateLightAccountClientParams } from "../light-account/client";
+import {
+  accountLoupeActions,
+  type AccountLoupeActions,
+} from "./account-loupe/decorator.js";
+import {
+  createMultiOwnerModularAccount,
+  type CreateMultiOwnerModularAccountParams,
+  type MultiOwnerModularAccount,
+} from "./account/multiOwnerAccount.js";
+import {
+  pluginManagerActions,
+  type PluginManagerActions,
+} from "./plugin-manager/decorator.js";
+import {
+  multiOwnerPluginActions,
+  type MultiOwnerPluginActions,
+} from "./plugins/multi-owner/index.js";
+
+export type CreateMultiOwnerModularAccountClientParams<
+  TTransport extends Transport = Transport,
+  TChain extends Chain | undefined = Chain | undefined,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+> = {
+  account: Omit<
+    CreateMultiOwnerModularAccountParams<TTransport, TSigner>,
+    "transport" | "chain"
+  >;
+} & Omit<
+  CreateLightAccountClientParams<TTransport, TChain, TSigner>,
+  "account"
+>;
+
+export function createMultiOwnerModularAccountClient<
+  TChain extends Chain | undefined = Chain | undefined,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+>(
+  args: CreateMultiOwnerModularAccountClientParams<Transport, TChain, TSigner>
+): Promise<
+  SmartAccountClient<
+    CustomTransport,
+    Chain,
+    MultiOwnerModularAccount<TSigner>,
+    SmartAccountClientActions<Chain, MultiOwnerModularAccount<TSigner>> &
+      MultiOwnerPluginActions<MultiOwnerModularAccount<TSigner>> &
+      PluginManagerActions<MultiOwnerModularAccount<TSigner>> &
+      AccountLoupeActions<MultiOwnerModularAccount<TSigner>>
+  >
+>;
+
+export async function createMultiOwnerModularAccountClient({
+  account,
+  transport,
+  chain,
+  ...clientConfig
+}: CreateMultiOwnerModularAccountClientParams): Promise<SmartAccountClient> {
+  const modularAccount = await createMultiOwnerModularAccount({
+    ...account,
+    transport,
+    chain,
+  });
+
+  return createSmartAccountClient({
+    ...clientConfig,
+    transport,
+    chain,
+    account: modularAccount,
+  })
+    .extend(pluginManagerActions)
+    .extend(multiOwnerPluginActions)
+    .extend(accountLoupeActions);
+}

--- a/packages/accounts/src/msca/plugins/multi-owner/signer.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/signer.ts
@@ -21,7 +21,7 @@ export const multiOwnerMessageSigner = <
 >(
   client: BundlerClient<TTransport>,
   accountAddress: Address,
-  owner: () => TSigner,
+  signer: () => TSigner,
   pluginAddress: Address = MultiOwnerPlugin.meta.addresses[client.chain.id]
 ) => {
   const signWith712Wrapper = async (msg: Hash): Promise<`0x${string}`> => {
@@ -33,7 +33,7 @@ export const multiOwnerMessageSigner = <
         account: accountAddress,
       });
 
-    return owner().signTypedData({
+    return signer().signTypedData({
       domain: {
         chainId: Number(chainId),
         name,
@@ -57,7 +57,7 @@ export const multiOwnerMessageSigner = <
     },
 
     signUserOperationHash: (uoHash: `0x${string}`): Promise<`0x${string}`> => {
-      return owner().signMessage({ raw: uoHash });
+      return signer().signMessage({ raw: uoHash });
     },
 
     signMessage({

--- a/packages/accounts/src/nani-account/__tests__/account.test.ts
+++ b/packages/accounts/src/nani-account/__tests__/account.test.ts
@@ -14,7 +14,7 @@ const chain = polygonMumbai;
 describe("Nani Account Tests", () => {
   const dummyMnemonic =
     "test test test test test test test test test test test test";
-  const owner: SmartAccountSigner =
+  const signer: SmartAccountSigner =
     LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
 
   it("should correctly sign the message", async () => {
@@ -98,7 +98,7 @@ describe("Nani Account Tests", () => {
 
   const givenAccount = async () => {
     return createNaniAccount({
-      owner,
+      signer,
       chain,
       accountAddress: "0x903072d2112412406597eb5DCAA8CeDD71ea141c",
       transport: http(`${chain.rpcUrls.alchemy.http[0]}/test`),

--- a/packages/accounts/src/nani-account/schema.ts
+++ b/packages/accounts/src/nani-account/schema.ts
@@ -4,7 +4,7 @@ import { isHex } from "viem";
 import { z } from "zod";
 
 export const NaniAccountFactoryConfigSchema = z.object({
-  owner: SignerSchema,
+  signer: SignerSchema,
   accountAddress: Address.optional().describe(
     "Optional override for the account address."
   ),

--- a/packages/accounts/src/nani-account/transferNaniAccountOwnership.ts
+++ b/packages/accounts/src/nani-account/transferNaniAccountOwnership.ts
@@ -20,12 +20,12 @@ import type { NaniAccount } from "./account";
 export const transferOwnership: <
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TOwner extends SmartAccountSigner = SmartAccountSigner,
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
   TAccount extends NaniAccount | undefined = NaniAccount | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: {
-    newOwner: TOwner;
+    newOwner: TSigner;
     waitForTxn?: boolean;
   } & GetAccountParameter<TAccount>
 ) => Promise<Hex> = async (

--- a/packages/alchemy/README.md
+++ b/packages/alchemy/README.md
@@ -43,7 +43,7 @@ export const provider = new AlchemyProvider({
   (rpcClient) =>
     new LightSmartContractAccount({
       chain,
-      owner: eoaSigner,
+      signer: eoaSigner,
       factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
     })

--- a/packages/alchemy/e2e-tests/light-account.e2e.test.ts
+++ b/packages/alchemy/e2e-tests/light-account.e2e.test.ts
@@ -21,19 +21,19 @@ const chain = sepolia;
 const network = Network.ETH_SEPOLIA;
 
 describe("Light Account Tests", () => {
-  const owner = LocalAccountSigner.mnemonicToAccountSigner(
+  const signer = LocalAccountSigner.mnemonicToAccountSigner(
     LIGHT_ACCOUNT_OWNER_MNEMONIC
   );
 
   it("should successfully get counterfactual address", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     expect(provider.getAddress()).toMatchInlineSnapshot(
       '"0x86f3B0211764971Ad0Fc8C8898d31f5d792faD84"'
     );
   });
 
   it("should execute successfully", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
 
     const result = await provider.sendUserOperation({
       uo: {
@@ -50,7 +50,7 @@ describe("Light Account Tests", () => {
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       accountAddress,
     });
@@ -67,7 +67,7 @@ describe("Light Account Tests", () => {
 
   it("should successfully execute with alchemy paymaster info", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       gasManagerConfig: {
         policyId: PAYMASTER_POLICY_ID,
@@ -87,7 +87,7 @@ describe("Light Account Tests", () => {
 
   it("should successfully override fees and gas when using paymaster", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       gasManagerConfig: {
         policyId: PAYMASTER_POLICY_ID,
@@ -137,7 +137,7 @@ describe("Light Account Tests", () => {
 
   it("should successfully use paymaster with fee opts", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       gasManagerConfig: {
         policyId: PAYMASTER_POLICY_ID,
@@ -164,7 +164,7 @@ describe("Light Account Tests", () => {
 
   it("should execute successfully via drop and replace", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
     });
 
@@ -184,7 +184,7 @@ describe("Light Account Tests", () => {
 
   it("should execute successfully via drop and replace when using paymaster", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       gasManagerConfig: {
         policyId: PAYMASTER_POLICY_ID,
@@ -213,7 +213,7 @@ describe("Light Account Tests", () => {
     });
 
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       gasManagerConfig: {
         policyId: PAYMASTER_POLICY_ID,
@@ -232,7 +232,7 @@ describe("Light Account Tests", () => {
     });
 
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       gasManagerConfig: {
         policyId: PAYMASTER_POLICY_ID,
@@ -246,7 +246,7 @@ describe("Light Account Tests", () => {
 
   it("should correctly simulate asset changes for the user operation", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
     });
 
@@ -284,7 +284,7 @@ describe("Light Account Tests", () => {
 
   it("should simulate as part of middleware stack when added to provider", async () => {
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       useSimulation: true,
     });
@@ -302,7 +302,7 @@ describe("Light Account Tests", () => {
 });
 
 const givenConnectedProvider = async ({
-  owner,
+  signer,
   chain,
   accountAddress,
   opts,
@@ -311,7 +311,7 @@ const givenConnectedProvider = async ({
 }: AlchemyLightAccountClientConfig) =>
   createLightAccountAlchemyClient({
     chain,
-    owner,
+    signer,
     accountAddress,
     apiKey: API_KEY!,
     gasManagerConfig,

--- a/packages/alchemy/src/client/lightAccountClient.test.ts
+++ b/packages/alchemy/src/client/lightAccountClient.test.ts
@@ -14,12 +14,12 @@ import { createAlchemySmartAccountClient } from "./smartAccountClient.js";
 describe("Light Account Client Tests", () => {
   const dummyMnemonic =
     "test test test test test test test test test test test test";
-  const owner = LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
+  const signer = LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
   const chain = polygonMumbai;
 
   it("should have a JWT property", async () => {
     const spy = vi.spyOn(AACoreModule, "createBundlerClient");
-    await givenConnectedProvider({ owner, chain });
+    await givenConnectedProvider({ signer, chain });
     expect(spy.mock.results[0].value.transport).toMatchInlineSnapshot(
       {
         fetchOptions: {
@@ -48,7 +48,7 @@ describe("Light Account Client Tests", () => {
   });
 
   it("should correctly encode batch transaction data", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     const account = provider.account;
     const data = [
       {
@@ -91,7 +91,7 @@ describe("Light Account Client Tests", () => {
 
   it("should correctly do runtime validation when chain is not supported by Alchemy", async () => {
     await expect(() => {
-      return givenConnectedProvider({ owner, chain: avalanche });
+      return givenConnectedProvider({ signer, chain: avalanche });
     }).rejects.toThrowErrorMatchingInlineSnapshot(`
       "[
         {
@@ -112,7 +112,7 @@ describe("Light Account Client Tests", () => {
       apiKey: "test",
     });
 
-    const provider = (await givenConnectedProvider({ owner, chain })).extend(
+    const provider = (await givenConnectedProvider({ signer, chain })).extend(
       alchemyEnhancedApiActions(alchemy)
     );
 
@@ -123,15 +123,15 @@ describe("Light Account Client Tests", () => {
   });
 
   const givenConnectedProvider = async ({
-    owner,
+    signer,
     chain,
   }: {
-    owner: SmartAccountSigner;
+    signer: SmartAccountSigner;
     chain: Chain;
   }) =>
     createLightAccountAlchemyClient({
       jwt: "test",
-      owner,
+      signer,
       chain,
       accountAddress: "0x86f3B0211764971Ad0Fc8C8898d31f5d792faD84",
     });

--- a/packages/alchemy/src/client/lightAccountClient.ts
+++ b/packages/alchemy/src/client/lightAccountClient.ts
@@ -15,25 +15,25 @@ import {
 } from "./smartAccountClient.js";
 
 export type AlchemyLightAccountClientConfig<
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = Omit<
-  CreateLightAccountParams<HttpTransport, TOwner>,
+  CreateLightAccountParams<HttpTransport, TSigner>,
   "transport" | "chain"
 > &
   Omit<
-    AlchemySmartAccountClientConfig<Transport, Chain, LightAccount<TOwner>>,
+    AlchemySmartAccountClientConfig<Transport, Chain, LightAccount<TSigner>>,
     "account"
   >;
 
 export const createLightAccountAlchemyClient: <
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  params: AlchemyLightAccountClientConfig<TOwner>
+  params: AlchemyLightAccountClientConfig<TSigner>
 ) => Promise<
   AlchemySmartAccountClient<
     CustomTransport,
     Chain | undefined,
-    LightAccount<TOwner>
+    LightAccount<TSigner>
   >
 > = async (config) => {
   const { chain, opts, ...connectionConfig } =

--- a/packages/alchemy/src/client/modularAccountClient.ts
+++ b/packages/alchemy/src/client/modularAccountClient.ts
@@ -28,29 +28,29 @@ import type {
 } from "./smartAccountClient";
 
 export type AlchemyModularAccountClientConfig<
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = Omit<
-  CreateMultiOwnerModularAccountParams<HttpTransport, TOwner>,
+  CreateMultiOwnerModularAccountParams<HttpTransport, TSigner>,
   "transport" | "chain"
 > &
   Omit<
-    AlchemySmartAccountClientConfig<Transport, Chain, LightAccount<TOwner>>,
+    AlchemySmartAccountClientConfig<Transport, Chain, LightAccount<TSigner>>,
     "account"
   >;
 
 export function createModularAccountAlchemyClient<
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  params: AlchemyModularAccountClientConfig<TOwner>
+  params: AlchemyModularAccountClientConfig<TSigner>
 ): Promise<
   AlchemySmartAccountClient<
     CustomTransport,
     Chain | undefined,
-    MultiOwnerModularAccount<TOwner>,
-    BaseAlchemyActions<Chain | undefined, MultiOwnerModularAccount<TOwner>> &
-      MultiOwnerPluginActions<MultiOwnerModularAccount<TOwner>> &
-      PluginManagerActions<MultiOwnerModularAccount<TOwner>> &
-      AccountLoupeActions<MultiOwnerModularAccount<TOwner>>
+    MultiOwnerModularAccount<TSigner>,
+    BaseAlchemyActions<Chain | undefined, MultiOwnerModularAccount<TSigner>> &
+      MultiOwnerPluginActions<MultiOwnerModularAccount<TSigner>> &
+      PluginManagerActions<MultiOwnerModularAccount<TSigner>> &
+      AccountLoupeActions<MultiOwnerModularAccount<TSigner>>
   >
 >;
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,7 +37,7 @@ import {
 import { http } from "viem";
 
 const chain = polygonMumbai;
-const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
+const signer: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
   "YOUR_OWNER_MNEMONIC"
 );
 const rpcTransport = http("https://polygon-mumbai.g.alchemy.com/v2/demo");
@@ -48,7 +48,7 @@ export const smartAccountClient = createSmartAccountClient({
   account: await createMultiOwnerModularAccount({
     transport: rpcTransport,
     chain,
-    owner,
+    signer,
   }),
 });
 ```

--- a/packages/core/e2e-tests/simple-account.e2e.test.ts
+++ b/packages/core/e2e-tests/simple-account.e2e.test.ts
@@ -100,7 +100,7 @@ describe("Simple Account Tests", () => {
     });
 
     const structWithFeeOptionsPromise =
-      await providerWithFeeOptions.buildUserOperation({
+      providerWithFeeOptions.buildUserOperation({
         uo: {
           target: provider.getAddress(),
           data: "0x",
@@ -155,7 +155,7 @@ describe("Simple Account Tests", () => {
       },
     });
 
-    const struct = await provider.sendUserOperation({
+    const struct = provider.sendUserOperation({
       uo: {
         target: provider.getAddress(),
         data: "0x",

--- a/packages/core/e2e-tests/simple-account.e2e.test.ts
+++ b/packages/core/e2e-tests/simple-account.e2e.test.ts
@@ -24,18 +24,18 @@ import { API_KEY, OWNER_MNEMONIC } from "./constants.js";
 const chain = polygonMumbai;
 
 describe("Simple Account Tests", () => {
-  const owner: SmartAccountSigner =
+  const signer: SmartAccountSigner =
     LocalAccountSigner.mnemonicToAccountSigner(OWNER_MNEMONIC);
 
   it("should successfully get counterfactual address", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     expect(provider.getAddress()).toMatchInlineSnapshot(
       `"0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"`
     );
   });
 
   it("should execute successfully", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     const result = await provider.sendUserOperation({
       uo: {
         target: provider.getAddress(),
@@ -51,7 +51,7 @@ describe("Simple Account Tests", () => {
   it("should fail to execute if account address is not deployed and not correct", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const provider = await givenConnectedProvider({
-      owner,
+      signer,
       chain,
       accountAddress,
     });
@@ -67,46 +67,45 @@ describe("Simple Account Tests", () => {
   });
 
   it("should get counterfactual for undeployed account", async () => {
-    const owner = LocalAccountSigner.privateKeyToAccountSigner(
+    const signer = LocalAccountSigner.privateKeyToAccountSigner(
       generatePrivateKey()
     );
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
 
     const address = provider.getAddress();
     expect(isAddress(address)).toBe(true);
   });
 
   it("should correctly handle multiplier overrides for buildUserOperation", async () => {
-    const signer = await givenConnectedProvider({
-      owner,
+    const provider = await givenConnectedProvider({
+      signer,
       chain,
     });
 
-    const structPromise = signer.buildUserOperation({
+    const structPromise = provider.buildUserOperation({
       uo: {
-        target: signer.getAddress(),
+        target: provider.getAddress(),
         data: "0x",
       },
     });
 
     await expect(structPromise).resolves.not.toThrowError();
 
-    const signerWithFeeOptions = await givenConnectedProvider({
-      owner,
+    const providerWithFeeOptions = await givenConnectedProvider({
+      signer,
       chain,
       feeOptions: {
         preVerificationGas: { multiplier: 2 },
       },
     });
 
-    const structWithFeeOptionsPromise = signerWithFeeOptions.buildUserOperation(
-      {
+    const structWithFeeOptionsPromise =
+      await providerWithFeeOptions.buildUserOperation({
         uo: {
-          target: signer.getAddress(),
+          target: provider.getAddress(),
           data: "0x",
         },
-      }
-    );
+      });
     await expect(structWithFeeOptionsPromise).resolves.not.toThrowError();
 
     const [struct, structWithFeeOptions] = await Promise.all([
@@ -129,14 +128,14 @@ describe("Simple Account Tests", () => {
   }, 60000);
 
   it("should correctly handle absolute overrides for sendUserOperation", async () => {
-    const signer = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
 
     const overrides: UserOperationOverrides = {
       preVerificationGas: 100_000_000n,
     };
-    const promise = signer.buildUserOperation({
+    const promise = provider.buildUserOperation({
       uo: {
-        target: signer.getAddress(),
+        target: provider.getAddress(),
         data: "0x",
       },
       overrides,
@@ -148,17 +147,17 @@ describe("Simple Account Tests", () => {
   }, 60000);
 
   it("should correctly handle multiplier overrides for sendUserOperation", async () => {
-    const signer = await givenConnectedProvider({
-      owner,
+    const provider = await givenConnectedProvider({
+      signer,
       chain,
       feeOptions: {
         preVerificationGas: { multiplier: 2 },
       },
     });
 
-    const struct = signer.sendUserOperation({
+    const struct = await provider.sendUserOperation({
       uo: {
-        target: signer.getAddress(),
+        target: provider.getAddress(),
         data: "0x",
       },
     });
@@ -167,12 +166,12 @@ describe("Simple Account Tests", () => {
 });
 
 const givenConnectedProvider = async ({
-  owner,
+  signer,
   chain,
   accountAddress,
   feeOptions,
 }: {
-  owner: SmartAccountSigner;
+  signer: SmartAccountSigner;
   chain: Chain;
   accountAddress?: Address;
   feeOptions?: UserOperationFeeOptions;
@@ -185,7 +184,7 @@ const givenConnectedProvider = async ({
     client,
     account: await createSimpleSmartAccount({
       chain,
-      owner,
+      signer,
       factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
       transport: custom(client),
       accountAddress,

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -18,7 +18,7 @@ import { createSimpleSmartAccount } from "../simple.js";
 describe("Account Simple Tests", async () => {
   const dummyMnemonic =
     "test test test test test test test test test test test test";
-  const owner: SmartAccountSigner =
+  const signer: SmartAccountSigner =
     LocalAccountSigner.mnemonicToAccountSigner(dummyMnemonic);
 
   const chain = sepolia;
@@ -37,7 +37,7 @@ describe("Account Simple Tests", async () => {
   );
 
   it("should correctly sign the message", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     expect(
       await provider.account.signMessage({
         message: {
@@ -50,7 +50,7 @@ describe("Account Simple Tests", async () => {
   });
 
   it("should correctly encode batch transaction data", async () => {
-    const provider = await givenConnectedProvider({ owner, chain });
+    const provider = await givenConnectedProvider({ signer, chain });
     const data = [
       {
         target: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
@@ -72,7 +72,7 @@ describe("Account Simple Tests", async () => {
   it("should correctly use the account init code override", async () => {
     const account = await createSimpleSmartAccount({
       chain: sepolia,
-      owner: owner,
+      signer,
       factoryAddress: getDefaultSimpleAccountFactoryAddress(sepolia),
       transport: custom(publicClient),
       // override the account address here so we don't have to resolve the address from the entry point
@@ -89,10 +89,10 @@ describe("Account Simple Tests", async () => {
   });
 
   const givenConnectedProvider = async ({
-    owner,
+    signer,
     chain,
   }: {
-    owner: SmartAccountSigner;
+    signer: SmartAccountSigner;
     chain: Chain;
   }) =>
     createSmartAccountClient({
@@ -100,7 +100,7 @@ describe("Account Simple Tests", async () => {
       chain: chain,
       account: await createSimpleSmartAccount({
         chain,
-        owner,
+        signer,
         accountAddress: "0x1234567890123456789012345678901234567890",
         factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
         transport: http(`${chain.rpcUrls.alchemy.http[0]}/${"test"}`),

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -45,14 +45,14 @@ export enum DeploymentState {
  */
 export abstract class BaseSmartContractAccount<
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner | undefined = SmartAccountSigner | undefined
-> implements ISmartContractAccount<TTransport, TOwner>
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+> implements ISmartContractAccount<TTransport, TSigner>
 {
   protected factoryAddress: Address;
   protected deploymentState: DeploymentState = DeploymentState.UNDEFINED;
   protected accountAddress?: Address;
   protected accountInitCode?: Hex;
-  protected owner: TOwner;
+  protected signer: TSigner;
   protected entryPoint: GetContractReturnType<
     typeof EntryPointAbi,
     PublicClient
@@ -65,7 +65,7 @@ export abstract class BaseSmartContractAccount<
   constructor(params_: BaseSmartAccountParams<TTransport>) {
     const params = createBaseSmartAccountParamsSchema<
       TTransport,
-      TOwner
+      TSigner
     >().parse(params_);
 
     this.entryPointAddress =
@@ -99,7 +99,7 @@ export abstract class BaseSmartContractAccount<
               ...fetchOptions,
               headers: {
                 ...fetchOptions?.headers,
-                "Alchemy-Aa-Sdk-Signer": params.owner?.signerType || "unknown",
+                "Alchemy-Aa-Sdk-Signer": params.signer?.signerType || "unknown",
                 "Alchemy-Aa-Sdk-Factory-Address": params.factoryAddress,
               },
             },
@@ -109,7 +109,7 @@ export abstract class BaseSmartContractAccount<
 
     this.accountAddress = params.accountAddress;
     this.factoryAddress = params.factoryAddress;
-    this.owner = params.owner as TOwner;
+    this.signer = params.signer as TSigner;
     this.accountInitCode = params.initCode;
 
     this.entryPoint = getContract({
@@ -316,8 +316,8 @@ export abstract class BaseSmartContractAccount<
     return Object.assign(this, extended);
   };
 
-  getOwner(): TOwner {
-    return this.owner;
+  getSigner(): TSigner {
+    return this.signer;
   }
 
   getFactoryAddress(): Address {

--- a/packages/core/src/account/schema.ts
+++ b/packages/core/src/account/schema.ts
@@ -8,7 +8,7 @@ import { ChainSchema } from "../utils/index.js";
 
 export const createBaseSmartAccountParamsSchema = <
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner | undefined = SmartAccountSigner | undefined
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >() =>
   z.object({
     rpcClient: z.union([
@@ -16,9 +16,7 @@ export const createBaseSmartAccountParamsSchema = <
       createPublicErc4337ClientSchema<TTransport>(),
     ]),
     factoryAddress: Address,
-    owner: z
-      .custom<TOwner>((owner) => (owner ? isSigner(owner) : undefined))
-      .optional(),
+    signer: z.custom<TSigner>(isSigner),
     entryPointAddress: Address.optional(),
     chain: ChainSchema,
     accountAddress: Address.optional().describe(
@@ -33,14 +31,13 @@ export const createBaseSmartAccountParamsSchema = <
 
 export const SimpleSmartAccountParamsSchema = <
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >() =>
-  createBaseSmartAccountParamsSchema<TTransport, TOwner>()
+  createBaseSmartAccountParamsSchema<TTransport, TSigner>()
     .omit({
       rpcClient: true,
     })
     .extend({
       transport: z.custom<TTransport>(),
-      owner: z.custom<TOwner>(isSigner),
       salt: z.bigint().optional(),
     });

--- a/packages/core/src/account/smartContractAccount.ts
+++ b/packages/core/src/account/smartContractAccount.ts
@@ -53,12 +53,11 @@ export type UpgradeToAndCallParams = {
   upgradeToInitData: Hex;
 };
 
-export type OwnedSmartContractAccount<
+export type SmartContractAccountWithSigner<
   Name extends string = string,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = SmartContractAccount<Name> & {
-  getOwner: () => TOwner;
-  setOwner: (owner: TOwner) => void;
+  getSigner: () => TSigner;
 };
 
 export type SmartContractAccount<

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -18,16 +18,16 @@ export type SignTypedDataParams = Omit<SignTypedDataParameters, "privateKey">;
  */
 export type BaseSmartAccountParams<
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner | undefined = SmartAccountSigner | undefined
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = z.input<
-  ReturnType<typeof createBaseSmartAccountParamsSchema<TTransport, TOwner>>
+  ReturnType<typeof createBaseSmartAccountParamsSchema<TTransport, TSigner>>
 >;
 
 export type SimpleSmartAccountParams<
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > = z.input<
-  ReturnType<typeof SimpleSmartAccountParamsSchema<TTransport, TOwner>>
+  ReturnType<typeof SimpleSmartAccountParamsSchema<TTransport, TSigner>>
 >;
 
 /**
@@ -35,7 +35,7 @@ export type SimpleSmartAccountParams<
  */
 export interface ISmartContractAccount<
   TTransport extends Transport = Transport,
-  TOwner extends SmartAccountSigner | undefined = SmartAccountSigner | undefined
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 > {
   /**
    * The RPC provider the account uses to make RPC calls
@@ -126,10 +126,13 @@ export interface ISmartContractAccount<
   getAddress(): Promise<Address>;
 
   /**
-   * @returns the smart account owner instance if it exists.
-   * It is optional for a smart account to have an owner account.
+   * @returns the current account signer instance that the smart account client
+   * operations are being signed with.
+   *
+   * The signer is expected to be the owner or one of the owners of the account
+   * for the signatures to be valid for the acting account.
    */
-  getOwner(): TOwner;
+  getSigner(): TSigner;
 
   /**
    * @returns the address of the factory contract for the smart account

--- a/packages/core/src/signer/local-account.ts
+++ b/packages/core/src/signer/local-account.ts
@@ -42,14 +42,14 @@ export class LocalAccountSigner<
   };
 
   static mnemonicToAccountSigner(key: string): LocalAccountSigner<HDAccount> {
-    const owner = mnemonicToAccount(key);
-    return new LocalAccountSigner(owner);
+    const signer = mnemonicToAccount(key);
+    return new LocalAccountSigner(signer);
   }
 
   static privateKeyToAccountSigner(
     key: Hex
   ): LocalAccountSigner<PrivateKeyAccount> {
-    const owner = privateKeyToAccount(key);
-    return new LocalAccountSigner(owner);
+    const signer = privateKeyToAccount(key);
+    return new LocalAccountSigner(signer);
   }
 }

--- a/packages/ethers/README.md
+++ b/packages/ethers/README.md
@@ -47,7 +47,7 @@ const ethersProvider = await alchemy.config.getProvider();
 
 const provider = EthersProviderAdapter.fromEthersProvider(ethersProvider);
 
-const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
+const signer: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
   process.env.YOUR_OWNER_MNEMONIC!
 );
 
@@ -58,7 +58,7 @@ export const signer = provider.connectToAccount(
       chain,
       factoryAddress: getDefaultLightAccountFactoryAddress(chain),
       rpcClient,
-      owner,
+      signer,
     })
 );
 ```

--- a/packages/ethers/e2e-tests/simple-account.e2e.test.ts
+++ b/packages/ethers/e2e-tests/simple-account.e2e.test.ts
@@ -18,17 +18,17 @@ describe("Simple Account Tests", async () => {
     network: Network.ETH_SEPOLIA,
   });
   const alchemyProvider = await alchemy.config.getProvider();
-  const owner = Wallet.fromMnemonic(OWNER_MNEMONIC);
+  const signer = Wallet.fromMnemonic(OWNER_MNEMONIC);
 
   it("should successfully get counterfactual address", async () => {
-    const provider = await givenConnectedProvider({ alchemyProvider, owner });
+    const provider = await givenConnectedProvider({ alchemyProvider, signer });
     expect(await provider.getAddress()).toMatchInlineSnapshot(
       `"0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4"`
     );
   });
 
   it("should execute successfully", async () => {
-    const provider = await givenConnectedProvider({ alchemyProvider, owner });
+    const provider = await givenConnectedProvider({ alchemyProvider, signer });
     const result = await provider.sendUserOperation({
       target: (await provider.getAddress()) as `0x${string}`,
       data: "0x",
@@ -42,7 +42,7 @@ describe("Simple Account Tests", async () => {
     const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
     const provider = await givenConnectedProvider({
       alchemyProvider,
-      owner,
+      signer,
       accountAddress,
     });
 
@@ -57,11 +57,11 @@ describe("Simple Account Tests", async () => {
 
 const givenConnectedProvider = async ({
   alchemyProvider,
-  owner,
+  signer,
   accountAddress,
 }: {
   alchemyProvider: AlchemyProvider;
-  owner: Wallet;
+  signer: Wallet;
   accountAddress?: Address;
 }) => {
   const chain = getChain(alchemyProvider.network.chainId);
@@ -72,7 +72,7 @@ const givenConnectedProvider = async ({
     await createSimpleSmartAccount({
       accountAddress,
       chain,
-      owner: convertWalletToAccountSigner(owner),
+      signer: convertWalletToAccountSigner(signer),
       factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
       rpcClient: createPublicErc4337Client({
         chain,

--- a/packages/ethers/src/__tests__/provider-adapter.test.ts
+++ b/packages/ethers/src/__tests__/provider-adapter.test.ts
@@ -17,11 +17,11 @@ describe("Simple Account Tests", async () => {
   // demo mnemonic from viem docs
   const dummyMnemonic =
     "legal winner thank year wave sausage worth useful legal winner thank yellow";
-  const owner = Wallet.fromMnemonic(dummyMnemonic);
+  const signer = Wallet.fromMnemonic(dummyMnemonic);
   const alchemyProvider = await alchemy.config.getProvider();
 
   it("should correctly sign the message", async () => {
-    const provider = await givenConnectedProvider({ alchemyProvider, owner });
+    const provider = await givenConnectedProvider({ alchemyProvider, signer });
     expect(
       await provider.signMessage(
         "0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"
@@ -34,10 +34,10 @@ describe("Simple Account Tests", async () => {
 
 const givenConnectedProvider = async ({
   alchemyProvider,
-  owner,
+  signer,
 }: {
   alchemyProvider: AlchemyProvider;
-  owner: Wallet;
+  signer: Wallet;
 }) => {
   const chain = getChain(alchemyProvider.network.chainId);
 
@@ -46,7 +46,7 @@ const givenConnectedProvider = async ({
   ).connectToAccount(
     await createSimpleSmartAccount({
       chain,
-      owner: convertWalletToAccountSigner(owner),
+      signer: convertWalletToAccountSigner(signer),
       accountAddress: "0x856185aedfab56809e6686d2d6d0c039d615bd9c",
       factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
       transport: http(

--- a/site/getting-started/setup.md
+++ b/site/getting-started/setup.md
@@ -165,7 +165,7 @@ In this guide, we initialized an `AlchemySmartAccountClient` with the `aa-alchem
 
 2. To learn about the end-to-end process of integrating smart accounts in your applications, check out the section on [Smart Accounts](/smart-accounts/).
 
-3. To learn about the `owner` field on your smart account, check out the section on [Choosing a Signer](/signers/choosing-a-signer) to own the smart account.
+3. To learn about the `signer` field on your smart account, check out the section on [Choosing a Signer](/signers/choosing-a-signer) to own the smart account.
 
 4. To learn more about different User Operations you can send with different `target` and `data` fields in the `sendUserOperation` function above, look at our [How to send a User Operation](/using-smart-accounts/send-user-operations) guide for an example using NFT mints.
 

--- a/site/index.md
+++ b/site/index.md
@@ -84,7 +84,7 @@ import { sepolia } from "@alchemy/aa-core";
 export const smartAccountClient = await createModularAccountAlchemyClient({
   apiKey: "YOUR_API_KEY",
   chain: sepolia,
-  owner,
+  signer,
 });
 ```
 

--- a/site/packages/aa-accounts/light-account/actions/transferOwnership.md
+++ b/site/packages/aa-accounts/light-account/actions/transferOwnership.md
@@ -46,6 +46,6 @@ A Promise containing the hash of either the UO or transaction containing the UO 
 
 - `client: SmartAccountClient` -- the client to use to send the transaction
 - `options: TransferLightAccountOwnershipParams` -- the options to use to transfer ownership
-  - `newOwner: TOwner extends SmartAccountSigner = SmartAccountSigner` -- the new owner of the account
+  - `newOwner: TSigner extends SmartAccountSigner = SmartAccountSigner` -- the new on-chain owner of the account
   - `waitForTxn?: boolean` -- optionally, wait for the transaction to be mined with the UO
   - `account?: LightAccount` -- optionally, pass the account if your client is not connected to it

--- a/site/packages/aa-accounts/light-account/encodeTransferOwnership.md
+++ b/site/packages/aa-accounts/light-account/encodeTransferOwnership.md
@@ -23,7 +23,7 @@ head:
 ```ts [example.ts]
 import { smartAccountClient } from "./smartAccountClient";
 // [!code focus:99]
-// encode transfer pownership
+// encode transfer ownership
 const newOwner = LocalAccountSigner.mnemonicToAccountSigner(NEW_OWNER_MNEMONIC);
 const encodedTransferOwnershipData =
   smartAccountClient.account.encodeTransferOwnership({ newOwner });

--- a/site/packages/aa-accounts/light-account/getOwnerAddress.md
+++ b/site/packages/aa-accounts/light-account/getOwnerAddress.md
@@ -23,8 +23,8 @@ head:
 ```ts [example.ts]
 import { smartAccountClient } from "./smartAccountClient";
 // [!code focus:99]
-// get owner
-const owner = await smartAccountClient.account.getOwnerAddress();
+// get on-chain account owner address
+const ownerAddress = await smartAccountClient.account.getOwnerAddress();
 ```
 
 <<< @/snippets/aa-core/lightAccountClient.ts

--- a/site/packages/aa-accounts/light-account/index.md
+++ b/site/packages/aa-accounts/light-account/index.md
@@ -14,12 +14,12 @@ head:
 
 # Light Account
 
-`LightAccount` is a simple, secure, and cost-effective smart account implementation which extends `SmartContractAccount`. It supports features such as owner transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. We recommend using Light Account for most use cases.
+`LightAccount` is a simple, secure, and cost-effective smart account implementation which extends `SmartContractAccount`. It supports features such as ownership transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. We recommend using Light Account for most use cases.
 
 The additional methods supported by `LightAccount` are:
 
 1.  [`signMessageWith6492`](/packages/aa-accounts/light-account/signMessageWith6492) -- supports message signatures for deployed smart accounts, as well as undeployed accounts (counterfactual addresses) using [ERC-6492](https://eips.ethereum.org/EIPS/eip-6492).
-2.  [`signTypedData`](/packages/aa-accounts/light-account/signTypedData) -- supports typed data signatures from the smart account's owner address.
+2.  [`signTypedData`](/packages/aa-accounts/light-account/signTypedData) -- supports typed data signatures from the smart account's current signer address.
 3.  [`signTypedDataWith6492`](/packages/aa-accounts/light-account/signTypedDataWith6492) -- supports typed data signatures for deployed smart accounts, as well as undeployed accounts (counterfactual addresses) using ERC-6492.
 4.  [`getOwnerAddress`](/packages/aa-accounts/light-account/getOwnerAddress) -- returns the on-chain owner address of the account.
 5.  [`encodeTransferOwnership`](/packages/aa-accounts/light-account/encodeTransferOwnership) -- encodes the transferOwnership function call using Light Account ABI.
@@ -51,8 +51,8 @@ const signedTypedDataWith6492 = smartAccountClient.signTypedDataWith6492({
   },
 });
 
-// get owner address
-const owner = await smartAccountClient.account.getOwnerAddress();
+// get on-chain account owner address
+const ownerAddress = await smartAccountClient.account.getOwnerAddress();
 
 // transfer ownership
 const newOwner = LocalAccountSigner.mnemonicToAccountSigner(NEW_OWNER_MNEMONIC);
@@ -87,7 +87,7 @@ A Promise containing a new `LightAccount`.
 
 - `chain: Chain` -- the chain on which to create the client.
 
-- `owner: SmartAccountSigner` -- the owner EOA signer responsible for signing user operations on behalf of the smart account.
+- `signer: SmartAccountSigner` -- the EOA signer to connect to the account with for signing user operations on behalf of the smart account.
 
 - `entryPoint: EntryPointDef` -- [optional] the entry point contract address. If not provided, the entry point contract address for the client is the connected account's entry point contract, or if not connected, falls back to the default entry point contract for the chain. See [getDefaultEntryPointAddress](/packages/aa-core/utils/getDefaultEntryPointAddress.html#getdefaultentrypointaddress).
 
@@ -95,7 +95,7 @@ A Promise containing a new `LightAccount`.
 
 - `initCode: Hex` -- [optional] the initCode for deploying the smart account with which the client will connect.
 
-- `salt: bigint` -- [optional] a value that is added to the address calculation to allow for multiple accounts for the same owner. The default value supplied is `0n`. To see this calculation used in the smart contract, check out [the LightAccountFactory](https://github.com/alchemyplatform/light-account/blob/main/src/LightAccountFactory.sol#L30).
+- `salt: bigint` -- [optional] a value that is added to the address calculation to allow for multiple accounts for the same signer (owner). The default value supplied is `0n`. To see this calculation used in the smart contract, check out [the LightAccountFactory](https://github.com/alchemyplatform/light-account/blob/main/src/LightAccountFactory.sol#L30).
 
 - `accountAddress: Address` -- [optional] a smart account address override that this object will manage instead of generating its own.
 

--- a/site/packages/aa-accounts/light-account/signTypedData.md
+++ b/site/packages/aa-accounts/light-account/signTypedData.md
@@ -14,7 +14,7 @@ head:
 
 # signTypedData
 
-`signTypedData` supports signing typed data from the smart account's owner address.
+`signTypedData` supports signing typed data from the smart account's currently connnected signer address.
 
 ## Usage
 

--- a/site/packages/aa-core/signers/wallet-client.md
+++ b/site/packages/aa-core/signers/wallet-client.md
@@ -14,7 +14,7 @@ head:
 
 # WalletClientSigner
 
-The `WalletClientSigner` is useful if you want to convert a `viem` `WalletClient` to a `SmartAccountSigner` which can be used as an owner on Smart Contract Accounts
+The `WalletClientSigner` is useful if you want to convert a `viem` `WalletClient` to a `SmartAccountSigner` which can be used as a signer to use to connect to Smart Contract Accounts
 
 ## Usage
 

--- a/site/packages/aa-core/smart-account-client/types/userOperationFeeOptions.md
+++ b/site/packages/aa-core/smart-account-client/types/userOperationFeeOptions.md
@@ -34,7 +34,7 @@ type UserOperationFeeOptions {
 
 ```ts [example.ts]
 const chain = polygonMumbai;
-const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
+const signer: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
   "YOUR_OWNER_MNEMONIC"
 );
 const rpcTransport = http("https://polygon-mumbai.g.alchemy.com/v2/demo");
@@ -52,7 +52,7 @@ export const smartAccountClient = createSmartAccountClient({
   account: await createMultiOwnerModularAccount({
     transport: rpcTransport,
     chain,
-    owner,
+    signer,
   }),
   opts: {
     feeOptions: userOperationFeeOptions,

--- a/site/packages/aa-ethers/account-signer/connect.md
+++ b/site/packages/aa-ethers/account-signer/connect.md
@@ -16,16 +16,16 @@ next:
 
 # connect
 
-`connect` is a method on `AccountSigner` that you can call to connect an `EthersProviderAdapter` to this Signer. This lets the returned `AccountSigner` leverage the provider when signing messages, UserOperations, and transactions for a smart account using the owner account.
+`connect` is a method on `AccountSigner` that you can call to connect an `EthersProviderAdapter` to this Signer. This lets the returned `AccountSigner` leverage the provider when signing messages, sending user operations and transactions for the smart account using the signer.
 
 ## Usage
 
 ::: code-group
 
 ```ts [example.ts]
-import { signer } from "./ethers-signer";
+import { accountSigner } from "./ethers-signer";
 
-// changing the provider for the signer
+// changing the ethers provider for the account signer
 const alchemy = new Alchemy({
   apiKey: process.env.API_KEY!,
   network: Network.SEPOLIA, // new chain -> new provider
@@ -33,8 +33,8 @@ const alchemy = new Alchemy({
 const ethersProvider = await alchemy.config.getProvider();
 const newProvider = EthersProviderAdapter.fromEthersProvider(ethersProvider);
 
-// connecting the signer
-const newSigner = signer.connect(newProvider);
+// connecting the account signer to ethers
+const newAccountSigner = accountSigner.connect(newProvider);
 ```
 
 <<< @/snippets/aa-ethers/ethers-signer.ts

--- a/site/packages/aa-ethers/account-signer/getAddress.md
+++ b/site/packages/aa-ethers/account-signer/getAddress.md
@@ -21,10 +21,10 @@ head:
 ::: code-group
 
 ```ts [example.ts]
-import { signer } from "./ethers-signer";
+import { accountSigner } from "./ethers-signer";
 
-// get the signer's smart account address
-const client = await signer.getAddress();
+// get the account signer's account address
+const client = await accountSigner.getAddress();
 ```
 
 <<< @/snippets/aa-ethers/ethers-signer.ts

--- a/site/packages/aa-ethers/account-signer/getBundlerClient.md
+++ b/site/packages/aa-ethers/account-signer/getBundlerClient.md
@@ -21,10 +21,10 @@ head:
 ::: code-group
 
 ```ts [example.ts]
-import { signer } from "./ethers-signer";
+import { accountSigner } from "./ethers-signer";
 
-// get the signer's underlying viem client with EIP-4337 capabilities
-const client = signer.getBundlerClient();
+// get the account signer's underlying viem client with EIP-4337 capabilities
+const client = accountSigner.getBundlerClient();
 ```
 
 <<< @/snippets/aa-ethers/ethers-signer.ts

--- a/site/packages/aa-ethers/account-signer/introduction.md
+++ b/site/packages/aa-ethers/account-signer/introduction.md
@@ -19,8 +19,8 @@ head:
 Notable differences between `EthersProviderAdapter` and `JsonRpcProvider` are implementations for:
 
 1.  [`getAddress`](/packages/aa-ethers/account-signer/getAddress) -- gets the `AccountSigner`'s smart account address.
-2.  [`signMessage`](/packages/aa-ethers/account-signer/signMessage) -- signs messages with the `AccountSigner`'s owner address.
-3.  [`sendTransaction`](/packages/aa-ethers/account-signer/sendTransaction) -- sends transactions on behalf of the `AccountSigner`'s smart account, with request and response formatted as if you were using the ethers.js library.
+2.  [`signMessage`](/packages/aa-ethers/account-signer/signMessage) -- signs messages with the `AccountSigner`'s EOA signer address.
+3.  [`sendTransaction`](/packages/aa-ethers/account-signer/sendTransaction) -- sends transactions on behalf of the `AccountSigner`'s connected signer, with request and response formatted as if you were using the ethers.js library.
 4.  [`getBundlerClient`](/packages/aa-ethers/account-signer/getBundlerClient) -- gets the underlying viem client with ERC-4337 compatibility.
 5.  [`connect`](/packages/aa-ethers/account-signer/connect) -- connects the inputted provider to an account and returns an `AccountSigner`.
 
@@ -29,22 +29,22 @@ Notable differences between `EthersProviderAdapter` and `JsonRpcProvider` are im
 ::: code-group
 
 ```ts [example.ts]
-import { signer } from "./ethers-signer";
+import { accountSigner } from "./ethers-signer";
 
-// get the signer's smart account address
-const address = await signer.getAddress();
+// get the account signer's account address
+const address = await accountSigner.getAddress();
 
-// sign message with the signer's owner address
-const signedMessage = await signer.signMessage("test");
+// sign message with the account signer's EOA signer address
+const signedMessage = await accountSigner.signMessage("test");
 
-// sends transaction on behalf of the smart account
-const txn = await signer.sendTransaction({
+// sends transaction on behalf of the smart account connected EOA signer
+const txn = await accountSigner.sendTransaction({
   to: "0xRECIPIENT_ADDRESS",
   data: "0xDATA",
 });
 
-// get the signer's underlying viem client with EIP-4337 capabilities
-const client = signer.getBundlerClient();
+// get the account signer's underlying viem client with EIP-4337 capabilities
+const client = accountSigner.getBundlerClient();
 ```
 
 <<< @/snippets/aa-ethers/ethers-signer.ts

--- a/site/packages/aa-ethers/account-signer/sendTransaction.md
+++ b/site/packages/aa-ethers/account-signer/sendTransaction.md
@@ -23,9 +23,9 @@ Note that `to` field of transaction is required, and among other fields of trans
 ::: code-group
 
 ```ts [example.ts]
-import { signer } from "./ethers-signer";
+import { accountSigner } from "./ethers-signer";
 
-const txHash = await signer.sendTransaction({
+const txHash = await accountSigner.sendTransaction({
   from, // ignored
   to,
   data: encodeFunctionData({

--- a/site/packages/aa-ethers/account-signer/signMessage.md
+++ b/site/packages/aa-ethers/account-signer/signMessage.md
@@ -14,17 +14,17 @@ head:
 
 # signMessage
 
-`signMessage` is a method on `AccountSigner` that signs messages with the `AccountSigner`'s owner address.
+`signMessage` is a method on `AccountSigner` that signs messages with the `AccountSigner`'s connected EOA signer address.
 
 ## Usage
 
 ::: code-group
 
 ```ts [example.ts]
-import { signer } from "./ethers-signer";
+import { accountSigner } from "./ethers-signer";
 
-// sign message with the signer's owner address
-const signedMessage = await signer.signMessage("test");
+// sign message with the account signer's connected EOA signer address
+const signedMessage = await accountSigner.signMessage("test");
 ```
 
 <<< @/snippets/aa-ethers/ethers-signer.ts

--- a/site/packages/aa-ethers/provider-adapter/connectToAccount.md
+++ b/site/packages/aa-ethers/provider-adapter/connectToAccount.md
@@ -14,7 +14,7 @@ head:
 
 # connectToAccount
 
-`connectToAccount` is a method on `EthersProviderAdapter` that you can optionally call to connect the provider to an account and returns a `AccountSigner`. This enables the returned `AccountSigner` to leverage the provider when signing messages, UserOperations, and transactions for a smart account using the owner account.
+`connectToAccount` is a method on `EthersProviderAdapter` that you can optionally call to connect the provider to an account and returns a `AccountSigner`. This enables the returned `AccountSigner` to leverage the provider when signing messages, UserOperations, and transactions for a smart account using the connected EOA signer account.
 
 ## Usage
 

--- a/site/packages/aa-ethers/provider-adapter/introduction.md
+++ b/site/packages/aa-ethers/provider-adapter/introduction.md
@@ -45,14 +45,14 @@ const chainId = await provider.send("eth_chainId", []);
 const client = provider.getBundlerClient();
 
 // connect the provider to an AccountSigner
-const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
+const signer: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
   process.env.YOUR_OWNER_MNEMONIC!
 );
-const signer = provider.connectToAccount(
+const accountSigner = provider.connectToAccount(
   await createLightAccount({
     chain,
     transport: http("RPC_URL"),
-    owner,
+    signer,
   })
 );
 ```

--- a/site/packages/aa-signers/arcana-auth/introduction.md
+++ b/site/packages/aa-signers/arcana-auth/introduction.md
@@ -19,7 +19,7 @@ head:
 `ArcanaAuthSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/arcana-auth/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/arcana-auth/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/arcana-auth/getAddress) -- gets the address of the the smart contract account's connected signer.
 3.  [`signMessage`](/packages/aa-signers/arcana-auth/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/arcana-auth/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/arcana-auth/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/capsule/introduction.md
+++ b/site/packages/aa-signers/capsule/introduction.md
@@ -19,7 +19,7 @@ head:
 `CapsuleSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/capsule/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/capsule/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/capsule/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/capsule/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/capsule/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/capsule/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/fireblocks/introduction.md
+++ b/site/packages/aa-signers/fireblocks/introduction.md
@@ -19,7 +19,7 @@ head:
 `FireblocksSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/fireblocks/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/fireblocks/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/fireblocks/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/fireblocks/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/fireblocks/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/fireblocks/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/magic/introduction.md
+++ b/site/packages/aa-signers/magic/introduction.md
@@ -19,7 +19,7 @@ head:
 `MagicSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/magic/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/magic/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/magic/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/magic/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/magic/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/magic/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/particle/introduction.md
+++ b/site/packages/aa-signers/particle/introduction.md
@@ -19,7 +19,7 @@ head:
 `ParticleSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/particle/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/particle/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/particle/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/particle/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/particle/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/particle/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/portal/introduction.md
+++ b/site/packages/aa-signers/portal/introduction.md
@@ -19,7 +19,7 @@ head:
 `PortalSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/portal/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/portal/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/portal/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/portal/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/portal/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/portal/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/turnkey/introduction.md
+++ b/site/packages/aa-signers/turnkey/introduction.md
@@ -19,7 +19,7 @@ head:
 `TurnkeySigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/turnkey/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/turnkey/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/turnkey/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/turnkey/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/turnkey/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/turnkey/getAuthDetails) -- supports authentication details retrieval.

--- a/site/packages/aa-signers/web3auth/introduction.md
+++ b/site/packages/aa-signers/web3auth/introduction.md
@@ -19,7 +19,7 @@ head:
 `Web3AuthSigner` provides implementations for all methods on `SmartAccountAuthenticator`:
 
 1.  [`authenticate`](/packages/aa-signers/web3auth/authenticate) -- supports user authentication.
-2.  [`getAddress`](/packages/aa-signers/web3auth/getAddress) -- supports typed data signatures from the smart contract account's owner address.
+2.  [`getAddress`](/packages/aa-signers/web3auth/getAddress) -- gets the address of the the smart contract account's connected EOA signer account.
 3.  [`signMessage`](/packages/aa-signers/web3auth/signMessage) -- supports message signatures.
 4.  [`signTypedData`](/packages/aa-signers/web3auth/signTypedData) -- supports typed data signatures.
 5.  [`getAuthDetails`](/packages/aa-signers/web3auth/getAuthDetails) -- supports authentication details retrieval.

--- a/site/resources/faqs.md
+++ b/site/resources/faqs.md
@@ -25,11 +25,11 @@ head:
 ### Do accounts have the same address across all chains?
 
 ::: details Answer
-In almost all cases, yes, you will get the same address on all chains as long as the owner address is the same! The deployment address is a function of the owner address, the account implementation (e.g. latest version of Light Account), and the salt (you can optionally specify this). If all three of those remain the same, then you deploy the smart account at the same contract address.
+In almost all cases, yes, you will get the same address on all chains as long as the connecting signer address is the same! The deployment address is a function of the address of owner/signer address, the account implementation (e.g. latest version of Light Account), and the salt (you can optionally specify this). If all three of those remain the same, then you deploy the smart account at the same contract address.
 
 There are two scenarios where you'd get a different contract address:
 
-1. If you deploy one smart account, then change the owner address, then deploy the second account.
+1. If you deploy one smart account, then change the signer, then deploy the second account.
 2. If you upgrade the smart account (e.g. to a new version of Light Account). It is unlikely that we will make many updates to this contract so the address will not change frequently.
    :::
 
@@ -45,10 +45,10 @@ Your smart account will be deployed when the first `UserOperation` (UO) is sent 
 It is unlikely you will need to frequently update the Light Account contract itself, however it is possible if needed. Light Account has [`UUPSUpgradeable`](https://github.com/alchemyplatform/light-account/blob/main/src/LightAccount.sol#L50) which adds upgrade methods on the account itself. To upgrade an account you will need to send a `UserOperation` using the method `upgradeTo` or `upgradeToAndCall`, depending on whether or not you need to initialize the new implementation.
 :::
 
-### Can I have multiple accounts for the same owner address? / How do I set the value of the salt/index for Light Account?
+### Can I have multiple accounts for the same signer address? / How do I set the value of the salt for Light Account?
 
 ::: details Answer
-Yes! The optional index value (salt) on Light Account enables the ability to have multiple accounts for the same owner address. This value defaults to 0. You can set it when you create [light account](/packages/aa-accounts/light-account/).
+Yes! The optional salt value on Light Account enables the ability to have multiple accounts under a single signer. This value defaults to 0. You can set it when you create [light account](/packages/aa-accounts/light-account/).
 :::
 
 ### How can I upgrade from Simple Account to Light Account?
@@ -60,7 +60,7 @@ You can call `upgradeToAndCall` on the Simple Account with these params:
 
 - `newImplementation`: Latest LightAccount implementation address (found [here](https://github.com/alchemyplatform/light-account/blob/main/Deployments.md#lightaccount) - make sure to use the implementation address, not the factory address)
   - For example LightAccount v1.1.0 - 0xae8c656ad28F2B59a196AB61815C16A0AE1c3cba
-- `data`: encoded version of the `initialize` function with `anOwner` parameter set to the owner/signer on the account, usually the same owner as what the account used as Simple Account.
+- `data`: encoded version of the `initialize` function with `anOwner` parameter set to the owner on the account, usually the same owner as what the account used as Simple Account.
   - In solidity (foundry) you can use abi.encodeCall and in viem you can use [encodeFunctionData](https://github.com/alchemyplatform/light-account/blob/main/Deployments.md#lightaccount)
 
 It is very important that the `initialize` step is encoded correctly to ensure the account does not get in to a risky state where someone else could call initialize on it and reassign and a signer. You can call `owner()` on the account after upgrade to make sure it is assigned correctly.

--- a/site/signers/choosing-a-signer.md
+++ b/site/signers/choosing-a-signer.md
@@ -24,7 +24,7 @@ A **Signer** is a service (e.g. Magic or Turnkey) or application (e.g. MetaMask)
 
 With Account Kit, you will deploy a **smart account** for each user instead of an EOA wallet. This smart account stores the user’s assets (e.g. tokens or NFTs). The default smart account in Account Kit is called [`LightAccount`](/smart-accounts/light-account/) and it uses a typical single-owner architecture.
 
-The smart account is controlled by an **Owner** address. The smart account will only execute a transaction if it was signed by the owner’s private key.
+The signer connected to the `SmartAccountClient` is used to sign messages, data including user operations and transactions. The signatures for the user operation will be only valid and execute if the signer is the owner or one of the owners of the account.
 
 You can choose any Signer service or application to manage the Owner private key for the user. Using services like Magic, Turnkey, or Web3auth, you can secure the user’s account with an email, social login, or passkeys. You can also use a self-custodial wallet like MetaMask as the Signer.
 

--- a/site/signers/eoa.md
+++ b/site/signers/eoa.md
@@ -40,7 +40,7 @@ const client = createWalletClient({
   transport: custom(window.ethereum),
 });
 
-// this can now be used as an owner for a Smart Contract Account
+// this can now be used as an signer for a Smart Contract Account
 export const eoaSigner = new WalletClientSigner(
   client,
   "json-rpc" //signerType
@@ -68,7 +68,7 @@ export const client = createWalletClient({
   transport: http(),
 });
 
-// this can now be used as an owner for a Smart Contract Account
+// this can now be used as an signer for a Smart Contract Account
 export const eoaSigner = new WalletClientSigner(
   client,
   "local" // signerType

--- a/site/signers/guides/arcana-auth.md
+++ b/site/signers/guides/arcana-auth.md
@@ -68,7 +68,7 @@ export async function getProvider() {
   return createModularAccountAlchemyClient({
     apiKey: "ALCHEMY_API_KEY",
     chain,
-    owner: signer,
+    signer,
   });
 }
 ```

--- a/site/signers/guides/capsule.md
+++ b/site/signers/guides/capsule.md
@@ -87,7 +87,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createCapsuleSigner(),
+  signer: await createCapsuleSigner(),
 });
 ```
 

--- a/site/signers/guides/custom-signer.md
+++ b/site/signers/guides/custom-signer.md
@@ -39,6 +39,6 @@ Smart accounts in Account Kit expect an implementation of `SmartAccountSigner` t
 
 Viem allows you to create a `WalletClient`, which can be used to wrap local or JSON RPC based wallets. You can see the complete docs for leveraging the `WalletClient` [here](https://viem.sh/docs/clients/wallet.html).
 
-We support a `SmartAccountSigner` implementation called `WalletClientSigner` that makes it really easy to use a viem `WalletClient` as an owner on your Smart Contract Account. If your Signer is [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compliant, it's really easy to use with `WalletClient`. Let's take a look at a simple example:
+We support a `SmartAccountSigner` implementation called `WalletClientSigner` that makes it really easy to use a viem `WalletClient` as a signer on your Smart Contract Account. If your Signer is [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compliant, it's really easy to use with `WalletClient`. Let's take a look at a simple example:
 
 <<< @/snippets/signers/wallet-client-signer.ts

--- a/site/signers/guides/dfns.md
+++ b/site/signers/guides/dfns.md
@@ -57,7 +57,7 @@ const createAlchemyProvider = async () => {
   return createModularAccountAlchemyClient({
     apiKey: ALCHEMY_API_KEY,
     chain,
-    owner: await createDfnsSigner(),
+    signer: await createDfnsSigner(),
   });
 };
 ```

--- a/site/signers/guides/dynamic.md
+++ b/site/signers/guides/dynamic.md
@@ -91,7 +91,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: dynamicSigner,
+  signer: dynamicSigner,
 });
 ```
 

--- a/site/signers/guides/fireblocks.md
+++ b/site/signers/guides/fireblocks.md
@@ -67,7 +67,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createFireblocksSigner(),
+  signer: await createFireblocksSigner(),
 });
 ```
 

--- a/site/signers/guides/lit.md
+++ b/site/signers/guides/lit.md
@@ -88,7 +88,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createLitSigner(AUTH_METHOD),
+  signer: await createLitSigner(AUTH_METHOD),
 });
 ```
 

--- a/site/signers/guides/magic.md
+++ b/site/signers/guides/magic.md
@@ -68,7 +68,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createMagicSigner(),
+  signer: await createMagicSigner(),
 });
 ```
 

--- a/site/signers/guides/particle-network.md
+++ b/site/signers/guides/particle-network.md
@@ -65,7 +65,7 @@ const chain = polygonMumbai;
 const provider = await createModularAccountAlchemyClient({
   apiKey: process.env.ALCHEMY_API_KEY,
   chain,
-  owner: await createParticleSigner(),
+  signer: await createParticleSigner(),
 });
 ```
 

--- a/site/signers/guides/portal.md
+++ b/site/signers/guides/portal.md
@@ -66,7 +66,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createPortalSigner(),
+  signer: await createPortalSigner(),
 });
 ```
 

--- a/site/signers/guides/turnkey.md
+++ b/site/signers/guides/turnkey.md
@@ -71,7 +71,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createTurnkeySigner(),
+  signer: await createTurnkeySigner(),
 });
 ```
 

--- a/site/signers/guides/walletkit.md
+++ b/site/signers/guides/walletkit.md
@@ -100,9 +100,9 @@ const signer: SmartAccountSigner = new WalletClientSigner(
 );
 ```
 
-### Configure AlchemySmartContractClient
+### Configure ModularAccountAlchemyClient
 
-Finally, create `createModularAccountAlchemyClient` using the signer we just created as the owner of the smart contract wallet.
+Finally, create `createModularAccountAlchemyClient` using the signer we just created to control the modular smart contract wallet.
 
 ```ts
 import { createModularAccountAlchemyClient } from "@alchemy/aa-alchemy";
@@ -111,6 +111,6 @@ import { sepolia } from "@alchemy/aa-core";
 const client = await createModularAccountAlchemyClient({
   apiKey: "<Alchemy-API-Key>",
   chain: sepolia,
-  owner: signer,
+  signer,
 });
 ```

--- a/site/signers/guides/web3auth.md
+++ b/site/signers/guides/web3auth.md
@@ -66,7 +66,7 @@ const chain = sepolia;
 const provider = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner: await createWeb3AuthSigner(),
+  signer: await createWeb3AuthSigner(),
 });
 ```
 

--- a/site/smart-accounts/index.md
+++ b/site/smart-accounts/index.md
@@ -38,7 +38,7 @@ Modular Account has been audited by Spearbit and Quanstamp. You can find the aud
 
 Account Kit provides a default smart account called `LightAccount`.
 
-[Light Account](/smart-accounts/light-account/) is a secure, audited, gas-optimized, ERC-4337 compatible smart account implementation. It comes equipped with features like owner transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. It's also [open source](https://github.com/alchemyplatform/light-account)!
+[Light Account](/smart-accounts/light-account/) is a secure, audited, gas-optimized, ERC-4337 compatible smart account implementation. It comes equipped with features like ownership transfers, [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) message signing, and batched transactions. It's also [open source](https://github.com/alchemyplatform/light-account)!
 
 It is [deployed](/smart-accounts/light-account/#deployment-addresses) on Ethereum, Optimism, Arbitrum, Polygon, Base, and the respective testnets.
 

--- a/site/smart-accounts/light-account/index.md
+++ b/site/smart-accounts/light-account/index.md
@@ -36,9 +36,9 @@ The code snippet below demonstrates how to use Light Account with Account Kit. I
 ::: code-group
 
 ::: tip Address calculation
-For the Light Account, the address of the smart account will be calculated as a combination of [the owner and the salt](https://github.com/alchemyplatform/light-account/blob/main/src/LightAccountFactory.sol#L24-L33). You will get the same smart account address each time you supply the same `owner`. You can also optionally supply `salt` if you want a different address for the same owner (the default salt is `0n`).
+For the Light Account, the address of the smart account will be calculated as a combination of [the owner and the salt](https://github.com/alchemyplatform/light-account/blob/main/src/LightAccountFactory.sol#L24-L33). You will get the same smart account address each time you supply the same `owner`, the signer that was used to create the account for the first time. You can also optionally supply `salt` if you want a different address for the same `owner` param (the default salt is `0n`).
 
-If you already have an account with a new or different owner (transferred ownership), you can supply the `accountAddress` to connect with your account with a new owner. In that case, the `owner` is not used for address calculation, but still used for signing the operation.
+If you want to use a signer to connect to an account whose address does not map to the contract generated address, you can supply the `accountAddress` to connect with the account of interest. In that case, the `signer` address is not used for address calculation, but only used for signing the operation.
 :::
 
 ## [Deployment addresses](https://github.com/alchemyplatform/light-account/blob/v1.1.0/Deployments.md)

--- a/site/smart-accounts/modular-account/getting-started.md
+++ b/site/smart-accounts/modular-account/getting-started.md
@@ -49,14 +49,14 @@ Then you can simply do the following:
 <<< @/snippets/aa-alchemy/connected-client.ts
 
 ::: tip Address calculation
-For the Modular Account, the address of the smart account will be calculated as a combination of [several variables](https://github.com/alchemyplatform/modular-account/blob/74fe1bfa056bbd41c933990fca0598c8cc3e90e8/src/factory/MultiOwnerModularAccountFactory.sol#L66-L71). You will get the same smart account address each time you supply the same `owner` or `owners`. You can also optionally supply `salt` if you want a different address for the same owner(s) (the default salt is `0n`).
+For the Light Account, the address of the smart account will be calculated as a combination of [the owner and the salt](https://github.com/alchemyplatform/light-account/blob/main/src/LightAccountFactory.sol#L24-L33). You will get the same smart account address each time you supply the same `owner`, the signer that was used to create the account for the first time. You can also optionally supply `salt` if you want a different address for the same `owner` param (the default salt is `0n`).
 
-If you already have an account with a new or different owner (transferred ownership), you can supply the `accountAddress` to connect with your account with a new owner. In that case, the `owner` is not used for address calculation, but still used for signing the operation.
+If you want to use a signer to connect to an account whose address does not map to the contract generated address, you can supply the `accountAddress` to connect with the account of interest. In that case, the `signer` address is not used for address calculation, but only used for signing the operation.
 :::
 
 That's it! You've configured your client.
 
-Next, if you want to replace that `owner` with a smart account signer, check out [choosing a signer](/signers/choosing-a-signer). Or, if you're ready to get onchain, go to [send user operations](/using-smart-accounts/send-user-operations).
+Next, if you want to replace that `signer` with a smart account signer, check out [choosing a signer](/signers/choosing-a-signer). Or, if you're ready to get onchain, go to [send user operations](/using-smart-accounts/send-user-operations).
 
 ## With `@alchemy/aa-core`
 
@@ -112,4 +112,4 @@ const decoratedClient = smartAccountClient
 <<< @/snippets/aa-core/smartAccountClient.ts
 :::
 
-Next, if you want to replace that `owner` with a smart account signer, check out [choosing a signer](/signers/choosing-a-signer). Or, if you're ready to get onchain, go to [send user operations](/using-smart-accounts/send-user-operations).
+Next, if you want to use a different `signer` with a smart account signer, check out [choosing a signer](/signers/choosing-a-signer). Or, if you're ready to get onchain, go to [send user operations](/using-smart-accounts/send-user-operations).

--- a/site/snippets/aa-accounts/lightAccountClient.ts
+++ b/site/snippets/aa-accounts/lightAccountClient.ts
@@ -6,5 +6,5 @@ export const smartAccountClient = createLightAccountClient({
   transport: http("RPC_URL"),
   chain: sepolia,
   // or any other SmartAccountSigner
-  owner: LocalAccountSigner.mnemonicToAccountSigner("YOUR_MNEMONIC"),
+  signer: LocalAccountSigner.mnemonicToAccountSigner("YOUR_MNEMONIC"),
 });

--- a/site/snippets/aa-alchemy/connected-client.ts
+++ b/site/snippets/aa-alchemy/connected-client.ts
@@ -7,5 +7,5 @@ export const smartAccountClient = await createModularAccountAlchemyClient({
   apiKey: "YOUR_API_KEY",
   chain,
   // you can swap this out for any SmartAccountSigner
-  owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
+  signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
 });

--- a/site/snippets/aa-alchemy/gas-manager-client.ts
+++ b/site/snippets/aa-alchemy/gas-manager-client.ts
@@ -6,7 +6,7 @@ import { LocalAccountSigner, sepolia } from "@alchemy/aa-core";
 export const smartAccountClient = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY",
   chain: sepolia,
-  owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"), // or any SmartAccountSigner
+  signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"), // or any SmartAccountSigner
   gasManagerConfig: {
     policyId: "YourGasManagerPolicyId",
   },

--- a/site/snippets/aa-alchemy/light-account-client.ts
+++ b/site/snippets/aa-alchemy/light-account-client.ts
@@ -4,5 +4,5 @@ import { LocalAccountSigner, sepolia } from "@alchemy/aa-core";
 export const smartAccountClient = await createLightAccountAlchemyClient({
   apiKey: "YOUR_API_KEY",
   chain: sepolia,
-  owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
+  signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
 });

--- a/site/snippets/aa-alchemy/light-account.ts
+++ b/site/snippets/aa-alchemy/light-account.ts
@@ -3,16 +3,16 @@ import { LocalAccountSigner, sepolia, type Hex } from "@alchemy/aa-core";
 
 const chain = sepolia;
 
-// The private key of your EOA that will be the owner of Light Account
+// The private key of your EOA that will be the signer of Light Account
 const PRIVATE_KEY = "0xYourEOAPrivateKey" as Hex;
-const owner = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
+const signer = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
 
 // Create a provider to send user operations from your smart account
 const provider = await createLightAccountAlchemyClient({
   // get your Alchemy API key at https://dashboard.alchemy.com
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner,
+  signer,
 });
 
 // Fund your account address with ETH to send for the user operations

--- a/site/snippets/aa-core/lightAccountClient.ts
+++ b/site/snippets/aa-core/lightAccountClient.ts
@@ -11,7 +11,7 @@ import {
 import { http } from "viem";
 
 export const chain = polygonMumbai;
-export const owner: SmartAccountSigner =
+export const signer: SmartAccountSigner =
   LocalAccountSigner.mnemonicToAccountSigner("YOUR_OWNER_MNEMONIC");
 export const rpcTransport = http(
   "https://polygon-mumbai.g.alchemy.com/v2/demo"
@@ -23,6 +23,6 @@ export const smartAccountClient = createSmartAccountClient({
   account: await createLightAccount({
     transport: rpcTransport,
     chain,
-    owner,
+    signer,
   }),
 }).extend(lightAccountClientActions);

--- a/site/snippets/aa-core/smartAccountClient.ts
+++ b/site/snippets/aa-core/smartAccountClient.ts
@@ -8,7 +8,7 @@ import {
 import { http } from "viem";
 
 const chain = polygonMumbai;
-const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
+const signer: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
   "YOUR_OWNER_MNEMONIC"
 );
 const rpcTransport = http("https://polygon-mumbai.g.alchemy.com/v2/demo");
@@ -19,6 +19,6 @@ export const smartAccountClient = createSmartAccountClient({
   account: await createMultiOwnerModularAccount({
     transport: rpcTransport,
     chain,
-    owner,
+    signer,
   }),
 });

--- a/site/snippets/aa-ethers/ethers-provider.ts
+++ b/site/snippets/aa-ethers/ethers-provider.ts
@@ -5,7 +5,7 @@ import {
 } from "@alchemy/aa-core";
 import { EthersProviderAdapter } from "@alchemy/aa-ethers";
 import { Alchemy, Network } from "alchemy-sdk";
-import { owner } from "snippets/aa-core/lightAccountClient";
+import { signer } from "snippets/aa-core/lightAccountClient";
 import { http } from "viem";
 
 // 1. Create alchemy instance
@@ -23,7 +23,7 @@ export const provider = EthersProviderAdapter.fromEthersProvider(
 ).connectToAccount(
   await createSimpleSmartAccount({
     chain,
-    owner,
+    signer,
     factoryAddress: getDefaultSimpleAccountFactoryAddress(chain),
     transport: http(
       `${chain.rpcUrls.alchemy.http[0]}/${ethersProvider.apiKey}`

--- a/site/snippets/aa-ethers/ethers-signer.ts
+++ b/site/snippets/aa-ethers/ethers-signer.ts
@@ -7,17 +7,16 @@ import {
 import { http } from "viem";
 import { provider } from "./ethers-provider.js";
 
-const owner: SmartAccountSigner = LocalAccountSigner.mnemonicToAccountSigner(
-  process.env.YOUR_OWNER_MNEMONIC!
-);
+const eoaSigner: SmartAccountSigner =
+  LocalAccountSigner.mnemonicToAccountSigner(process.env.YOUR_OWNER_MNEMONIC!);
 
 const chain = polygonMumbai;
 
 // 2. Connect the provider to the smart account signer
-export const signer = provider.connectToAccount(
+export const accountSigner = provider.connectToAccount(
   await createLightAccount({
     chain,
     transport: http("RPC_URL"),
-    owner,
+    signer: eoaSigner,
   })
 );

--- a/site/snippets/enhanced-apis-example/nft.ts
+++ b/site/snippets/enhanced-apis-example/nft.ts
@@ -14,7 +14,7 @@ const client = (
   await createModularAccountAlchemyClient({
     chain: sepolia,
     apiKey: "YOUR_API_KEY",
-    owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
+    signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
   })
 ).extend(alchemyEnhancedApiActions(alchemy));
 

--- a/site/snippets/enhanced-apis-example/token.ts
+++ b/site/snippets/enhanced-apis-example/token.ts
@@ -14,7 +14,7 @@ const client = (
   await createModularAccountAlchemyClient({
     chain: sepolia,
     apiKey: "YOUR_API_KEY",
-    owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
+    signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
   })
 ).extend(alchemyEnhancedApiActions(alchemy));
 

--- a/site/snippets/getting-started/client.ts
+++ b/site/snippets/getting-started/client.ts
@@ -3,17 +3,17 @@ import { LocalAccountSigner, sepolia, type Hex } from "@alchemy/aa-core";
 
 const chain = sepolia;
 
-// The private key of your EOA that will be the owner of Light Account
+// The private key of your EOA that will be the signer to connect with the Modular Account
 // Our recommendation is to store the private key in an environment variable
 const PRIVATE_KEY = "0xYourEOAPrivateKey" as Hex;
-const owner = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
+const signer = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
 
 // Create a smart account client to send user operations from your smart account
 const client = await createModularAccountAlchemyClient({
   // get your Alchemy API key at https://dashboard.alchemy.com
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner,
+  signer,
 });
 
 (async () => {

--- a/site/snippets/getting-started/send-user-operation.ts
+++ b/site/snippets/getting-started/send-user-operation.ts
@@ -8,16 +8,16 @@ import {
 
 const chain = polygonMumbai;
 
-// The private key of your EOA that will be the owner of Light Account
+// The private key of your EOA that will be the signer to connect with the Modular Account
 const PRIVATE_KEY = "0xYourEOAPrivateKey" as Hex;
-const owner = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
+const signer = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
 
 // Create a provider to send user operations from your smart account
 const provider = await createModularAccountAlchemyClient({
   // get your Alchemy API key at https://dashboard.alchemy.com
   apiKey: "ALCHEMY_API_KEY",
   chain,
-  owner,
+  signer,
 });
 
 // [!code focus:22]

--- a/site/snippets/nani-account.ts
+++ b/site/snippets/nani-account.ts
@@ -4,9 +4,9 @@ import { LocalAccountSigner, sepolia, type Hex } from "@alchemy/aa-core";
 
 const chain = sepolia;
 
-// The private key of your EOA that will be the owner of Nani Account
+// The private key of your EOA that will be the signer of Nani Account
 const PRIVATE_KEY = "0xYourEOAPrivateKey" as Hex;
-const owner = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
+const signer = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY);
 
 // Create a provider to send user operations from your smart account
 const provider = new AlchemyProvider({
@@ -17,7 +17,7 @@ const provider = new AlchemyProvider({
   (rpcClient) =>
     new NaniAccount({
       rpcClient,
-      owner,
+      signer,
       chain,
       factoryAddress: getDefaultNaniAccountFactoryAddress(chain),
     })

--- a/site/snippets/send-uo-example/full-example.ts
+++ b/site/snippets/send-uo-example/full-example.ts
@@ -13,7 +13,7 @@ const eoaSigner: SmartAccountSigner =
 const client = await createModularAccountAlchemyClient({
   apiKey: "ALCHEMY_API_KEY", // replace with your Alchemy API Key
   chain: sepolia,
-  owner: eoaSigner,
+  signer: eoaSigner,
   gasManagerConfig: {
     policyId: "POLICY_ID", // replace with your policy id, get yours at https://dashboard.alchemy.com/
   },

--- a/site/snippets/session-keys/base-client.ts
+++ b/site/snippets/session-keys/base-client.ts
@@ -5,7 +5,7 @@ import { LocalAccountSigner, sepolia } from "@alchemy/aa-core";
 export const client = (
   await createModularAccountAlchemyClient({
     chain: sepolia,
-    owner: LocalAccountSigner.mnemonicToAccountSigner("MNEMONIC"),
+    signer: LocalAccountSigner.mnemonicToAccountSigner("MNEMONIC"),
     apiKey: "ALCHEMY_API_KEY",
   })
 ).extend(sessionKeyPluginActions);

--- a/site/snippets/session-keys/full-example.ts
+++ b/site/snippets/session-keys/full-example.ts
@@ -9,14 +9,14 @@ import { createModularAccountAlchemyClient } from "@alchemy/aa-alchemy";
 import { LocalAccountSigner, sepolia } from "@alchemy/aa-core";
 
 const chain = sepolia;
-// this is the owner of the account, you can swap out for any signer, later we'll create a new client using a session key signe
-const owner = LocalAccountSigner.mnemonicToAccountSigner("MNEMONIC");
+// this is the signer to connect with the account, later we'll create a new client using a session key signe
+const signer = LocalAccountSigner.mnemonicToAccountSigner("MNEMONIC");
 const sessionKeySigner = new SessionKeySigner();
 const client = (
   await createModularAccountAlchemyClient({
     chain,
     apiKey: "ALCHEMY_API_KEY",
-    owner,
+    signer,
   })
 ).extend(sessionKeyPluginActions);
 
@@ -59,7 +59,7 @@ if (!isPluginInstalled) {
 const sessionKeyClient = (
   await createModularAccountAlchemyClient({
     chain,
-    owner: sessionKeySigner,
+    signer: sessionKeySigner,
     apiKey: "ALCHEMY_API_KEY",
     // this is important because it tells the client to use our previously deployed account
     accountAddress: client.getAddress(),

--- a/site/snippets/signers/privy.ts
+++ b/site/snippets/signers/privy.ts
@@ -51,7 +51,7 @@ export const provider = new AlchemyProvider({
   (rpcClient) =>
     new LightSmartContractAccount({
       chain: rpcClient.chain,
-      owner: privySigner,
+      signer: privySigner,
       factoryAddress: getDefaultLightAccountFactoryAddress(rpcClient.chain),
       rpcClient,
     })

--- a/site/snippets/sim-uo-example/sim-method.ts
+++ b/site/snippets/sim-uo-example/sim-method.ts
@@ -8,7 +8,7 @@ import {
 export const smartAccountClient = await createModularAccountAlchemyClient({
   apiKey: "YOUR_API_KEY",
   chain: sepolia,
-  owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
+  signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
 });
 
 const uoStruct: UserOperationCallData = {

--- a/site/snippets/sim-uo-example/sim-middleware.ts
+++ b/site/snippets/sim-uo-example/sim-middleware.ts
@@ -4,7 +4,7 @@ import { LocalAccountSigner, sepolia } from "@alchemy/aa-core";
 export const smartAccountClient = await createModularAccountAlchemyClient({
   apiKey: "YOUR_API_KEY",
   chain: sepolia,
-  owner: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
+  signer: LocalAccountSigner.mnemonicToAccountSigner("OWNER_MNEMONIC"),
   useSimulation: true,
 });
 

--- a/site/using-smart-accounts/session-keys/getting-started.md
+++ b/site/using-smart-accounts/session-keys/getting-started.md
@@ -20,7 +20,7 @@ head:
 
 # Getting started with Session Keys
 
-`@alchemy/aa-accounts` exports all of the definitions you need to use session keys with a Modular Account. We provide a simple `SessionKeySigner` class that generates session keys on the client and can be used as the `owner` for the Multi Owner Modular Account.
+`@alchemy/aa-accounts` exports all of the definitions you need to use session keys with a Modular Account. We provide a simple `SessionKeySigner` class that generates session keys on the client and can be used as the `signer` for the Multi Owner Modular Account.
 We also export the necessary decorators which can be used to extend your `SmartAccountClient` to make interacting with session keys easy.
 
 ## Usage

--- a/site/using-smart-accounts/transfer-ownership/light-account.md
+++ b/site/using-smart-accounts/transfer-ownership/light-account.md
@@ -64,31 +64,13 @@ import { encodeFunctionData } from "viem";
 import { smartAccountClient } from "./smartAccountClient";
 
 // this will return the address of the smart account you want to transfer ownerhip of
-const accountAddress = await smartAccountClient.getAddress();
+const accountAddress = smartAccountClient.getAddress();
 const newOwner = "0x..."; // the address of the new owner
 
 // [!code focus:99]
-const { hash: userOperationHash } = smartAccountClient.sendUserOperation({
+const { hash: userOperationHash } = await smartAccountClient.sendUserOperation({
   to: accountAddress,
-  data: encodeFunctionData({
-    abi: [
-      {
-        inputs: [
-          {
-            internalType: "address",
-            name: "newOwner",
-            type: "address",
-          },
-        ],
-        name: "transferOwnership",
-        outputs: [],
-        stateMutability: "nonpayable",
-        type: "function",
-      },
-    ],
-    functionName: "transferOwnership",
-    args: [newOwner],
-  }),
+  data: smartAccountClient.encodeTransferOwnership(newOwner),
 });
 ```
 

--- a/site/using-smart-accounts/transfer-ownership/light-account.md
+++ b/site/using-smart-accounts/transfer-ownership/light-account.md
@@ -20,11 +20,11 @@ head:
 
 # How to transfer ownership of a Light Account
 
-Not all smart account implementations support transfering the owner (e.g. `SimpleAccount`). However, a number of the accounts in this guide and in Account Kit do, including our Light Account! Let's see a few different ways we can transfer ownership of an Account (using Light Account as an example).
+Not all smart account implementations support transfering the ownership(e.g. `SimpleAccount`). However, a number of the accounts in this guide and in Account Kit do, including our Light Account! Let's see a few different ways we can transfer ownership of an Account (using Light Account as an example).
 
 ## Usage
 
-Light Account exposes the following method which allows the existing owner to transfer ownership to a new address:
+Light Account exposes the following method which allows the existing owner to transfer ownership to a new owner address:
 
 ```solidity
 function transferOwnership(address newOwner) public virtual onlyOwner

--- a/site/using-smart-accounts/transfer-ownership/modular-account.md
+++ b/site/using-smart-accounts/transfer-ownership/modular-account.md
@@ -27,9 +27,9 @@ The Multi Owner plugin lets your smart accounts have one or more ECDSA or SCA ow
 The Multi-Owner Plugin is able to:
 
 - Update (add or remove) owners for an MSCA.
-- Check if an address is an owner of an MSCA.
+- Check if an address is an owner address of an MSCA.
 - Show all owners of an MSCA.
-- Validate owner signatures of ERC-4337 enabled user operation transactions as well as regular transactions.
+- Validate signed signatures of ERC-4337 enabled user operations as well as regular transactions.
 
 All Modular Accounts have `MultiOwnerPlugin` pre-installed upon creation, exposing following methods for account owners to update (add or remove) and read the current owners of the account:
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the codebase to replace occurrences of `owner` with `signer` in various files for consistency and clarity.

### Detailed summary
- Replaced `owner` with `signer` in multiple files for consistency and clarity.
- Updated function calls, object properties, and variable names.
- Ensured alignment with the terminology used across the codebase.

> The following files were skipped due to too many changes: `packages/accounts/src/nani-account/transferNaniAccountOwnership.ts`, `packages/core/src/signer/local-account.ts`, `site/signers/eoa.md`, `packages/accounts/src/nani-account/__tests__/account.test.ts`, `site/packages/aa-core/smart-account-client/types/userOperationFeeOptions.md`, `site/snippets/aa-ethers/ethers-signer.ts`, `site/snippets/aa-ethers/ethers-provider.ts`, `site/packages/aa-accounts/light-account/actions/transferOwnership.md`, `site/using-smart-accounts/transfer-ownership/modular-account.md`, `site/signers/guides/walletkit.md`, `site/snippets/nani-account.ts`, `site/snippets/getting-started/send-user-operation.ts`, `site/snippets/aa-alchemy/light-account.ts`, `site/packages/aa-ethers/account-signer/signMessage.md`, `site/packages/aa-signers/magic/introduction.md`, `site/packages/aa-signers/portal/introduction.md`, `site/packages/aa-signers/capsule/introduction.md`, `site/packages/aa-signers/turnkey/introduction.md`, `site/packages/aa-signers/particle/introduction.md`, `site/packages/aa-signers/web3auth/introduction.md`, `site/packages/aa-ethers/provider-adapter/connectToAccount.md`, `site/packages/aa-signers/arcana-auth/introduction.md`, `packages/accounts/src/msca/plugins/multi-owner/signer.ts`, `site/packages/aa-signers/fireblocks/introduction.md`, `site/using-smart-accounts/session-keys/getting-started.md`, `site/snippets/getting-started/client.ts`, `site/getting-started/setup.md`, `packages/alchemy/src/client/lightAccountClient.ts`, `site/smart-accounts/index.md`, `site/snippets/session-keys/full-example.ts`, `site/signers/guides/custom-signer.md`, `site/signers/choosing-a-signer.md`, `packages/core/src/account/schema.ts`, `packages/ethers/src/__tests__/provider-adapter.test.ts`, `packages/accounts/src/light-account/decorator.ts`, `packages/accounts/src/light-account/actions/transferOwnership.ts`, `packages/accounts/src/light-account/client.ts`, `site/packages/aa-ethers/account-signer/connect.md`, `packages/alchemy/src/client/modularAccountClient.ts`, `site/smart-accounts/light-account/index.md`, `packages/core/src/account/types.ts`, `packages/ethers/e2e-tests/simple-account.e2e.test.ts`, `packages/core/src/account/base.ts`, `packages/alchemy/src/client/lightAccountClient.test.ts`, `packages/core/src/account/__tests__/simple.test.ts`, `packages/accounts/src/light-account/account.test.ts`, `site/using-smart-accounts/transfer-ownership/light-account.md`, `packages/accounts/src/msca/utils.ts`, `packages/accounts/src/msca/client.ts`, `site/packages/aa-ethers/account-signer/introduction.md`, `site/smart-accounts/modular-account/getting-started.md`, `packages/accounts/src/msca/account/multiOwnerAccount.ts`, `packages/alchemy/e2e-tests/light-account.e2e.test.ts`, `packages/core/src/account/simple.ts`, `site/resources/faqs.md`, `packages/accounts/src/light-account/account.ts`, `site/packages/aa-accounts/light-account/index.md`, `packages/accounts/src/nani-account/account.ts`, `packages/core/e2e-tests/simple-account.e2e.test.ts`, `packages/accounts/src/light-account/e2e-tests/light-account.e2e.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->