### PR TITLE
fix: doc fixes for light account transfer ownership

### DIFF
--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -63,7 +63,7 @@ export async function createLightAccount<
 export async function createLightAccount({
   transport,
   chain,
-  signer: owner,
+  signer,
   initCode,
   version = "v1.1.0",
   entryPoint = getVersion060EntryPoint(chain),
@@ -71,7 +71,6 @@ export async function createLightAccount({
   factoryAddress = getDefaultLightAccountFactoryAddress(chain, version),
   salt: salt_ = 0n,
 }: CreateLightAccountParams): Promise<LightAccount> {
-  let signer = owner;
   const client = createBundlerClient({
     transport,
     chain,

--- a/site/packages/aa-accounts/light-account/actions/transferOwnership.md
+++ b/site/packages/aa-accounts/light-account/actions/transferOwnership.md
@@ -14,9 +14,9 @@ next:
   text: Utils
 ---
 
-# transferLightAccountOwnership
+# transferOwnership
 
-`transferLightAccountOwnership` is an action exported by `@alchemy/aa-accounts` which sends a UO that transfers ownership of the account to a new owner, and returns either the UO hash or transaction hash.
+`transferOwnership` is an action exported by `@alchemy/aa-accounts` which sends a UO that transfers ownership of the account to a new owner, and returns either the UO hash or transaction hash.
 
 ## Usage
 
@@ -25,11 +25,21 @@ next:
 ```ts [example.ts]
 import { smartAccountClient } from "./lightAccountClient";
 // [!code focus:99]
+const accountAddress = smartAccountClient.getAddress();
+
 // transfer ownership
 const newOwner = LocalAccountSigner.mnemonicToAccountSigner(NEW_OWNER_MNEMONIC);
-const hash = smartAccountClient.transferOwnership({
+const hash = await smartAccountClient.transferOwnership({
   newOwner,
   waitForTxn: true,
+});
+// after transaction is mined on the network,
+// create a new light account client for the transferred Light Account
+const transferredClient = await createLightAccountClient({
+  transport: custom(smartAccountClient),
+  chain: smartAccountClient.chain,
+  signer: newOwner,
+  accountAddress, // NOTE: you MUST to specify the original smart account address to connect using the new owner/signer
 });
 ```
 

--- a/site/packages/aa-accounts/light-account/index.md
+++ b/site/packages/aa-accounts/light-account/index.md
@@ -23,7 +23,7 @@ The additional methods supported by `LightAccount` are:
 3.  [`signTypedDataWith6492`](/packages/aa-accounts/light-account/signTypedDataWith6492) -- supports typed data signatures for deployed smart accounts, as well as undeployed accounts (counterfactual addresses) using ERC-6492.
 4.  [`getOwnerAddress`](/packages/aa-accounts/light-account/getOwnerAddress) -- returns the on-chain owner address of the account.
 5.  [`encodeTransferOwnership`](/packages/aa-accounts/light-account/encodeTransferOwnership) -- encodes the transferOwnership function call using Light Account ABI.
-6.  [`transferLightAccountOwnership`](/packages/aa-accounts/light-account/actions/transferOwnership) -- transfers ownership of the account to a new owner, and returns either the UO hash or transaction hash.
+6.  [`transferOwnership`](/packages/aa-accounts/light-account/actions/transferOwnership) -- transfers ownership of the account to a new owner, and returns either the UO hash or transaction hash.
 
 ## Usage
 
@@ -31,17 +31,18 @@ The additional methods supported by `LightAccount` are:
 
 ```ts [example.ts]
 import { smartAccountClient } from "./smartAccountClient";
-import { transferLightAccountOwnership } from "@alchemy/aa-accounts";
 
 // [!code focus:99]
 // sign message (works for undeployed and deployed accounts)
-const signedMessageWith6492 = smartAccountClient.signMessageWith6492("test");
+const signedMessageWith6492 = await smartAccountClient.signMessageWith6492(
+  "test"
+);
 
 // sign typed data
-const signedTypedData = smartAccountClient.signTypedData("test");
+const signedTypedData = await smartAccountClient.signTypedData("test");
 
 // sign typed data (works for undeployed and deployed accounts), using
-const signedTypedDataWith6492 = smartAccountClient.signTypedDataWith6492({
+const signedTypedDataWith6492 = await smartAccountClient.signTypedDataWith6492({
   types: {
     Request: [{ name: "hello", type: "string" }],
   },
@@ -53,12 +54,22 @@ const signedTypedDataWith6492 = smartAccountClient.signTypedDataWith6492({
 
 // get on-chain account owner address
 const ownerAddress = await smartAccountClient.account.getOwnerAddress();
+const accountAddress = smartAccountClient.getAddress();
 
 // transfer ownership
 const newOwner = LocalAccountSigner.mnemonicToAccountSigner(NEW_OWNER_MNEMONIC);
-const hash = smartAccountClient.transferOwnership({
+const hash = await smartAccountClient.transferOwnership({
   newOwner,
   waitForTxn: true, // wait for txn with UO to be mined
+});
+
+// after transaction is mined on the network,
+// create a new light account client for the transferred Light Account
+const transferredClient = await createLightAccountClient({
+  transport: custom(smartAccountClient),
+  chain: smartAccountClient.chain,
+  signer: newOwner,
+  accountAddress, // NOTE: you MUST to specify the original smart account address to connect using the new owner/signer
 });
 ```
 

--- a/site/packages/aa-core/smart-account-client/actions/getAddress.md
+++ b/site/packages/aa-core/smart-account-client/actions/getAddress.md
@@ -23,7 +23,7 @@ Returns the address of the connected account. Throws error if there is no connec
 ```ts [example.ts]
 import { smartAccountClient } from "./smartAccountClient";
 // [!code focus:99]
-const address = await smartAccountClient.getAddress();
+const address = smartAccountClient.getAddress();
 ```
 
 <<< @/snippets/aa-core/smartAccountClient.ts

--- a/site/snippets/aa-accounts/lightAccountClient.ts
+++ b/site/snippets/aa-accounts/lightAccountClient.ts
@@ -2,7 +2,7 @@ import { createLightAccountClient } from "@alchemy/aa-accounts";
 import { LocalAccountSigner, sepolia } from "@alchemy/aa-core";
 import { http } from "viem";
 
-export const smartAccountClient = createLightAccountClient({
+export const smartAccountClient = await createLightAccountClient({
   transport: http("RPC_URL"),
   chain: sepolia,
   // or any other SmartAccountSigner

--- a/site/using-smart-accounts/transfer-ownership/light-account.md
+++ b/site/using-smart-accounts/transfer-ownership/light-account.md
@@ -41,11 +41,20 @@ import { smartAccountClient as lightAccountClient } from "./smartAccountClient";
 
 // this will return the signer of the smart account you want to transfer ownerhip to
 const newOwner = LocalAccountSigner.mnemonicToAccountSigner(NEW_OWNER_MNEMONIC);
+const accountAddress = lightAccountClient.getAddress();
 
 // [!code focus:99]
 const hash = lightAccountClient.transferOwnership({
   newOwner,
   waitForTxn: true,
+});
+// after transaction is mined on the network,
+// create a new light account client for the transferred Light Account
+const transferredClient = await createLightAccountClient({
+  transport: custom(smartAccountClient),
+  chain: smartAccountClient.chain,
+  signer: newOwner,
+  accountAddress, // NOTE: you MUST to specify the original smart account address to connect using the new owner/signer
 });
 ```
 
@@ -68,10 +77,12 @@ const accountAddress = smartAccountClient.getAddress();
 const newOwner = "0x..."; // the address of the new owner
 
 // [!code focus:99]
-const { hash: userOperationHash } = await smartAccountClient.sendUserOperation({
+const result = await smartAccountClient.sendUserOperation({
   to: accountAddress,
   data: smartAccountClient.encodeTransferOwnership(newOwner),
 });
+// wait for txn with UO to be mined
+await smartAccountClient.waitForUserOperationTransaction(result);
 ```
 
 <<< @/snippets/aa-alchemy/light-account-client.ts [smartAccountClient.ts]


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds asynchronous initialization to `smartAccountClient` creation and updates usage of `transferOwnership` in `aa-accounts`. 

### Detailed summary
- Added `await` to `createLightAccountClient` initialization in `lightAccountClient.ts`
- Renamed `transferLightAccountOwnership` to `transferOwnership` in `transferOwnership.md`
- Updated usage of `transferOwnership` in various files
- Added usage of `await` in `index.md` for signing methods

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->