### PR TITLE
fix: custom Alchemy-AA-Sdk-Version header fix

### DIFF
--- a/packages/core/src/client/bundlerClient.ts
+++ b/packages/core/src/client/bundlerClient.ts
@@ -86,7 +86,9 @@ export function createBundlerClient(
             ...fetchOptions,
             headers: {
               ...fetchOptions?.headers,
-              "Alchemy-AA-Sdk-Version": VERSION,
+              ...(url.toLowerCase().indexOf("alchemy") > -1
+                ? { "Alchemy-AA-Sdk-Version": VERSION }
+                : undefined),
             },
           },
         }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR dynamically adds the `Alchemy-AA-Sdk-Version` header based on the URL containing "alchemy".

### Detailed summary
- Added logic to conditionally include `Alchemy-AA-Sdk-Version` header based on URL containing "alchemy"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->