### PR TITLE
fix: tx signing needs to happen over hash of RLP

### DIFF
--- a/packages/alchemy/src/signer/signer.ts
+++ b/packages/alchemy/src/signer/signer.ts
@@ -2,6 +2,7 @@ import type { SmartAccountAuthenticator } from "@alchemy/aa-core";
 import {
   hashMessage,
   hashTypedData,
+  keccak256,
   serializeTransaction,
   type CustomSource,
   type Hex,
@@ -139,7 +140,7 @@ export class AlchemySigner
     const serializeFn = args?.serializer ?? serializeTransaction;
     const serializedTx = serializeFn(tx);
 
-    return this.inner.signRawMessage(serializedTx);
+    return this.inner.signRawMessage(keccak256(serializedTx));
   };
 
   /**


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `keccak256` function to the `AlchemySigner` class for signing raw messages.

### Detailed summary
- Added `keccak256` function
- Updated `signRawMessage` method to use `keccak256` for message hashing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->