### PR TITLE
fix(alchemy-signer): missing transports on iOS during passkey creation

### DIFF
--- a/packages/alchemy/src/signer/client/index.ts
+++ b/packages/alchemy/src/signer/client/index.ts
@@ -513,6 +513,14 @@ export class AlchemySignerClient {
       signal: options?.signal,
     });
 
+    // on iOS sometimes this is returned as empty or null, so handling that here
+    if (attestation.transports == null || attestation.transports.length === 0) {
+      attestation.transports = [
+        "AUTHENTICATOR_TRANSPORT_INTERNAL",
+        "AUTHENTICATOR_TRANSPORT_HYBRID",
+      ];
+    }
+
     return { challenge, authenticatorUserId, attestation };
   };
 }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to handle cases where `attestation.transports` is empty or null on iOS by assigning default values.

### Detailed summary
- Handle cases where `attestation.transports` is empty or null on iOS
- Assign default values to `attestation.transports` if necessary

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->