### PR TITLE
fix(alchemy-signer): undo a whoami change

### DIFF
--- a/packages/alchemy/src/signer/client/index.ts
+++ b/packages/alchemy/src/signer/client/index.ts
@@ -139,11 +139,13 @@ export class AlchemySignerClient {
     return user;
   };
 
-  public whoami = async (
-    orgId = this.user?.orgId ?? ROOT_ORG_ID
-  ): Promise<User> => {
+  public whoami = async (orgId = this.user?.orgId): Promise<User> => {
     if (this.user) {
       return this.user;
+    }
+
+    if (!orgId) {
+      throw new Error("No orgId provided");
     }
 
     const stampedRequest = await this.turnkeyClient.stampGetWhoami({


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `whoami` method in the `SignerClient` class to throw an error if no `orgId` is provided.

### Detailed summary
- Updated `whoami` method to throw an error if no `orgId` is provided
- Removed default value for `orgId` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->