### PR TITLE
fix(alchemy-signer): allow for org id to be passed with bundle

### DIFF
--- a/packages/alchemy/src/signer/client/index.ts
+++ b/packages/alchemy/src/signer/client/index.ts
@@ -89,6 +89,7 @@ export class AlchemySignerClient {
         email,
         targetPublicKey: publicKey,
         expirationSeconds,
+        redirectParams: params.redirectParams?.toString(),
       });
 
       return response;
@@ -117,6 +118,7 @@ export class AlchemySignerClient {
       email,
       targetPublicKey: publicKey,
       expirationSeconds,
+      redirectParams: params.redirectParams?.toString(),
     });
   };
 

--- a/packages/alchemy/src/signer/client/types.ts
+++ b/packages/alchemy/src/signer/client/types.ts
@@ -18,6 +18,7 @@ export type CreateAccountParams =
       type: "email";
       email: string;
       expirationSeconds?: number;
+      redirectParams?: URLSearchParams;
     }
   | {
       type: "passkey";
@@ -29,6 +30,7 @@ export type EmailAuthParams = {
   email: string;
   expirationSeconds?: number;
   targetPublicKey: string;
+  redirectParams?: URLSearchParams;
 };
 
 export type SignerRoutes = SignerEndpoints[number]["Route"];
@@ -45,7 +47,7 @@ export type SignerEndpoints = [
   {
     Route: "/v1/signup";
     Body:
-      | EmailAuthParams
+      | (Omit<EmailAuthParams, "redirectParams"> & { redirectParams?: string })
       | {
           passkey: {
             challenge: string;
@@ -67,7 +69,7 @@ export type SignerEndpoints = [
   },
   {
     Route: "/v1/auth";
-    Body: EmailAuthParams;
+    Body: Omit<EmailAuthParams, "redirectParams"> & { redirectParams?: string };
     Response: {
       orgId: string;
     };

--- a/packages/alchemy/src/signer/signer.ts
+++ b/packages/alchemy/src/signer/signer.ts
@@ -26,7 +26,7 @@ import {
 
 export type AuthParams =
   | { type: "email"; email: string }
-  | { type: "email"; bundle: string }
+  | { type: "email"; bundle: string; orgId?: string }
   | {
       type: "passkey";
       createNew: false;
@@ -214,7 +214,10 @@ export class AlchemySigner
         });
       });
     } else {
-      const temporarySession = this.sessionManager.getTemporarySession();
+      const temporarySession = params.orgId
+        ? { orgId: params.orgId }
+        : this.sessionManager.getTemporarySession();
+
       if (!temporarySession) {
         throw new Error("Could not find email auth init session!");
       }

--- a/packages/alchemy/src/signer/signer.ts
+++ b/packages/alchemy/src/signer/signer.ts
@@ -25,7 +25,7 @@ import {
 } from "./session/manager.js";
 
 export type AuthParams =
-  | { type: "email"; email: string }
+  | { type: "email"; email: string; redirectParams?: URLSearchParams }
   | { type: "email"; bundle: string; orgId?: string }
   | {
       type: "passkey";
@@ -196,11 +196,13 @@ export class AlchemySigner
         ? await this.inner.initEmailAuth({
             email: params.email,
             expirationSeconds: this.sessionManager.expirationTimeMs,
+            redirectParams: params.redirectParams,
           })
         : await this.inner.createAccount({
             type: "email",
             email: params.email,
             expirationSeconds: this.sessionManager.expirationTimeMs,
+            redirectParams: params.redirectParams,
           });
 
       this.sessionManager.setTemporarySession({ orgId });


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the ability to include `redirectParams` in various parts of the Alchemy Signer codebase.

### Detailed summary
- Added `redirectParams` handling in `SignerClient` and `Signer` classes
- Updated types in `SignerClient` and `Signer` for `redirectParams`
- Modified `SignerEndpoints` types to handle `redirectParams`
- Enhanced `AuthParams` type to include `redirectParams` and `orgId` options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->