### PR TITLE
fix(alchemy-signer): set the user during passkey account creation

### DIFF
--- a/packages/alchemy/src/signer/client/index.ts
+++ b/packages/alchemy/src/signer/client/index.ts
@@ -95,17 +95,26 @@ export class AlchemySignerClient {
       return response;
     }
 
+    // Passkey account creation flow
     const { attestation, challenge } = await this.getWebAuthnAttestation(
       params.creationOpts,
       { username: params.username }
     );
 
-    return this.request("/v1/signup", {
+    const result = await this.request("/v1/signup", {
       passkey: {
         challenge: base64UrlEncode(challenge),
         attestation,
       },
     });
+
+    this.user = {
+      orgId: result.orgId,
+      address: result.address!,
+      userId: result.userId!,
+    };
+
+    return result;
   };
 
   public initEmailAuth = async (


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the Passkey account creation flow in the `index.ts` file by adding user information after signup.

### Detailed summary
- Added Passkey account creation flow with attestation and challenge
- Updated signup request to include Passkey challenge and attestation
- Set user information after successful signup

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->