### PR TITLE
fix(alchemy-signer): check if process is defined before reading env vars

### DIFF
--- a/packages/alchemy/src/signer/client/index.ts
+++ b/packages/alchemy/src/signer/client/index.ts
@@ -37,10 +37,11 @@ export type AlchemySignerClientParams = z.input<
 // use this to override the parent org id for suborgs
 // used for whoami passkey requests to figure out the
 // suborg for a user
-const ROOT_ORG_ID =
-  process.env.ROOT_ORG_ID ??
-  process.env.NEXT_PUBLIC_ROOT_ORG_ID ??
-  "24c1acf5-810f-41e0-a503-d5d13fa8e830";
+const _ENV_ROOT_ORG_ID =
+  typeof process !== "undefined"
+    ? process.env.ROOT_ORG_ID ?? process.env.NEXT_PUBLIC_ROOT_ORG_ID
+    : null;
+const ROOT_ORG_ID = _ENV_ROOT_ORG_ID ?? "24c1acf5-810f-41e0-a503-d5d13fa8e830";
 
 /**
  * A lower level client used by the AlchemySigner used to communicate with


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the way the `ROOT_ORG_ID` is determined in the `signer/client/index.ts` file to handle different environments more effectively.

### Detailed summary
- Introduced `_ENV_ROOT_ORG_ID` to handle environment checks
- Updated `ROOT_ORG_ID` assignment to use `_ENV_ROOT_ORG_ID` or default value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->