### PR TITLE
feat: add optional stateOverride parameter to eth_estimateUserOperationGas

### DIFF
--- a/packages/core/src/actions/bundler/estimateUserOperationGas.ts
+++ b/packages/core/src/actions/bundler/estimateUserOperationGas.ts
@@ -1,4 +1,4 @@
-import type { Address, Chain, Client, Transport } from "viem";
+import type { Address, Chain, Client, Transport, StateOverride } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
 import type {
   UserOperationEstimateGasResponse,
@@ -12,10 +12,11 @@ export const estimateUserOperationGas = async <
   args: {
     request: UserOperationRequest;
     entryPoint: Address;
+    stateOverride?: StateOverride;
   }
 ): Promise<UserOperationEstimateGasResponse> => {
   return client.request({
     method: "eth_estimateUserOperationGas",
-    params: [args.request, args.entryPoint],
+    params: [args.request, args.entryPoint, args.stateOverride],
   });
 };

--- a/packages/core/src/client/decorators/bundlerClient.ts
+++ b/packages/core/src/client/decorators/bundlerClient.ts
@@ -55,6 +55,7 @@ export type BundlerActions = {
    *
    * @param request - the {@link UserOperationRequest} to estimate gas for
    * @param entryPoint - the entry point address the op will be sent to
+   * @params stateOverride - the state override to use for the estimation
    * @returns the gas estimates for the given response (see: {@link UserOperationEstimateGasResponse})
    */
   estimateUserOperationGas(

--- a/packages/core/src/client/decorators/bundlerClient.ts
+++ b/packages/core/src/client/decorators/bundlerClient.ts
@@ -4,6 +4,7 @@ import type {
   Client,
   Hash,
   PublicRpcSchema,
+  StateOverride,
   Transport,
 } from "viem";
 import { estimateUserOperationGas } from "../../actions/bundler/estimateUserOperationGas.js";
@@ -27,7 +28,7 @@ export type BundlerRpcSchema = [
   },
   {
     Method: "eth_estimateUserOperationGas";
-    Parameters: [UserOperationRequest, Address];
+    Parameters: [UserOperationRequest, Address, StateOverride?];
     ReturnType: UserOperationEstimateGasResponse;
   },
   {
@@ -58,7 +59,8 @@ export type BundlerActions = {
    */
   estimateUserOperationGas(
     request: UserOperationRequest,
-    entryPoint: Address
+    entryPoint: Address,
+    stateOverride?: StateOverride
   ): Promise<UserOperationEstimateGasResponse>;
 
   /**
@@ -108,8 +110,8 @@ export const bundlerActions: <
 >(
   client: TClient
 ) => BundlerActions = (client) => ({
-  estimateUserOperationGas: async (request, entryPoint) =>
-    estimateUserOperationGas(client, { request, entryPoint }),
+  estimateUserOperationGas: async (request, entryPoint, stateOverride) =>
+    estimateUserOperationGas(client, { request, entryPoint, stateOverride }),
   sendRawUserOperation: async (request, entryPoint) =>
     sendRawUserOperation(client, { request, entryPoint }),
   getUserOperationByHash: async (hash) =>

--- a/packages/core/src/middleware/defaults/gasEstimator.ts
+++ b/packages/core/src/middleware/defaults/gasEstimator.ts
@@ -12,7 +12,8 @@ export const defaultGasEstimator: <C extends MiddlewareClient>(
 
     const estimates = await client.estimateUserOperationGas(
       request,
-      account.getEntryPoint().address
+      account.getEntryPoint().address,
+      overrides?.stateOverride
     );
 
     const callGasLimit = applyUserOpOverrideOrFeeOption(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,9 @@
-import { type Address, type Hash, type TransactionReceipt } from "viem";
+import {
+  type Address,
+  type Hash,
+  type StateOverride,
+  type TransactionReceipt,
+} from "viem";
 import type { z } from "zod";
 import type {
   UserOperationFeeOptionsFieldSchema,
@@ -67,6 +72,7 @@ export type UserOperationOverrides = Partial<{
    * one user operation for your account in a bundle
    */
   nonceKey: bigint;
+  stateOverride: StateOverride;
 }>;
 //#endregion UserOperationOverrides
 

--- a/site/packages/aa-alchemy/smart-account-client/actions/simulateUserOperation.md
+++ b/site/packages/aa-alchemy/smart-account-client/actions/simulateUserOperation.md
@@ -74,4 +74,4 @@ const uo = await smartAccountClient.sendUserOperation({ uo: uoStruct });
 
 ### `overrides?:` [`UserOperationOverrides`](/resources/types#UserOperationOverrides)
 
-Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit` or `paymasterAndData` on the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit` or `paymasterAndData` on the user operation request. You can also specify a `stateOverride` to be passed into `eth_estimateUserOperationGas` during fee estimation.

--- a/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
+++ b/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
@@ -111,7 +111,7 @@ A Promise containing the _unsigned_ UO struct resulting from the middleware pipe
 
 - `overrides?:` [`UserOperationOverrides`](/resources/types#UserOperationOverrides)
 
-Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey` for the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey` for the user operation request. You can also specify a `stateOverride` to be passed into `eth_estimateUserOperationGas` during fee estimation.
 
 - `account?: TAccount extends SmartContractAccount | undefined`
 

--- a/site/packages/aa-core/smart-account-client/types/userOperationOverrides.md
+++ b/site/packages/aa-core/smart-account-client/types/userOperationOverrides.md
@@ -16,7 +16,7 @@ next:
 
 # UserOperationOverrides
 
-Contains override values to be applied on the user operation request to be constructed or sent. Available fields include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey`.
+Contains override values to be applied on the user operation request to be constructed or sent. Available fields include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey`. You can also specify a `stateOverride` to be passed into `eth_estimateUserOperationGas` during fee estimation.
 
 These override values are available from each middleware of the `SmartAccountClient`. For example, the default middlewares such as `gasEstimator` or `feeEstimator` apply the override values to the estimated values if the override values are provided.
 

--- a/site/resources/types.md
+++ b/site/resources/types.md
@@ -142,7 +142,7 @@ An interface that defines the structure for the response received from the RPC m
 
 ## `UserOperationOverrides`
 
-Partial structure for overriding default values in a `UserOperationStruct`, such as gas limits and fees. Available fields include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey`. These override values are available from each [`ClientMiddleware`](#clientmiddleware) of the `SmartAccountClient`. Check out [`UserOperationOverrides`](/packages/aa-core/smart-account-client/types/userOperationOverrides) page to learn more.
+Partial structure for overriding default values in a `UserOperationStruct`, such as gas limits and fees. Available fields include `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey`. You can also specify a `stateOverride` to be passed into `eth_estimateUserOperationGas` during fee estimation. These override values are available from each [`ClientMiddleware`](#clientmiddleware) of the `SmartAccountClient`. Check out [`UserOperationOverrides`](/packages/aa-core/smart-account-client/types/userOperationOverrides) page to learn more.
 
 ::: details UserOperationOverrides
 <<< @/../packages/core/src/types.ts#UserOperationOverrides

--- a/site/snippets/aa-core/send-tx-param.md
+++ b/site/snippets/aa-core/send-tx-param.md
@@ -18,7 +18,7 @@ Same as `viem` [`TransactionRequest`](https://viem.sh/docs/glossary/types#transa
 
 - `overrides?:` [`UserOperationOverrides`](/resources/types#UserOperationOverrides)
 
-Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey` for the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey` for the user operation request. You can also specify a `stateOverride` to be passed into `eth_estimateUserOperationGas` during fee estimation.
 
 - `account?: TAccount extends SmartContractAccount | undefined`
 

--- a/site/snippets/aa-core/send-uo-param.md
+++ b/site/snippets/aa-core/send-uo-param.md
@@ -19,7 +19,7 @@ export type SendUserOperationParameters<
 
 - `overrides?:` [`UserOperationOverrides`](/resources/types#UserOperationOverrides)
 
-Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey` for the user operation request
+Optional parameter where you can specify override values for `maxFeePerGas`, `maxPriorityFeePerGas`, `callGasLimit`, `preVerificationGas`, `verificationGasLimit`, `paymasterAndData`, or `nonceKey` for the user operation request. You can also specify a `stateOverride` to be passed into `eth_estimateUserOperationGas` during fee estimation.
 
 - `account?: TAccount extends SmartContractAccount | undefined`
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `stateOverride` parameter to `UserOperationOverrides` for gas estimation in `estimateUserOperationGas`.

### Detailed summary
- Added `stateOverride` parameter to `UserOperationOverrides`
- Updated multiple files to include `stateOverride` in gas estimation
- Clarified usage of `stateOverride` in documentation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->