### PR TITLE
feat(entrypoint-0.7): base - all changes in regards to the Entrypoint v6 & v7 support

### DIFF
--- a/packages/accounts/plugingen/phases/plugin-actions/index.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/index.ts
@@ -54,8 +54,8 @@ export const PluginActionsGenPhase: Phase = async (input) => {
                   account = client.account
               }`
           : dedent`{
-                  context,
                   overrides,
+                  context,
                   account = client.account
               }`;
       const argsEncodeString = n.inputs.length > 0 ? "args," : "";

--- a/packages/accounts/plugingen/phases/plugin-actions/index.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/index.ts
@@ -21,15 +21,19 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     isType: true,
   });
   addImport("@alchemy/aa-core", {
-    name: "UserOperationOverrides",
-    isType: true,
-  });
-  addImport("@alchemy/aa-core", {
     name: "GetAccountParameter",
     isType: true,
   });
   addImport("@alchemy/aa-core", {
     name: "SendUserOperationResult",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
+    name: "GetEntryPointFromAccount",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
+    name: "UserOperationOverridesParameter",
     isType: true,
   });
   addImport("@alchemy/aa-core", { name: "AccountNotFoundError" });
@@ -43,15 +47,15 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     .map((n) => {
       const argsParamString =
         n.inputs.length > 0
-          ? dedent`{ 
-                  args, 
-                  overrides, 
+          ? dedent`{
+                  args,
+                  overrides,
                   context,
                   account = client.account
               }`
-          : dedent`{ 
-                  overrides, 
-                  account = client.account 
+          : dedent`{
+                  overrides,
+                  account = client.account
               }`;
       const argsEncodeString = n.inputs.length > 0 ? "args," : "";
 
@@ -60,33 +64,38 @@ export const PluginActionsGenPhase: Phase = async (input) => {
             n.name
           )}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${
         n.name
-      }">, "args"> & { 
-        overrides?: UserOperationOverrides;
-      } & GetAccountParameter<TAccount> & GetContextParameter<TContext>) => Promise<SendUserOperationResult>
-        `);
+      }">, "args"> & UserOperationOverridesParameter<TEntryPointVersion> &
+        GetAccountParameter<TAccount> & GetContextParameter<TContext>) =>
+          Promise<SendUserOperationResult<TEntryPointVersion>>
+      `);
       const methodName = camelCase(n.name);
       return dedent`
               ${methodName}(${argsParamString}) {
                 if (!account) {
                   throw new AccountNotFoundError();
-                } 
+                }
                 if (!isSmartAccountClient(client)) {
                   throw new IncompatibleClientError("SmartAccountClient", "${methodName}", client);
                 }
-  
+
                 const uo = encodeFunctionData({
                   abi: ${executionAbiConst},
                   functionName: "${n.name}",
                   ${argsEncodeString}
                 });
-  
+
                 return client.sendUserOperation({ uo, overrides, account, context });
               }
             `;
     });
 
   addType(
-    "ExecutionActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined, TContext extends Record<string, any> | undefined = Record<string, any> | undefined>",
+    `ExecutionActions<
+      TAccount extends SmartContractAccount | undefined =
+        SmartContractAccount | undefined,
+      TContext extends Record<string, any> | undefined = Record<string, any> | undefined,
+      TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+    >`,
     dedent`{
         ${providerFunctionDefs.join(";\n\n")}
       }`
@@ -101,13 +110,18 @@ export const PluginActionsGenPhase: Phase = async (input) => {
   });
 
   addType(
-    `${contract.name}Actions<TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
-    | undefined, TContext extends Record<string, any> | undefined = Record<string, any> | undefined>`,
+    `${contract.name}Actions<
+      TAccount extends SmartContractAccount | undefined =
+          | SmartContractAccount
+          | undefined,
+      TContext extends Record<string, any> | undefined =
+          | Record<string, any>
+          | undefined
+    >`,
     dedent`
-  ExecutionActions<TAccount, TContext> & ManagementActions<TAccount, TContext> & ReadAndEncodeActions${
-    hasReadMethods ? "<TAccount>" : ""
-  }
+      ExecutionActions<TAccount, TContext> & ManagementActions<TAccount, TContext> & ReadAndEncodeActions${
+        hasReadMethods ? "<TAccount>" : ""
+      }
   `,
     true
   );

--- a/packages/accounts/plugingen/phases/plugin-actions/index.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/index.ts
@@ -54,6 +54,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
                   account = client.account
               }`
           : dedent`{
+                  context,
                   overrides,
                   account = client.account
               }`;

--- a/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
@@ -24,12 +24,16 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
       true
     );
     addType(
-      "ManagementActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined, TContext extends Record<string, any> | undefined = Record<string,any> | undefined>",
+      `ManagementActions<
+        TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined,
+        TContext extends Record<string, any> | undefined = Record<string,any> | undefined,
+        TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+      >`,
       dedent`{
-      install${contract.name}: (args: { 
-        overrides?: UserOperationOverrides;
-      } & Install${contract.name}Params & GetAccountParameter<TAccount> & GetContextParameter<TContext>) => Promise<SendUserOperationResult>
-    }`
+        install${contract.name}: (args: UserOperationOverridesParameter<TEntryPointVersion> &
+          Install${contract.name}Params & GetAccountParameter<TAccount> & GetContextParameter<TContext>) =>
+            Promise<SendUserOperationResult<TEntryPointVersion>>
+      }`
     );
 
     const dependencies = (config.installConfig.dependencies ?? []).map(
@@ -122,6 +126,10 @@ const addImports = (
   });
   addImport("@alchemy/aa-core", {
     name: "GetAccountParameter",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
+    name: "GetEntryPointFromAccount",
     isType: true,
   });
   // TODO: after plugingen becomes its own cli tool package, this should be changed to

--- a/packages/accounts/plugingen/phases/plugin-actions/read-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/read-actions.ts
@@ -73,7 +73,10 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
   });
 
   const typeName = input.hasReadMethods
-    ? "ReadAndEncodeActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>"
+    ? `ReadAndEncodeActions<
+        TAccount extends SmartContractAccount | undefined =
+          SmartContractAccount | undefined,
+      >`
     : "ReadAndEncodeActions";
 
   addType(

--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -58,11 +58,10 @@ export type CreateLightAccountParams<
     Chain,
     TEntryPointVersion
   >,
-  "transport" | "chain"
+  "transport" | "chain" | "accountAddress"
 > & {
   signer: TSigner;
   salt?: bigint;
-  accountAddress?: Address;
   factoryAddress?: Address;
   initCode?: Hex;
   version?: LightAccountVersion;

--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -2,10 +2,9 @@ import {
   FailedToGetStorageSlotError,
   createBundlerClient,
   getAccountAddress,
-  getVersion060EntryPoint,
+  getEntryPoint,
   toSmartContractAccount,
-  type Address,
-  type Hex,
+  type EntryPointParameter,
   type SmartAccountSigner,
   type SmartContractAccountWithSigner,
   type ToSmartContractAccountParams,
@@ -18,6 +17,9 @@ import {
   hashMessage,
   hashTypedData,
   trim,
+  type Address,
+  type Chain,
+  type Hex,
   type SignTypedDataParameters,
   type Transport,
 } from "viem";
@@ -32,8 +34,13 @@ import {
 } from "./utils.js";
 
 export type LightAccount<
-  TSigner extends SmartAccountSigner = SmartAccountSigner
-> = SmartContractAccountWithSigner<"LightAccount", TSigner> & {
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends "0.6.0" = "0.6.0"
+> = SmartContractAccountWithSigner<
+  "LightAccount",
+  TSigner,
+  TEntryPointVersion
+> & {
   getLightAccountVersion: () => Promise<LightAccountVersion>;
   encodeTransferOwnership: (newOwner: Address) => Hex;
   getOwnerAddress: () => Promise<Address>;
@@ -42,25 +49,33 @@ export type LightAccount<
 //#region CreateLightAccountParams
 export type CreateLightAccountParams<
   TTransport extends Transport = Transport,
-  TSigner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends "0.6.0" = "0.6.0"
 > = Pick<
-  ToSmartContractAccountParams<"LightAccount", TTransport>,
-  "transport" | "chain" | "entryPoint" | "accountAddress"
+  ToSmartContractAccountParams<
+    "LightAccount",
+    TTransport,
+    Chain,
+    TEntryPointVersion
+  >,
+  "transport" | "chain"
 > & {
   signer: TSigner;
   salt?: bigint;
+  accountAddress?: Address;
   factoryAddress?: Address;
   initCode?: Hex;
   version?: LightAccountVersion;
-};
+} & EntryPointParameter<TEntryPointVersion, Chain>;
 //#endregion CreateLightAccountParams
 
 export async function createLightAccount<
   TTransport extends Transport = Transport,
-  TSigner extends SmartAccountSigner = SmartAccountSigner
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends "0.6.0" = "0.6.0"
 >(
-  config: CreateLightAccountParams<TTransport, TSigner>
-): Promise<LightAccount<TSigner>>;
+  config: CreateLightAccountParams<TTransport, TSigner, TEntryPointVersion>
+): Promise<LightAccount<TSigner, TEntryPointVersion>>;
 
 export async function createLightAccount({
   transport,
@@ -68,7 +83,7 @@ export async function createLightAccount({
   signer,
   initCode,
   version = "v1.1.0",
-  entryPoint = getVersion060EntryPoint(chain),
+  entryPoint = getEntryPoint(chain),
   accountAddress,
   factoryAddress = getDefaultLightAccountFactoryAddress(chain, version),
   salt: salt_ = 0n,
@@ -99,7 +114,7 @@ export async function createLightAccount({
 
   const address = await getAccountAddress({
     client,
-    entryPointAddress: entryPoint.address,
+    entryPoint,
     accountAddress,
     getAccountInitCode,
   });
@@ -197,7 +212,7 @@ export async function createLightAccount({
       return signer.signMessage({ raw: uoHash });
     },
     async signMessage({ message }) {
-      const version = await getLightAccountVersion(account);
+      const version = await getLightAccountVersion(account!);
       switch (version) {
         case "v1.0.1":
           return signer.signMessage(message);
@@ -210,7 +225,7 @@ export async function createLightAccount({
       }
     },
     async signTypedData(params) {
-      const version = await getLightAccountVersion(account);
+      const version = await getLightAccountVersion(account!);
       switch (version) {
         case "v1.0.1": {
           return signer.signTypedData(

--- a/packages/accounts/src/light-account/decorator.ts
+++ b/packages/accounts/src/light-account/decorator.ts
@@ -1,11 +1,10 @@
-import type {
-  GetAccountParameter,
-  Hex,
-  SmartAccountSigner,
-} from "@alchemy/aa-core";
-import type { Chain, Client, Transport } from "viem";
+import type { SmartAccountSigner } from "@alchemy/aa-core";
+import type { Chain, Client, Hex, Transport } from "viem";
 import type { LightAccount } from "./account";
-import { transferOwnership } from "./actions/transferOwnership.js";
+import {
+  transferOwnership,
+  type TransferLightAccountOwnershipParams,
+} from "./actions/transferOwnership.js";
 
 export type LightAccountClientActions<
   TSigner extends SmartAccountSigner = SmartAccountSigner,
@@ -14,10 +13,7 @@ export type LightAccountClientActions<
     | undefined
 > = {
   transferOwnership: (
-    args: {
-      newOwner: TSigner;
-      waitForTxn?: boolean;
-    } & GetAccountParameter<TAccount, LightAccount>
+    args: TransferLightAccountOwnershipParams<TSigner, TAccount>
   ) => Promise<Hex>;
 };
 

--- a/packages/accounts/src/light-account/utils.ts
+++ b/packages/accounts/src/light-account/utils.ts
@@ -83,7 +83,7 @@ export const getDefaultLightAccountFactoryAddress = (
       return LightAccountVersions[version].factoryAddress;
   }
 
-  throw new DefaultFactoryNotDefinedError("LightAccount", chain);
+  throw new DefaultFactoryNotDefinedError("LightAccount", chain, "0.6.0");
 };
 
 export const LightAccountUnsupported1271Impls = [

--- a/packages/accounts/src/msca/account/multisigAccount.ts
+++ b/packages/accounts/src/msca/account/multisigAccount.ts
@@ -1,14 +1,14 @@
 import {
   createBundlerClient,
   getAccountAddress,
-  getVersion060EntryPoint,
+  getEntryPoint,
   toSmartContractAccount,
   type Address,
-  type EntryPointDef,
+  type EntryPointParameter,
   type SmartAccountSigner,
   type SmartContractAccount,
   type SmartContractAccountWithSigner,
-  type UserOperationRequest,
+  type ToSmartContractAccountParams,
 } from "@alchemy/aa-core";
 import {
   concatHex,
@@ -33,19 +33,25 @@ export type MultisigModularAccount<
 
 export type CreateMultisigModularAccountParams<
   TTransport extends Transport = Transport,
-  TSigner extends SmartAccountSigner = SmartAccountSigner
-> = {
-  transport: TTransport;
-  chain: Chain;
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends "0.6.0" = "0.6.0"
+> = Pick<
+  ToSmartContractAccountParams<
+    "MultisigModularAccount",
+    TTransport,
+    Chain,
+    TEntryPointVersion
+  >,
+  "transport" | "chain"
+> & {
   signer: TSigner;
   salt?: bigint;
   factoryAddress?: Address;
+  initCode?: Hex;
   threshold: bigint;
   owners?: Address[];
-  entryPoint?: EntryPointDef<UserOperationRequest>;
   accountAddress?: Address;
-  initCode?: Hex;
-};
+} & EntryPointParameter<TEntryPointVersion, Chain>;
 
 export async function createMultisigModularAccount<
   TTransport extends Transport = Transport,
@@ -60,7 +66,7 @@ export async function createMultisigModularAccount({
   signer,
   accountAddress,
   initCode,
-  entryPoint = getVersion060EntryPoint(chain),
+  entryPoint = getEntryPoint(chain, { version: "0.6.0" }),
   factoryAddress = getDefaultMultisigModularAccountFactoryAddress(chain),
   owners = [],
   salt = 0n,
@@ -100,7 +106,7 @@ export async function createMultisigModularAccount({
 
   accountAddress = await getAccountAddress({
     client,
-    entryPointAddress: entryPoint.address,
+    entryPoint,
     accountAddress: accountAddress,
     getAccountInitCode,
   });

--- a/packages/accounts/src/msca/plugin-manager/decorator.ts
+++ b/packages/accounts/src/msca/plugin-manager/decorator.ts
@@ -1,4 +1,5 @@
 import type {
+  GetEntryPointFromAccount,
   SendUserOperationResult,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -15,14 +16,15 @@ export { type UninstallPluginParams } from "./uninstallPlugin.js";
 export type PluginManagerActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   installPlugin: (
     params: InstallPluginParams<TAccount>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   uninstallPlugin: (
     params: UninstallPluginParams<TAccount>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 export const pluginManagerActions: <

--- a/packages/accounts/src/msca/plugin-manager/installPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/installPlugin.ts
@@ -4,9 +4,10 @@ import {
   isSmartAccountClient,
   type GetAccountParameter,
   type GetContextParameter,
+  type GetEntryPointFromAccount,
   type SmartAccountClient,
   type SmartContractAccount,
-  type UserOperationOverrides,
+  type UserOperationOverridesParameter,
 } from "@alchemy/aa-core";
 import {
   encodeFunctionData,
@@ -28,15 +29,15 @@ export type InstallPluginParams<
     | undefined,
   TContext extends Record<string, unknown> | undefined =
     | Record<string, unknown>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   pluginAddress: Address;
   manifestHash?: Hash;
   pluginInitData?: Hash;
   dependencies?: FunctionReference[];
-} & {
-  overrides?: UserOperationOverrides;
-} & GetAccountParameter<TAccount> &
+} & UserOperationOverridesParameter<TEntryPointVersion> &
+  GetAccountParameter<TAccount> &
   GetContextParameter<TContext>;
 
 export async function installPlugin<
@@ -70,7 +71,12 @@ export async function installPlugin<
   }
 
   const callData = await encodeInstallPluginUserOperation(client, params);
-  return client.sendUserOperation({ uo: callData, overrides, account });
+
+  return client.sendUserOperation({
+    uo: callData,
+    overrides,
+    account,
+  });
 }
 
 export async function encodeInstallPluginUserOperation<

--- a/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
@@ -4,8 +4,9 @@ import {
   isSmartAccountClient,
   type GetAccountParameter,
   type GetContextParameter,
+  type GetEntryPointFromAccount,
   type SmartContractAccount,
-  type UserOperationOverrides,
+  type UserOperationOverridesParameter,
 } from "@alchemy/aa-core";
 import {
   encodeFunctionData,
@@ -23,12 +24,14 @@ export type UninstallPluginParams<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   pluginAddress: Address;
   config?: Hash;
   pluginUninstallData?: Hash;
-} & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount> &
+} & UserOperationOverridesParameter<TEntryPointVersion> &
+  GetAccountParameter<TAccount> &
   GetContextParameter<TContext>;
 
 export async function uninstallPlugin<
@@ -61,7 +64,12 @@ export async function uninstallPlugin<
   }
 
   const callData = await encodeUninstallPluginUserOperation(params);
-  return client.sendUserOperation({ uo: callData, overrides, account });
+
+  return client.sendUserOperation({
+    uo: callData,
+    overrides: overrides,
+    account,
+  });
 }
 
 export async function encodeUninstallPluginUserOperation(

--- a/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
@@ -18,9 +18,10 @@ import {
   isSmartAccountClient,
   IncompatibleClientError,
   type SmartContractAccount,
-  type UserOperationOverrides,
   type GetAccountParameter,
   type SendUserOperationResult,
+  type GetEntryPointFromAccount,
+  type UserOperationOverridesParameter,
   type GetContextParameter,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
@@ -37,7 +38,8 @@ type ExecutionActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   updateOwners: (
     args: Pick<
@@ -46,11 +48,11 @@ type ExecutionActions<
         "updateOwners"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type InstallArgs = [{ type: "address[]" }];
@@ -67,15 +69,15 @@ type ManagementActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   installMultiOwnerPlugin: (
-    args: {
-      overrides?: UserOperationOverrides;
-    } & InstallMultiOwnerPluginParams &
+    args: UserOperationOverridesParameter<TEntryPointVersion> &
+      InstallMultiOwnerPluginParams &
       GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type ReadAndEncodeActions<

--- a/packages/accounts/src/msca/plugins/multisig/actions/proposeUserOperation.ts
+++ b/packages/accounts/src/msca/plugins/multisig/actions/proposeUserOperation.ts
@@ -4,19 +4,22 @@ import {
   isSmartAccountClient,
   isSmartAccountWithSigner,
   SmartAccountWithSignerRequiredError,
+  type GetEntryPointFromAccount,
   type SendUserOperationParameters,
   type SmartContractAccount,
+  type UserOperationOverrides,
 } from "@alchemy/aa-core";
 import { type Chain, type Client, type Transport } from "viem";
-import { type ProposeUserOperationResult, type Signature } from "../types.js";
 import { combineSignatures, getSignerType } from "../index.js";
+import { type ProposeUserOperationResult, type Signature } from "../types.js";
 
 export async function proposeUserOperation<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
   {
@@ -31,7 +34,7 @@ export async function proposeUserOperation<
     maxPriorityFeePerGas: { multiplier: 2 },
     preVerificationGas: { multiplier: 1000 },
     ...overrides_,
-  };
+  } as UserOperationOverrides<TEntryPointVersion>;
 
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/accounts/src/msca/plugins/multisig/extension.ts
+++ b/packages/accounts/src/msca/plugins/multisig/extension.ts
@@ -42,7 +42,7 @@ export type MultisigPluginActions<
 
   proposeUserOperation: (
     params: SendUserOperationParameters<TAccount, undefined>
-  ) => Promise<ProposeUserOperationResult>;
+  ) => Promise<ProposeUserOperationResult<TAccount>>;
 
   signMultisigUserOperation: (
     params: SignMultisigUserOperationParams<TAccount>

--- a/packages/accounts/src/msca/plugins/multisig/plugin.ts
+++ b/packages/accounts/src/msca/plugins/multisig/plugin.ts
@@ -18,9 +18,10 @@ import {
   isSmartAccountClient,
   IncompatibleClientError,
   type SmartContractAccount,
-  type UserOperationOverrides,
   type GetAccountParameter,
   type SendUserOperationResult,
+  type GetEntryPointFromAccount,
+  type UserOperationOverridesParameter,
   type GetContextParameter,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
@@ -37,7 +38,8 @@ type ExecutionActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   updateOwnership: (
     args: Pick<
@@ -46,11 +48,11 @@ type ExecutionActions<
         "updateOwnership"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type InstallArgs = [{ type: "address[]" }, { type: "uint256" }];
@@ -67,15 +69,15 @@ type ManagementActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   installMultisigPlugin: (
-    args: {
-      overrides?: UserOperationOverrides;
-    } & InstallMultisigPluginParams &
+    args: UserOperationOverridesParameter<TEntryPointVersion> &
+      InstallMultisigPluginParams &
       GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type ReadAndEncodeActions<

--- a/packages/accounts/src/msca/plugins/multisig/types.ts
+++ b/packages/accounts/src/msca/plugins/multisig/types.ts
@@ -1,9 +1,10 @@
 import type {
   GetAccountParameter,
-  Hex,
+  GetEntryPointFromAccount,
   SmartContractAccount,
   UserOperationRequest,
 } from "@alchemy/aa-core";
+import type { Hex } from "viem";
 import type { GetPluginAddressParameter } from "../types";
 
 export type SignerType = "EOA" | "CONTRACT";
@@ -26,15 +27,21 @@ export type SignMultisigUserOperationResult = {
 export type SignMultisigUserOperationParams<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
-  userOperationRequest: UserOperationRequest;
+  userOperationRequest: UserOperationRequest<TEntryPointVersion>;
   signatures: Signature[];
 } & GetAccountParameter<TAccount> &
   GetPluginAddressParameter;
 
-export type ProposeUserOperationResult = {
-  request: UserOperationRequest;
+export type ProposeUserOperationResult<
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+> = {
+  request: UserOperationRequest<TEntryPointVersion>;
   aggregatedSignature: Hex;
   signatureObj: Signature;
 };

--- a/packages/accounts/src/msca/plugins/multisig/utils/splitAggregatedSignature.ts
+++ b/packages/accounts/src/msca/plugins/multisig/utils/splitAggregatedSignature.ts
@@ -1,17 +1,23 @@
 import {
+  takeBytes,
+  type GetEntryPointFromAccount,
   type SmartContractAccount,
   type UserOperationRequest,
-  takeBytes,
 } from "@alchemy/aa-core";
-import { type Hex, hashMessage, recoverAddress, fromHex } from "viem";
-import type { Signature } from "../types";
+import { fromHex, hashMessage, recoverAddress, type Hex } from "viem";
 import { InvalidAggregatedSignatureError } from "../../../errors.js";
+import type { Signature } from "../types";
 
-export type SplitAggregateSignatureParams = {
+export type SplitAggregateSignatureParams<
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+> = {
   aggregatedSignature: Hex;
   threshold: number;
   account: SmartContractAccount;
-  request: UserOperationRequest;
+  request: UserOperationRequest<TEntryPointVersion>;
 };
 /**
  * Takes an aggregated signature and threshold and splits it into its components
@@ -19,12 +25,16 @@ export type SplitAggregateSignatureParams = {
  * @param aggregatedSignature - aggregated signature containing PVG || maxFeePerGas || maxPriorityFeePerGas || N-1 Signatures || [0, N-1] Contract Data
  * @param threshold - the account's required threshold of signatures
  */
-export const splitAggregatedSignature = async ({
+export const splitAggregatedSignature = async <
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined
+>({
   aggregatedSignature,
   threshold,
   account,
   request,
-}: SplitAggregateSignatureParams): Promise<{
+}: SplitAggregateSignatureParams<TAccount>): Promise<{
   upperLimitPvg: Hex;
   upperLimitMaxFeePerGas: Hex;
   upperLimitMaxPriorityFeePerGas: Hex;

--- a/packages/accounts/src/msca/plugins/session-key/plugin.ts
+++ b/packages/accounts/src/msca/plugins/session-key/plugin.ts
@@ -18,9 +18,10 @@ import {
   isSmartAccountClient,
   IncompatibleClientError,
   type SmartContractAccount,
-  type UserOperationOverrides,
   type GetAccountParameter,
   type SendUserOperationResult,
+  type GetEntryPointFromAccount,
+  type UserOperationOverridesParameter,
   type GetContextParameter,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
@@ -38,7 +39,8 @@ type ExecutionActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   executeWithSessionKey: (
     args: Pick<
@@ -47,11 +49,11 @@ type ExecutionActions<
         "executeWithSessionKey"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   addSessionKey: (
     args: Pick<
@@ -60,11 +62,11 @@ type ExecutionActions<
         "addSessionKey"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   removeSessionKey: (
     args: Pick<
@@ -73,11 +75,11 @@ type ExecutionActions<
         "removeSessionKey"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   rotateSessionKey: (
     args: Pick<
@@ -86,11 +88,11 @@ type ExecutionActions<
         "rotateSessionKey"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   updateKeyPermissions: (
     args: Pick<
@@ -99,11 +101,11 @@ type ExecutionActions<
         "updateKeyPermissions"
       >,
       "args"
-    > & {
-      overrides?: UserOperationOverrides;
-    } & GetAccountParameter<TAccount> &
+    > &
+      UserOperationOverridesParameter<TEntryPointVersion> &
+      GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type InstallArgs = [
@@ -124,15 +126,15 @@ type ManagementActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   installSessionKeyPlugin: (
-    args: {
-      overrides?: UserOperationOverrides;
-    } & InstallSessionKeyPluginParams &
+    args: UserOperationOverridesParameter<TEntryPointVersion> &
+      InstallSessionKeyPluginParams &
       GetAccountParameter<TAccount> &
       GetContextParameter<TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type ReadAndEncodeActions = {

--- a/packages/accounts/src/msca/plugins/session-key/utils.ts
+++ b/packages/accounts/src/msca/plugins/session-key/utils.ts
@@ -2,8 +2,8 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "@alchemy/aa-core";
-import { AccountNotFoundError, type Address } from "@alchemy/aa-core";
-import type { Chain, Client, Transport } from "viem";
+import { AccountNotFoundError } from "@alchemy/aa-core";
+import type { Address, Chain, Client, Transport } from "viem";
 import { SessionKeyPlugin } from "./plugin.js";
 
 // find predecessors for each keys and returned the struct `ISessionKeyPlugin.SessionKeyToRemove[]`

--- a/packages/accounts/src/msca/utils.ts
+++ b/packages/accounts/src/msca/utils.ts
@@ -55,7 +55,11 @@ export const getDefaultMultisigModularAccountFactoryAddress = (
     case sepolia.id:
       return "0x3D94D6713B76FBA07283502CfbeA405b44c69865";
   }
-  throw new DefaultFactoryNotDefinedError("MultisigModularAccount", chain);
+  throw new DefaultFactoryNotDefinedError(
+    "MultisigModularAccount",
+    chain,
+    "0.6.0"
+  );
 };
 
 /**
@@ -86,7 +90,11 @@ export const getDefaultMultiOwnerModularAccountFactoryAddress = (
     case baseGoerli.id:
       return "0x000000e92D78D90000007F0082006FDA09BD5f11";
   }
-  throw new DefaultFactoryNotDefinedError("MultiOwnerModularAccount", chain);
+  throw new DefaultFactoryNotDefinedError(
+    "MultiOwnerModularAccount",
+    chain,
+    "0.6.0"
+  );
 };
 
 export async function getMSCAUpgradeToData<
@@ -98,10 +106,7 @@ export async function getMSCAUpgradeToData<
     | undefined = SmartContractAccountWithSigner<string, TSigner> | undefined
 >(
   client: SmartAccountClient<TTransport, TChain, TAccount>,
-  {
-    multiOwnerPluginAddress,
-    account: account_ = client.account,
-  }: {
+  args: {
     multiOwnerPluginAddress?: Address;
   } & GetAccountParameter<TAccount>
 ): Promise<
@@ -109,6 +114,8 @@ export async function getMSCAUpgradeToData<
     createMAAccount: () => Promise<MultiOwnerModularAccount<TSigner>>;
   }
 > {
+  const { account: account_ = client.account, multiOwnerPluginAddress } = args;
+
   if (!account_) {
     throw new AccountNotFoundError();
   }
@@ -139,14 +146,17 @@ export async function getMSCAUpgradeToData<
 
 export async function getMAInitializationData<
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain | undefined
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends SmartContractAccountWithSigner | undefined =
+    | SmartContractAccountWithSigner
+    | undefined
 >({
   client,
   multiOwnerPluginAddress,
   signerAddress,
 }: {
   multiOwnerPluginAddress?: Address;
-  client: SmartAccountClient<TTransport, TChain>;
+  client: SmartAccountClient<TTransport, TChain, TAccount>;
   signerAddress: Address | Address[];
 }): Promise<UpgradeToData> {
   if (!client.chain) {

--- a/packages/alchemy/e2e-tests/light-account.e2e.test.ts
+++ b/packages/alchemy/e2e-tests/light-account.e2e.test.ts
@@ -20,7 +20,7 @@ const simulateUoChangesSpy = vi.spyOn(
 const chain = sepolia;
 const network = Network.ETH_SEPOLIA;
 
-describe("Light Account Tests", () => {
+describe("Light Account Client Tests", () => {
   const signer = LocalAccountSigner.mnemonicToAccountSigner(
     LIGHT_ACCOUNT_OWNER_MNEMONIC
   );

--- a/packages/alchemy/src/actions/simulateUserOperationChanges.ts
+++ b/packages/alchemy/src/actions/simulateUserOperationChanges.ts
@@ -2,6 +2,7 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   deepHexlify,
+  type GetEntryPointFromAccount,
   type SendUserOperationParameters,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -14,13 +15,19 @@ export const simulateUserOperationChanges: <
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
-  client: Client<Transport, TChain, TAccount, AlchemyRpcSchema>,
+  client: Client<
+    Transport,
+    TChain,
+    TAccount,
+    AlchemyRpcSchema<TEntryPointVersion>
+  >,
   args: SendUserOperationParameters<TAccount>
 ) => Promise<SimulateUserOperationAssetChangesResponse> = async (
   client,
-  { account = client.account, ...params }
+  { account = client.account, overrides, ...params }
 ) => {
   if (!account) {
     throw new AccountNotFoundError();
@@ -38,6 +45,7 @@ export const simulateUserOperationChanges: <
     await client.buildUserOperation({
       ...params,
       account,
+      overrides,
     })
   );
 

--- a/packages/alchemy/src/actions/simulateUserOperationChanges.ts
+++ b/packages/alchemy/src/actions/simulateUserOperationChanges.ts
@@ -2,7 +2,6 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   deepHexlify,
-  type GetEntryPointFromAccount,
   type SendUserOperationParameters,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -15,15 +14,9 @@ export const simulateUserOperationChanges: <
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
-    | undefined,
-  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+    | undefined
 >(
-  client: Client<
-    Transport,
-    TChain,
-    TAccount,
-    AlchemyRpcSchema<TEntryPointVersion>
-  >,
+  client: Client<Transport, TChain, TAccount, AlchemyRpcSchema>,
   args: SendUserOperationParameters<TAccount>
 ) => Promise<SimulateUserOperationAssetChangesResponse> = async (
   client,

--- a/packages/alchemy/src/actions/types.ts
+++ b/packages/alchemy/src/actions/types.ts
@@ -1,4 +1,4 @@
-import type { UserOperationStruct } from "@alchemy/aa-core";
+import type { EntryPointVersion, UserOperationStruct } from "@alchemy/aa-core";
 import type { Address, Hash } from "viem";
 
 export enum SimulateAssetType {
@@ -18,8 +18,10 @@ export enum SimulateChangeType {
   TRANSFER = "TRANSFER",
 }
 
-export type SimulateUserOperationAssetChangesRequest = [
-  UserOperationStruct,
+export type SimulateUserOperationAssetChangesRequest<
+  TEntryPointVersion extends EntryPointVersion
+> = [
+  UserOperationStruct<TEntryPointVersion>,
   entryPoint: Address,
   blockNumber?: Hash
 ];

--- a/packages/alchemy/src/actions/types.ts
+++ b/packages/alchemy/src/actions/types.ts
@@ -18,10 +18,8 @@ export enum SimulateChangeType {
   TRANSFER = "TRANSFER",
 }
 
-export type SimulateUserOperationAssetChangesRequest<
-  TEntryPointVersion extends EntryPointVersion
-> = [
-  UserOperationStruct<TEntryPointVersion>,
+export type SimulateUserOperationAssetChangesRequest = [
+  UserOperationStruct<EntryPointVersion>,
   entryPoint: Address,
   blockNumber?: Hash
 ];

--- a/packages/alchemy/src/client/lightAccountClient.ts
+++ b/packages/alchemy/src/client/lightAccountClient.ts
@@ -25,17 +25,21 @@ export type AlchemyLightAccountClientConfig<
     "account"
   >;
 
-export const createLightAccountAlchemyClient: <
+export async function createLightAccountAlchemyClient<
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
   params: AlchemyLightAccountClientConfig<TSigner>
-) => Promise<
+): Promise<
   AlchemySmartAccountClient<
     CustomTransport,
     Chain | undefined,
     LightAccount<TSigner>
   >
-> = async (config) => {
+>;
+
+export async function createLightAccountAlchemyClient(
+  config: AlchemyLightAccountClientConfig
+): Promise<AlchemySmartAccountClient> {
   const { chain, opts, ...connectionConfig } =
     AlchemyProviderConfigSchema.parse(config);
 
@@ -55,4 +59,4 @@ export const createLightAccountAlchemyClient: <
     account,
     opts,
   }).extend(lightAccountClientActions);
-};
+}

--- a/packages/alchemy/src/client/smartAccountClient.ts
+++ b/packages/alchemy/src/client/smartAccountClient.ts
@@ -1,4 +1,5 @@
 import {
+  type GetEntryPointFromAccount,
   type Prettify,
   type SmartAccountClient,
   type SmartAccountClientActions,
@@ -57,14 +58,15 @@ export type AlchemySmartAccountClient_Base<
   actions extends Record<string, unknown> = Record<string, unknown>,
   context extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  version extends GetEntryPointFromAccount<account> = GetEntryPointFromAccount<account>
 > = Prettify<
   SmartAccountClient<
     transport,
     chain,
     account,
     actions & BaseAlchemyActions<chain, account, context>,
-    [...SmartAccountClientRpcSchema, ...AlchemyRpcSchema],
+    [...SmartAccountClientRpcSchema, ...AlchemyRpcSchema<version>],
     context
   >
 >;

--- a/packages/alchemy/src/client/smartAccountClient.ts
+++ b/packages/alchemy/src/client/smartAccountClient.ts
@@ -1,5 +1,4 @@
 import {
-  type GetEntryPointFromAccount,
   type Prettify,
   type SmartAccountClient,
   type SmartAccountClientActions,
@@ -58,15 +57,14 @@ export type AlchemySmartAccountClient_Base<
   actions extends Record<string, unknown> = Record<string, unknown>,
   context extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined,
-  version extends GetEntryPointFromAccount<account> = GetEntryPointFromAccount<account>
+    | undefined
 > = Prettify<
   SmartAccountClient<
     transport,
     chain,
     account,
     actions & BaseAlchemyActions<chain, account, context>,
-    [...SmartAccountClientRpcSchema, ...AlchemyRpcSchema<version>],
+    [...SmartAccountClientRpcSchema, ...AlchemyRpcSchema],
     context
   >
 >;

--- a/packages/alchemy/src/client/types.ts
+++ b/packages/alchemy/src/client/types.ts
@@ -24,17 +24,7 @@ export type AlchemyRpcSchema = [
         userOperation: UserOperationRequest<EntryPointVersion>;
       }
     ];
-    ReturnType:
-      | {
-          paymasterAndData: UserOperationRequest<"0.6.0">["paymasterAndData"];
-        }
-      | Pick<
-          UserOperationRequest<"0.7.0">,
-          | "paymaster"
-          | "paymasterData"
-          | "paymasterPostOpGasLimit"
-          | "paymasterVerificationGasLimit"
-        >;
+    ReturnType: RequestPaymasterAndDataResponse<EntryPointVersion>;
   },
   {
     Method: "alchemy_requestGasAndPaymasterAndData";
@@ -47,26 +37,7 @@ export type AlchemyRpcSchema = [
         overrides?: RequestGasAndPaymasterAndDataOverrides<EntryPointVersion>;
       }
     ];
-    ReturnType: Pick<
-      UserOperationRequest<EntryPointVersion>,
-      | "callGasLimit"
-      | "preVerificationGas"
-      | "verificationGasLimit"
-      | "maxFeePerGas"
-      | "maxPriorityFeePerGas"
-    > &
-      (
-        | {
-            paymasterAndData: UserOperationRequest<"0.6.0">["paymasterAndData"];
-          }
-        | Pick<
-            UserOperationRequest<"0.7.0">,
-            | "paymaster"
-            | "paymasterData"
-            | "paymasterPostOpGasLimit"
-            | "paymasterVerificationGasLimit"
-          >
-      );
+    ReturnType: RequestGasAndPaymasterAndDataResponse<EntryPointVersion>;
   },
   {
     Method: "alchemy_simulateUserOperationAssetChanges";

--- a/packages/alchemy/src/client/types.ts
+++ b/packages/alchemy/src/client/types.ts
@@ -1,5 +1,6 @@
 import {
   type BundlerClient,
+  type EntryPointVersion,
   type UserOperationRequest,
 } from "@alchemy/aa-core";
 import type { Address, Hex, HttpTransport } from "viem";
@@ -9,14 +10,14 @@ import type {
 } from "../actions/types";
 import type { RequestGasAndPaymasterAndDataOverrides } from "../middleware/gasManager";
 
-export type AlchemyRpcSchema = [
+export type AlchemyRpcSchema<TEntryPointVersion extends EntryPointVersion> = [
   {
     Method: "alchemy_requestPaymasterAndData";
     Parameters: [
       {
         policyId: string;
         entryPoint: Address;
-        userOperation: UserOperationRequest;
+        userOperation: UserOperationRequest<TEntryPointVersion>;
       }
     ];
     ReturnType: { paymasterAndData: Hex };
@@ -27,9 +28,9 @@ export type AlchemyRpcSchema = [
       {
         policyId: string;
         entryPoint: Address;
-        userOperation: UserOperationRequest;
+        userOperation: UserOperationRequest<TEntryPointVersion>;
         dummySignature: Hex;
-        overrides?: RequestGasAndPaymasterAndDataOverrides;
+        overrides?: RequestGasAndPaymasterAndDataOverrides<TEntryPointVersion>;
       }
     ];
     ReturnType: {
@@ -43,7 +44,7 @@ export type AlchemyRpcSchema = [
   },
   {
     Method: "alchemy_simulateUserOperationAssetChanges";
-    Parameters: SimulateUserOperationAssetChangesRequest;
+    Parameters: SimulateUserOperationAssetChangesRequest<TEntryPointVersion>;
     ReturnType: SimulateUserOperationAssetChangesResponse;
   },
   {
@@ -54,7 +55,7 @@ export type AlchemyRpcSchema = [
 ];
 
 export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
-  request: BundlerClient["request"] &
+  request: BundlerClient<HttpTransport>["request"] &
     {
       request(args: {
         method: "alchemy_requestPaymasterAndData";
@@ -62,7 +63,7 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
           {
             policyId: string;
             entryPoint: Address;
-            userOperation: UserOperationRequest;
+            userOperation: UserOperationRequest<EntryPointVersion>;
           }
         ];
       }): Promise<{ paymasterAndData: Hex }>;
@@ -73,9 +74,9 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
           {
             policyId: string;
             entryPoint: Address;
-            userOperation: UserOperationRequest;
+            userOperation: UserOperationRequest<EntryPointVersion>;
             dummySignature: Hex;
-            overrides?: RequestGasAndPaymasterAndDataOverrides;
+            overrides?: RequestGasAndPaymasterAndDataOverrides<EntryPointVersion>;
           }
         ];
       }): Promise<{
@@ -89,7 +90,7 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
 
       request(args: {
         method: "alchemy_simulateUserOperationAssetChanges";
-        params: SimulateUserOperationAssetChangesRequest;
+        params: SimulateUserOperationAssetChangesRequest<EntryPointVersion>;
       }): Promise<SimulateUserOperationAssetChangesResponse>;
 
       request(args: {

--- a/packages/alchemy/src/client/types.ts
+++ b/packages/alchemy/src/client/types.ts
@@ -8,7 +8,11 @@ import type {
   SimulateUserOperationAssetChangesRequest,
   SimulateUserOperationAssetChangesResponse,
 } from "../actions/types";
-import type { RequestGasAndPaymasterAndDataOverrides } from "../middleware/gasManager";
+import type {
+  RequestGasAndPaymasterAndDataOverrides,
+  RequestGasAndPaymasterAndDataResponse,
+  RequestPaymasterAndDataResponse,
+} from "../middleware/gasManager";
 
 export type AlchemyRpcSchema = [
   {
@@ -88,18 +92,7 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
             userOperation: UserOperationRequest<EntryPointVersion>;
           }
         ];
-      }): Promise<
-        | {
-            paymasterAndData: UserOperationRequest<"0.6.0">["paymasterAndData"];
-          }
-        | Pick<
-            UserOperationRequest<"0.7.0">,
-            | "paymaster"
-            | "paymasterData"
-            | "paymasterPostOpGasLimit"
-            | "paymasterVerificationGasLimit"
-          >
-      >;
+      }): Promise<RequestPaymasterAndDataResponse<EntryPointVersion>>;
 
       request(args: {
         method: "alchemy_requestGasAndPaymasterAndData";
@@ -112,28 +105,7 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
             overrides?: RequestGasAndPaymasterAndDataOverrides<EntryPointVersion>;
           }
         ];
-      }): Promise<
-        Pick<
-          UserOperationRequest<EntryPointVersion>,
-          | "callGasLimit"
-          | "preVerificationGas"
-          | "verificationGasLimit"
-          | "maxFeePerGas"
-          | "maxPriorityFeePerGas"
-        > &
-          (
-            | {
-                paymasterAndData: UserOperationRequest<"0.6.0">["paymasterAndData"];
-              }
-            | Pick<
-                UserOperationRequest<"0.7.0">,
-                | "paymaster"
-                | "paymasterData"
-                | "paymasterPostOpGasLimit"
-                | "paymasterVerificationGasLimit"
-              >
-          )
-      >;
+      }): Promise<RequestGasAndPaymasterAndDataResponse<EntryPointVersion>>;
 
       request(args: {
         method: "alchemy_simulateUserOperationAssetChanges";

--- a/packages/alchemy/src/config/actions/createAccount.ts
+++ b/packages/alchemy/src/config/actions/createAccount.ts
@@ -4,7 +4,6 @@ import {
   type CreateLightAccountParams,
   type CreateMultiOwnerModularAccountParams,
 } from "@alchemy/aa-accounts";
-import { getEntryPoint } from "@alchemy/aa-core";
 import { custom } from "viem";
 import { ClientOnlyPropertyError } from "../errors.js";
 import type {
@@ -65,7 +64,6 @@ export async function createAccount<TAccount extends SupportedAccountTypes>(
           signer,
           transport: (opts) => transport({ ...opts, retryCount: 0 }),
           chain,
-          entryPoint: getEntryPoint(chain),
         });
       default:
         throw new Error("Unsupported account type");

--- a/packages/alchemy/src/config/actions/createAccount.ts
+++ b/packages/alchemy/src/config/actions/createAccount.ts
@@ -4,6 +4,7 @@ import {
   type CreateLightAccountParams,
   type CreateMultiOwnerModularAccountParams,
 } from "@alchemy/aa-accounts";
+import { getEntryPoint } from "@alchemy/aa-core";
 import { custom } from "viem";
 import { ClientOnlyPropertyError } from "../errors.js";
 import type {
@@ -64,6 +65,7 @@ export async function createAccount<TAccount extends SupportedAccountTypes>(
           signer,
           transport: (opts) => transport({ ...opts, retryCount: 0 }),
           chain,
+          entryPoint: getEntryPoint(chain),
         });
       default:
         throw new Error("Unsupported account type");

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -20,6 +20,7 @@ export type * from "./client/smartAccountClient.js";
 export { createAlchemySmartAccountClient } from "./client/smartAccountClient.js";
 export type * from "./client/types.js";
 export { getDefaultUserOperationFeeOptions } from "./defaults.js";
+export { getAlchemyPaymasterAddress } from "./gas-manager.js";
 export { alchemyFeeEstimator } from "./middleware/feeEstimator.js";
 export type * from "./middleware/gasManager.js";
 export { alchemyGasManagerMiddleware } from "./middleware/gasManager.js";
@@ -27,7 +28,6 @@ export { alchemyUserOperationSimulator } from "./middleware/userOperationSimulat
 export type * from "./schema.js";
 export { AlchemyProviderConfigSchema } from "./schema.js";
 export type { AlchemyProviderConfig } from "./type.js";
-export { getAlchemyPaymasterAddress } from "./gas-manager.js";
 
 export type * from "./signer/index.js";
 export {

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -52,6 +52,34 @@ export type RequestGasAndPaymasterAndDataOverrides<
     : {}
 >;
 
+export type RequestPaymasterAndDataResponse<
+  TEntryPointVersion extends EntryPointVersion
+> = TEntryPointVersion extends "0.6.0"
+  ? {
+      paymasterAndData: UserOperationRequest<"0.6.0">["paymasterAndData"];
+    }
+  : TEntryPointVersion extends "0.7.0"
+  ? Pick<
+      UserOperationRequest<"0.7.0">,
+      | "paymaster"
+      | "paymasterData"
+      | "paymasterPostOpGasLimit"
+      | "paymasterVerificationGasLimit"
+    >
+  : {};
+
+export type RequestGasAndPaymasterAndDataResponse<
+  TEntryPointVersion extends EntryPointVersion
+> = Pick<
+  UserOperationRequest<EntryPointVersion>,
+  | "callGasLimit"
+  | "preVerificationGas"
+  | "verificationGasLimit"
+  | "maxFeePerGas"
+  | "maxPriorityFeePerGas"
+> &
+  RequestPaymasterAndDataResponse<TEntryPointVersion>;
+
 export interface AlchemyGasManagerConfig {
   policyId: string;
   gasEstimationOptions?: AlchemyGasEstimationOptions;

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -241,7 +241,7 @@ const requestPaymasterAndData: <C extends ClientWithAlchemyMethods>(
 ) => ClientMiddlewareConfig["paymasterAndData"] = (client, config) => ({
   dummyPaymasterAndData: dummyPaymasterAndData(client, config),
   paymasterAndData: async (struct, { account }) => {
-    const { paymasterAndData } = await client.request({
+    const result = await client.request({
       method: "alchemy_requestPaymasterAndData",
       params: [
         {
@@ -254,7 +254,7 @@ const requestPaymasterAndData: <C extends ClientWithAlchemyMethods>(
 
     return {
       ...struct,
-      paymasterAndData,
+      ...result,
     };
   },
 });

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -23,23 +23,34 @@ import { alchemyFeeEstimator } from "./feeEstimator.js";
 
 export type RequestGasAndPaymasterAndDataOverrides<
   TEntryPointVersion extends EntryPointVersion
-> = Partial<{
-  maxFeePerGas:
-    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
-    | Multiplier;
-  maxPriorityFeePerGas:
-    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
-    | Multiplier;
-  callGasLimit:
-    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
-    | Multiplier;
-  preVerificationGas:
-    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
-    | Multiplier;
-  verificationGasLimit:
-    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
-    | Multiplier;
-}>;
+> = Partial<
+  {
+    maxFeePerGas:
+      | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+      | Multiplier;
+    maxPriorityFeePerGas:
+      | UserOperationRequest<TEntryPointVersion>["maxPriorityFeePerGas"]
+      | Multiplier;
+    callGasLimit:
+      | UserOperationRequest<TEntryPointVersion>["callGasLimit"]
+      | Multiplier;
+    verificationGasLimit:
+      | UserOperationRequest<TEntryPointVersion>["verificationGasLimit"]
+      | Multiplier;
+    preVerificationGas:
+      | UserOperationRequest<TEntryPointVersion>["preVerificationGas"]
+      | Multiplier;
+  } & TEntryPointVersion extends "0.7.0"
+    ? {
+        paymasterVerificationGasLimit:
+          | UserOperationRequest<"0.7.0">["paymasterVerificationGasLimit"]
+          | Multiplier;
+        paymasterPostOpGasLimit:
+          | UserOperationRequest<"0.7.0">["paymasterPostOpGasLimit"]
+          | Multiplier;
+      }
+    : {}
+>;
 
 export interface AlchemyGasManagerConfig {
   policyId: string;

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -2,6 +2,8 @@ import type {
   Address,
   ClientMiddlewareConfig,
   ClientMiddlewareFn,
+  EntryPointVersion,
+  UserOperationOverrides,
 } from "@alchemy/aa-core";
 import {
   deepHexlify,
@@ -10,22 +12,33 @@ import {
   isBigNumberish,
   isMultiplier,
   resolveProperties,
-  type Hex,
   type Multiplier,
   type UserOperationFeeOptions,
   type UserOperationRequest,
 } from "@alchemy/aa-core";
-import { fromHex } from "viem";
+import { fromHex, type Hex } from "viem";
 import type { ClientWithAlchemyMethods } from "../client/types";
 import { getAlchemyPaymasterAddress } from "../gas-manager.js";
 import { alchemyFeeEstimator } from "./feeEstimator.js";
 
-export type RequestGasAndPaymasterAndDataOverrides = Partial<{
-  maxFeePerGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  maxPriorityFeePerGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  callGasLimit: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  preVerificationGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  verificationGasLimit: UserOperationRequest["maxFeePerGas"] | Multiplier;
+export type RequestGasAndPaymasterAndDataOverrides<
+  TEntryPointVersion extends EntryPointVersion
+> = Partial<{
+  maxFeePerGas:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  maxPriorityFeePerGas:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  callGasLimit:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  preVerificationGas:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  verificationGasLimit:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
 }>;
 
 export interface AlchemyGasManagerConfig {
@@ -56,28 +69,35 @@ const dummyPaymasterAndData =
     return `${paymasterAddress}${dummyData}` as Address;
   };
 
-export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
+export function alchemyGasManagerMiddleware<C extends ClientWithAlchemyMethods>(
   client: C,
   config: AlchemyGasManagerConfig
 ): Pick<
   ClientMiddlewareConfig,
   "paymasterAndData" | "feeEstimator" | "gasEstimator"
-> => {
+> {
   const gasEstimationOptions = config.gasEstimationOptions;
   const disableGasEstimation =
     gasEstimationOptions?.disableGasEstimation ?? false;
   const fallbackFeeDataGetter =
     gasEstimationOptions?.fallbackFeeDataGetter ?? alchemyFeeEstimator(client);
   const fallbackGasEstimator =
-    gasEstimationOptions?.fallbackGasEstimator ?? defaultGasEstimator(client);
+    gasEstimationOptions?.fallbackGasEstimator ??
+    defaultGasEstimator<C>(client);
 
   return {
     gasEstimator: disableGasEstimation
       ? fallbackGasEstimator
       : async (struct, { overrides, account, feeOptions }) => {
-          // but if user is bypassing paymaster to fallback to having the account to pay the gas (one-off override),
+          const entryPoint = account.getEntryPoint();
+          // if user is bypassing paymaster to fallback to having the account to pay the gas (one-off override),
           // we cannot delegate gas estimation to the bundler because paymaster middleware will not be called
-          if (overrides?.paymasterAndData === "0x") {
+          if (
+            (entryPoint.version === "0.6.0"
+              ? (overrides as UserOperationOverrides<"0.6.0">)?.paymasterAndData
+              : (overrides as UserOperationOverrides<"0.7.0">)
+                  ?.paymasterData) === "0x"
+          ) {
             return {
               ...struct,
               ...fallbackGasEstimator(struct, {
@@ -89,7 +109,7 @@ export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
             };
           }
 
-          // essentiall noop, because the gas estimation will happen in the backend
+          // essentially noop, because the gas estimation will happen in the backend
           return struct;
         },
     feeEstimator: disableGasEstimation
@@ -98,9 +118,16 @@ export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
           let maxFeePerGas = await struct.maxFeePerGas;
           let maxPriorityFeePerGas = await struct.maxPriorityFeePerGas;
 
+          const entryPoint = account.getEntryPoint();
           // but if user is bypassing paymaster to fallback to having the account to pay the gas (one-off override),
           // we cannot delegate gas estimation to the bundler because paymaster middleware will not be called
-          if (overrides?.paymasterAndData === "0x") {
+          if (
+            entryPoint.version === "0.6.0"
+              ? (overrides as UserOperationOverrides<"0.6.0">)
+                  ?.paymasterAndData === "0x"
+              : (overrides as UserOperationOverrides<"0.7.0">)
+                  ?.paymasterData === "0x"
+          ) {
             const result = await fallbackFeeDataGetter(struct, {
               overrides,
               feeOptions,
@@ -122,79 +149,80 @@ export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
       ? requestPaymasterAndData(client, config)
       : requestGasAndPaymasterData(client, config),
   };
-};
+}
 
-const requestGasAndPaymasterData: <C extends ClientWithAlchemyMethods>(
+function requestGasAndPaymasterData<C extends ClientWithAlchemyMethods>(
   client: C,
   config: AlchemyGasManagerConfig
-) => ClientMiddlewareConfig["paymasterAndData"] = (client, config) => ({
-  dummyPaymasterAndData: dummyPaymasterAndData(client, config),
-  paymasterAndData: async (struct, { overrides, feeOptions, account }) => {
-    const userOperation: UserOperationRequest = deepHexlify(
-      await resolveProperties(struct)
-    );
+): ClientMiddlewareConfig["paymasterAndData"] {
+  return {
+    dummyPaymasterAndData: dummyPaymasterAndData(client, config),
+    paymasterAndData: async (struct, { overrides, feeOptions, account }) => {
+      const userOperation: UserOperationRequest<EntryPointVersion> =
+        deepHexlify(await resolveProperties(struct));
 
-    const overrideField = (
-      field: keyof UserOperationFeeOptions
-    ): Hex | Multiplier | undefined => {
-      if (overrides?.[field] != null) {
-        // one-off absolute override
-        if (isBigNumberish(overrides[field])) {
-          return deepHexlify(overrides[field]);
+      const overrideField = (
+        field: keyof UserOperationFeeOptions
+      ): Hex | Multiplier | undefined => {
+        if (overrides?.[field] != null) {
+          // one-off absolute override
+          if (isBigNumberish(overrides[field])) {
+            return deepHexlify(overrides[field]);
+          }
+          // one-off multiplier overrides
+          else {
+            return {
+              multiplier: Number((overrides[field] as Multiplier).multiplier),
+            };
+          }
         }
-        // one-off multiplier overrides
-        else {
+
+        // provider level fee options with multiplier
+        if (isMultiplier(feeOptions?.[field])) {
           return {
-            multiplier: Number((overrides[field] as Multiplier).multiplier),
+            multiplier: Number((feeOptions![field] as Multiplier).multiplier),
           };
         }
-      }
 
-      // provider level fee options with multiplier
-      if (isMultiplier(feeOptions?.[field])) {
-        return {
-          multiplier: Number((feeOptions![field] as Multiplier).multiplier),
-        };
-      }
+        if (
+          userOperation[field] != null &&
+          fromHex(userOperation[field], "bigint") > 0n
+        ) {
+          return userOperation[field];
+        }
+        return undefined;
+      };
 
-      if (
-        userOperation[field] != null &&
-        fromHex(userOperation[field], "bigint") > 0n
-      ) {
-        return userOperation[field];
-      }
+      const _overrides: RequestGasAndPaymasterAndDataOverrides<EntryPointVersion> =
+        filterUndefined({
+          maxFeePerGas: overrideField("maxFeePerGas"),
+          maxPriorityFeePerGas: overrideField("maxPriorityFeePerGas"),
+          callGasLimit: overrideField("callGasLimit"),
+          verificationGasLimit: overrideField("verificationGasLimit"),
+          preVerificationGas: overrideField("preVerificationGas"),
+        });
 
-      return undefined;
-    };
+      const result = await client.request({
+        method: "alchemy_requestGasAndPaymasterAndData",
+        params: [
+          {
+            policyId: config.policyId,
+            entryPoint: account.getEntryPoint().address,
+            userOperation: userOperation,
+            dummySignature: userOperation.signature,
+            overrides:
+              Object.keys(_overrides).length > 0 ? _overrides : undefined,
+          },
+        ],
+      });
 
-    const _overrides: RequestGasAndPaymasterAndDataOverrides = filterUndefined({
-      maxFeePerGas: overrideField("maxFeePerGas"),
-      maxPriorityFeePerGas: overrideField("maxPriorityFeePerGas"),
-      callGasLimit: overrideField("callGasLimit"),
-      verificationGasLimit: overrideField("verificationGasLimit"),
-      preVerificationGas: overrideField("preVerificationGas"),
-    });
-
-    const result = await client.request({
-      method: "alchemy_requestGasAndPaymasterAndData",
-      params: [
-        {
-          policyId: config.policyId,
-          entryPoint: account.getEntryPoint().address,
-          userOperation: userOperation,
-          dummySignature: userOperation.signature,
-          overrides:
-            Object.keys(_overrides).length > 0 ? _overrides : undefined,
-        },
-      ],
-    });
-
-    return {
-      ...struct,
-      ...result,
-    };
-  },
-});
+      return {
+        ...struct,
+        ...result,
+      };
+    },
+  };
+}
 
 const requestPaymasterAndData: <C extends ClientWithAlchemyMethods>(
   client: C,

--- a/packages/alchemy/src/middleware/userOperationSimulator.ts
+++ b/packages/alchemy/src/middleware/userOperationSimulator.ts
@@ -2,22 +2,17 @@ import {
   deepHexlify,
   resolveProperties,
   type ClientMiddlewareFn,
-  type EntryPointVersion,
-  type UserOperationStruct,
 } from "@alchemy/aa-core";
 import type { ClientWithAlchemyMethods } from "../client/types";
 
 export function alchemyUserOperationSimulator<
-  C extends ClientWithAlchemyMethods,
-  TEntryPointVersion extends EntryPointVersion
+  C extends ClientWithAlchemyMethods
 >(client: C): ClientMiddlewareFn {
   return async (struct, { account }) => {
     const uoSimResult = await client.request({
       method: "alchemy_simulateUserOperationAssetChanges",
       params: [
-        deepHexlify(
-          await resolveProperties(struct)
-        ) as UserOperationStruct<TEntryPointVersion>,
+        deepHexlify(await resolveProperties(struct)),
         account.getEntryPoint().address,
       ],
     });

--- a/packages/alchemy/src/middleware/userOperationSimulator.ts
+++ b/packages/alchemy/src/middleware/userOperationSimulator.ts
@@ -2,21 +2,22 @@ import {
   deepHexlify,
   resolveProperties,
   type ClientMiddlewareFn,
+  type EntryPointVersion,
   type UserOperationStruct,
 } from "@alchemy/aa-core";
 import type { ClientWithAlchemyMethods } from "../client/types";
 
-export const alchemyUserOperationSimulator: <
-  C extends ClientWithAlchemyMethods
->(
-  client: C
-) => ClientMiddlewareFn =
-  (client) =>
-  async (struct, { account }) => {
+export function alchemyUserOperationSimulator<
+  C extends ClientWithAlchemyMethods,
+  TEntryPointVersion extends EntryPointVersion
+>(client: C): ClientMiddlewareFn {
+  return async (struct, { account }) => {
     const uoSimResult = await client.request({
       method: "alchemy_simulateUserOperationAssetChanges",
       params: [
-        deepHexlify(await resolveProperties(struct)) as UserOperationStruct,
+        deepHexlify(
+          await resolveProperties(struct)
+        ) as UserOperationStruct<TEntryPointVersion>,
         account.getEntryPoint().address,
       ],
     });
@@ -27,3 +28,4 @@ export const alchemyUserOperationSimulator: <
 
     return struct;
   };
+}

--- a/packages/alchemy/src/signer/client/types.ts
+++ b/packages/alchemy/src/signer/client/types.ts
@@ -1,5 +1,6 @@
-import type { Address, Hex } from "@alchemy/aa-core";
+import type { Address } from "@alchemy/aa-core";
 import type { TSignedRequest, getWebAuthnAttestation } from "@turnkey/http";
+import type { Hex } from "viem";
 
 export type CredentialCreationOptionOverrides = {
   publicKey?: Partial<CredentialCreationOptions["publicKey"]>;

--- a/packages/core/e2e-tests/constants.ts
+++ b/packages/core/e2e-tests/constants.ts
@@ -1,2 +1,4 @@
+export const STAGING = process.env.STAGING!;
 export const API_KEY = process.env.API_KEY!;
+export const API_KEY_STAGING = process.env.API_KEY_STAGING!;
 export const OWNER_MNEMONIC = process.env.OWNER_MNEMONIC!;

--- a/packages/core/e2e-tests/simple-account-staging.e2e.test.ts
+++ b/packages/core/e2e-tests/simple-account-staging.e2e.test.ts
@@ -1,0 +1,224 @@
+import {
+  custom,
+  fromHex,
+  http,
+  isAddress,
+  type Address,
+  type Chain,
+  type Hex,
+} from "viem";
+import { generatePrivateKey } from "viem/accounts";
+import {
+  arbitrumSepolia,
+  createBundlerClient,
+  createSimpleSmartAccount,
+  createSmartAccountClientFromExisting,
+  getEntryPoint,
+  type SmartAccountSigner,
+  type UserOperationFeeOptions,
+  type UserOperationOverrides,
+} from "../src/index.js";
+import { LocalAccountSigner } from "../src/signer/local-account.js";
+import { API_KEY, API_KEY_STAGING, OWNER_MNEMONIC } from "./constants.js";
+
+const rpcUrl = "https://arb-sepolia.g.alchemypreview.com/v2";
+const chain = arbitrumSepolia;
+
+describe("Simple Account Tests on Split RPC", () => {
+  const signer: SmartAccountSigner =
+    LocalAccountSigner.mnemonicToAccountSigner(OWNER_MNEMONIC);
+
+  it("should successfully get counterfactual address", async () => {
+    const client = await givenConnectedClient({ signer, chain });
+    expect(client.getAddress()).toMatchInlineSnapshot(
+      `"0x439663CEb3861f1bCf7F45F1792668fC74fc4b97"`
+    );
+  });
+
+  it("should execute successfully", async () => {
+    const client = await givenConnectedClient({ signer, chain });
+    const result = await client.sendUserOperation({
+      uo: {
+        target: client.getAddress(),
+        data: "0x",
+      },
+    });
+
+    const txnHash = client.waitForUserOperationTransaction(result);
+
+    await expect(txnHash).resolves.not.toThrowError();
+  }, 60000);
+
+  it("should fail to execute if account address is not deployed and not correct", async () => {
+    const accountAddress = "0xc33AbD9621834CA7c6Fc9f9CC3c47b9c17B03f9F";
+    const client = await givenConnectedClient({
+      signer,
+      chain,
+      accountAddress,
+    });
+
+    const result = client.sendUserOperation({
+      uo: {
+        target: client.getAddress(),
+        data: "0x",
+      },
+    });
+
+    await expect(result).rejects.toThrowError();
+  });
+
+  it("should get counterfactual for undeployed account", async () => {
+    const signer = LocalAccountSigner.privateKeyToAccountSigner(
+      generatePrivateKey()
+    );
+    const client = await givenConnectedClient({ signer, chain });
+
+    const address = client.getAddress();
+    expect(isAddress(address)).toBe(true);
+  });
+
+  it("should correctly handle multiplier overrides for buildUserOperation", async () => {
+    const client = await givenConnectedClient({
+      signer,
+      chain,
+    });
+
+    const structPromise = client.buildUserOperation({
+      uo: {
+        target: client.getAddress(),
+        data: "0x",
+      },
+    });
+
+    await expect(structPromise).resolves.not.toThrowError();
+
+    const clientWithFeeOptions = await givenConnectedClient({
+      signer,
+      chain,
+      feeOptions: {
+        preVerificationGas: { multiplier: 2 },
+      },
+    });
+
+    const structWithFeeOptionsPromise = clientWithFeeOptions.buildUserOperation(
+      {
+        uo: {
+          target: client.getAddress(),
+          data: "0x",
+        },
+      }
+    );
+    await expect(structWithFeeOptionsPromise).resolves.not.toThrowError();
+
+    const [struct, structWithFeeOptions] = await Promise.all([
+      structPromise,
+      structWithFeeOptionsPromise,
+    ]);
+
+    const preVerificationGas =
+      typeof struct.preVerificationGas === "string"
+        ? fromHex(struct.preVerificationGas as Hex, "bigint")
+        : struct.preVerificationGas;
+    const preVerificationGasWithFeeOptions =
+      typeof structWithFeeOptions.preVerificationGas === "string"
+        ? fromHex(structWithFeeOptions.preVerificationGas as Hex, "bigint")
+        : structWithFeeOptions.preVerificationGas;
+
+    expect(preVerificationGasWithFeeOptions).toBeGreaterThan(
+      preVerificationGas!
+    );
+  }, 60000);
+
+  it("should correctly handle absolute overrides for sendUserOperation", async () => {
+    const client = await givenConnectedClient({ signer, chain });
+
+    const overrides: UserOperationOverrides<"0.6.0"> = {
+      preVerificationGas: 100_000_000n,
+    };
+    const promise = client.buildUserOperation({
+      uo: {
+        target: client.getAddress(),
+        data: "0x",
+      },
+      overrides,
+    });
+    await expect(promise).resolves.not.toThrowError();
+
+    const struct = await promise;
+    expect(struct.preVerificationGas).toBe(100_000_000n);
+  }, 60000);
+
+  it("should correctly handle multiplier overrides for sendUserOperation", async () => {
+    const client = await givenConnectedClient({
+      signer,
+      chain,
+      feeOptions: {
+        preVerificationGas: { multiplier: 2 },
+      },
+    });
+
+    const struct = client.sendUserOperation({
+      uo: {
+        target: client.getAddress(),
+        data: "0x",
+      },
+    });
+    await expect(struct).resolves.not.toThrowError();
+  }, 60000);
+});
+
+const givenConnectedClient = async ({
+  signer,
+  chain,
+  accountAddress,
+  feeOptions,
+}: {
+  signer: SmartAccountSigner;
+  chain: Chain;
+  accountAddress?: Address;
+  feeOptions?: UserOperationFeeOptions;
+}) => {
+  const client = createBundlerClient({
+    chain,
+    transport: (opts) => {
+      const bundlerRpc = http(`${rpcUrl}/${API_KEY_STAGING}`)(opts);
+      const publicRpc = http(`${chain.rpcUrls.alchemy.http[0]}/${API_KEY}`)(
+        opts
+      );
+
+      return custom({
+        request: async (args) => {
+          const bundlerMethods = new Set([
+            "eth_sendUserOperation",
+            "eth_estimateUserOperationGas",
+            "eth_getUserOperationReceipt",
+            "eth_getUserOperationByHash",
+            "eth_supportedEntryPoints",
+          ]);
+
+          if (bundlerMethods.has(args.method)) {
+            return bundlerRpc.request(args);
+          } else {
+            return publicRpc.request(args);
+          }
+        },
+      })(opts);
+    },
+  });
+  return createSmartAccountClientFromExisting({
+    client,
+    account: await createSimpleSmartAccount({
+      chain,
+      signer,
+      entryPoint: getEntryPoint(chain),
+      transport: custom(client),
+      accountAddress,
+    }),
+    feeEstimator: async (struct) => ({
+      ...struct,
+      maxFeePerGas: 100_000_000_000n,
+      maxPriorityFeePerGas: 100_000_000_000n,
+    }),
+    opts: { feeOptions },
+  });
+};

--- a/packages/core/e2e-tests/simple-account.e2e.test.ts
+++ b/packages/core/e2e-tests/simple-account.e2e.test.ts
@@ -130,7 +130,7 @@ describe("Simple Account Tests", () => {
   it("should correctly handle absolute overrides for sendUserOperation", async () => {
     const provider = await givenConnectedProvider({ signer, chain });
 
-    const overrides: UserOperationOverrides = {
+    const overrides: UserOperationOverrides<"0.6.0"> = {
       preVerificationGas: 100_000_000n,
     };
     const promise = provider.buildUserOperation({

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,6 +1,5 @@
 import { sepolia } from "@alchemy/aa-core";
 import { getEntryPoint } from "../entrypoint/index.js";
-import type { UserOperationRequest } from "../types";
 import { stringToIndex } from "../utils/index.js";
 
 describe("Utils Tests", () => {
@@ -23,9 +22,9 @@ describe("Utils Tests", () => {
         signature:
           "0xd16f93b584fbfdc03a5ee85914a1f29aa35c44fea5144c387ee1040a3c1678252bf323b7e9c3e9b4dfd91cca841fc522f4d3160a1e803f2bf14eb5fa037aae4a1b",
         verificationGasLimit: "0x114c2",
-      } as UserOperationRequest<"0.6.0">)
+      })
     ).toMatchInlineSnapshot(
-      '"0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"'
+      '"0xbb5560c1a3983429a6cdb244fa532fb4f2cf0de8ba9ccbf257bff93d069c76a3"'
     );
   });
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,38 +1,31 @@
 import { sepolia } from "@alchemy/aa-core";
+import { getEntryPoint } from "../entrypoint/index.js";
 import type { UserOperationRequest } from "../types";
-import {
-  getDefaultEntryPointAddress,
-  getUserOperationHash,
-  stringToIndex,
-} from "../utils/index.js";
+import { stringToIndex } from "../utils/index.js";
 
 describe("Utils Tests", () => {
   const chain = sepolia;
-  const entryPointAddress = getDefaultEntryPointAddress(chain);
+  const entryPoint = getEntryPoint(chain);
 
   it("getUserOperationHash should correctly hash a request", () => {
     expect(
-      getUserOperationHash(
-        {
-          callData:
-            "0xb61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
-          callGasLimit: "0x2f6c",
-          initCode: "0x",
-          maxFeePerGas: "0x59682f1e",
-          maxPriorityFeePerGas: "0x59682f00",
-          nonce: "0x1f",
-          paymasterAndData: "0x",
-          preVerificationGas: "0xa890",
-          sender: "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4",
-          signature:
-            "0xd16f93b584fbfdc03a5ee85914a1f29aa35c44fea5144c387ee1040a3c1678252bf323b7e9c3e9b4dfd91cca841fc522f4d3160a1e803f2bf14eb5fa037aae4a1b",
-          verificationGasLimit: "0x114c2",
-        } as UserOperationRequest,
-        entryPointAddress,
-        80001n
-      )
+      entryPoint.getUserOperationHash({
+        callData:
+          "0xb61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
+        callGasLimit: "0x2f6c",
+        initCode: "0x",
+        maxFeePerGas: "0x59682f1e",
+        maxPriorityFeePerGas: "0x59682f00",
+        nonce: "0x1f",
+        paymasterAndData: "0x",
+        preVerificationGas: "0xa890",
+        sender: "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4",
+        signature:
+          "0xd16f93b584fbfdc03a5ee85914a1f29aa35c44fea5144c387ee1040a3c1678252bf323b7e9c3e9b4dfd91cca841fc522f4d3160a1e803f2bf14eb5fa037aae4a1b",
+        verificationGasLimit: "0x114c2",
+      } as UserOperationRequest<"0.6.0">)
     ).toMatchInlineSnapshot(
-      `"0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"`
+      '"0xbb5560c1a3983429a6cdb244fa532fb4f2cf0de8ba9ccbf257bff93d069c76a3"'
     );
   });
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -25,7 +25,7 @@ describe("Utils Tests", () => {
         verificationGasLimit: "0x114c2",
       } as UserOperationRequest<"0.6.0">)
     ).toMatchInlineSnapshot(
-      '"0xbb5560c1a3983429a6cdb244fa532fb4f2cf0de8ba9ccbf257bff93d069c76a3"'
+      '"0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"'
     );
   });
 

--- a/packages/core/src/abis/EntryPointAbi_v6.ts
+++ b/packages/core/src/abis/EntryPointAbi_v6.ts
@@ -1,4 +1,4 @@
-export const EntryPointAbi = [
+export const EntryPointAbi_v6 = [
   {
     inputs: [
       {

--- a/packages/core/src/abis/EntryPointAbi_v7.ts
+++ b/packages/core/src/abis/EntryPointAbi_v7.ts
@@ -1,0 +1,658 @@
+// https://etherscan.io/address/0x0000000071727de22e5e9d8baf0edac6f37da032
+export const EntryPointAbi_v7 = [
+  {
+    inputs: [
+      { internalType: "bool", name: "success", type: "bool" },
+      { internalType: "bytes", name: "ret", type: "bytes" },
+    ],
+    name: "DelegateAndRevert",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "opIndex", type: "uint256" },
+      { internalType: "string", name: "reason", type: "string" },
+    ],
+    name: "FailedOp",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "opIndex", type: "uint256" },
+      { internalType: "string", name: "reason", type: "string" },
+      { internalType: "bytes", name: "inner", type: "bytes" },
+    ],
+    name: "FailedOpWithRevert",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "returnData", type: "bytes" }],
+    name: "PostOpReverted",
+    type: "error",
+  },
+  { inputs: [], name: "ReentrancyGuardReentrantCall", type: "error" },
+  {
+    inputs: [{ internalType: "address", name: "sender", type: "address" }],
+    name: "SenderAddressResult",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "address", name: "aggregator", type: "address" }],
+    name: "SignatureValidationFailed",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "factory",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "paymaster",
+        type: "address",
+      },
+    ],
+    name: "AccountDeployed",
+    type: "event",
+  },
+  { anonymous: false, inputs: [], name: "BeforeExecution", type: "event" },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "totalDeposit",
+        type: "uint256",
+      },
+    ],
+    name: "Deposited",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "revertReason",
+        type: "bytes",
+      },
+    ],
+    name: "PostOpRevertReason",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "aggregator",
+        type: "address",
+      },
+    ],
+    name: "SignatureAggregatorChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "totalStaked",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "unstakeDelaySec",
+        type: "uint256",
+      },
+    ],
+    name: "StakeLocked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "withdrawTime",
+        type: "uint256",
+      },
+    ],
+    name: "StakeUnlocked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "StakeWithdrawn",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "paymaster",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+      { indexed: false, internalType: "bool", name: "success", type: "bool" },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "actualGasCost",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "actualGasUsed",
+        type: "uint256",
+      },
+    ],
+    name: "UserOperationEvent",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+    ],
+    name: "UserOperationPrefundTooLow",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "revertReason",
+        type: "bytes",
+      },
+    ],
+    name: "UserOperationRevertReason",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Withdrawn",
+    type: "event",
+  },
+  {
+    inputs: [
+      { internalType: "uint32", name: "unstakeDelaySec", type: "uint32" },
+    ],
+    name: "addStake",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "target", type: "address" },
+      { internalType: "bytes", name: "data", type: "bytes" },
+    ],
+    name: "delegateAndRevert",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "depositTo",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "deposits",
+    outputs: [
+      { internalType: "uint256", name: "deposit", type: "uint256" },
+      { internalType: "bool", name: "staked", type: "bool" },
+      { internalType: "uint112", name: "stake", type: "uint112" },
+      { internalType: "uint32", name: "unstakeDelaySec", type: "uint32" },
+      { internalType: "uint48", name: "withdrawTime", type: "uint48" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "getDepositInfo",
+    outputs: [
+      {
+        components: [
+          { internalType: "uint256", name: "deposit", type: "uint256" },
+          { internalType: "bool", name: "staked", type: "bool" },
+          { internalType: "uint112", name: "stake", type: "uint112" },
+          { internalType: "uint32", name: "unstakeDelaySec", type: "uint32" },
+          { internalType: "uint48", name: "withdrawTime", type: "uint48" },
+        ],
+        internalType: "struct IStakeManager.DepositInfo",
+        name: "info",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "sender", type: "address" },
+      { internalType: "uint192", name: "key", type: "uint192" },
+    ],
+    name: "getNonce",
+    outputs: [{ internalType: "uint256", name: "nonce", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "initCode", type: "bytes" }],
+    name: "getSenderAddress",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "sender", type: "address" },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "bytes", name: "initCode", type: "bytes" },
+          { internalType: "bytes", name: "callData", type: "bytes" },
+          {
+            internalType: "bytes32",
+            name: "accountGasLimits",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "preVerificationGas",
+            type: "uint256",
+          },
+          { internalType: "bytes32", name: "gasFees", type: "bytes32" },
+          { internalType: "bytes", name: "paymasterAndData", type: "bytes" },
+          { internalType: "bytes", name: "signature", type: "bytes" },
+        ],
+        internalType: "struct PackedUserOperation",
+        name: "userOp",
+        type: "tuple",
+      },
+    ],
+    name: "getUserOpHash",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "sender", type: "address" },
+              { internalType: "uint256", name: "nonce", type: "uint256" },
+              { internalType: "bytes", name: "initCode", type: "bytes" },
+              { internalType: "bytes", name: "callData", type: "bytes" },
+              {
+                internalType: "bytes32",
+                name: "accountGasLimits",
+                type: "bytes32",
+              },
+              {
+                internalType: "uint256",
+                name: "preVerificationGas",
+                type: "uint256",
+              },
+              { internalType: "bytes32", name: "gasFees", type: "bytes32" },
+              {
+                internalType: "bytes",
+                name: "paymasterAndData",
+                type: "bytes",
+              },
+              { internalType: "bytes", name: "signature", type: "bytes" },
+            ],
+            internalType: "struct PackedUserOperation[]",
+            name: "userOps",
+            type: "tuple[]",
+          },
+          {
+            internalType: "contract IAggregator",
+            name: "aggregator",
+            type: "address",
+          },
+          { internalType: "bytes", name: "signature", type: "bytes" },
+        ],
+        internalType: "struct IEntryPoint.UserOpsPerAggregator[]",
+        name: "opsPerAggregator",
+        type: "tuple[]",
+      },
+      { internalType: "address payable", name: "beneficiary", type: "address" },
+    ],
+    name: "handleAggregatedOps",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "sender", type: "address" },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "bytes", name: "initCode", type: "bytes" },
+          { internalType: "bytes", name: "callData", type: "bytes" },
+          {
+            internalType: "bytes32",
+            name: "accountGasLimits",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "preVerificationGas",
+            type: "uint256",
+          },
+          { internalType: "bytes32", name: "gasFees", type: "bytes32" },
+          { internalType: "bytes", name: "paymasterAndData", type: "bytes" },
+          { internalType: "bytes", name: "signature", type: "bytes" },
+        ],
+        internalType: "struct PackedUserOperation[]",
+        name: "ops",
+        type: "tuple[]",
+      },
+      { internalType: "address payable", name: "beneficiary", type: "address" },
+    ],
+    name: "handleOps",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint192", name: "key", type: "uint192" }],
+    name: "incrementNonce",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes", name: "callData", type: "bytes" },
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "sender", type: "address" },
+              { internalType: "uint256", name: "nonce", type: "uint256" },
+              {
+                internalType: "uint256",
+                name: "verificationGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "callGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "paymasterVerificationGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "paymasterPostOpGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "preVerificationGas",
+                type: "uint256",
+              },
+              { internalType: "address", name: "paymaster", type: "address" },
+              {
+                internalType: "uint256",
+                name: "maxFeePerGas",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "maxPriorityFeePerGas",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct EntryPoint.MemoryUserOp",
+            name: "mUserOp",
+            type: "tuple",
+          },
+          { internalType: "bytes32", name: "userOpHash", type: "bytes32" },
+          { internalType: "uint256", name: "prefund", type: "uint256" },
+          { internalType: "uint256", name: "contextOffset", type: "uint256" },
+          { internalType: "uint256", name: "preOpGas", type: "uint256" },
+        ],
+        internalType: "struct EntryPoint.UserOpInfo",
+        name: "opInfo",
+        type: "tuple",
+      },
+      { internalType: "bytes", name: "context", type: "bytes" },
+    ],
+    name: "innerHandleOp",
+    outputs: [
+      { internalType: "uint256", name: "actualGasCost", type: "uint256" },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "uint192", name: "", type: "uint192" },
+    ],
+    name: "nonceSequenceNumber",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes4", name: "interfaceId", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "unlockStake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address payable",
+        name: "withdrawAddress",
+        type: "address",
+      },
+    ],
+    name: "withdrawStake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address payable",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      { internalType: "uint256", name: "withdrawAmount", type: "uint256" },
+    ],
+    name: "withdrawTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  { stateMutability: "payable", type: "receive" },
+] as const;

--- a/packages/core/src/abis/SimpleAccountAbi_v6.ts
+++ b/packages/core/src/abis/SimpleAccountAbi_v6.ts
@@ -1,0 +1,524 @@
+export const SimpleAccountAbi_v6 = [
+  {
+    inputs: [
+      {
+        internalType: "contract IEntryPoint",
+        name: "anEntryPoint",
+        type: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "previousAdmin",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newAdmin",
+        type: "address",
+      },
+    ],
+    name: "AdminChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "beacon",
+        type: "address",
+      },
+    ],
+    name: "BeaconUpgraded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint8",
+        name: "version",
+        type: "uint8",
+      },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "contract IEntryPoint",
+        name: "entryPoint",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+    ],
+    name: "SimpleAccountInitialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "implementation",
+        type: "address",
+      },
+    ],
+    name: "Upgraded",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "addDeposit",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "entryPoint",
+    outputs: [
+      {
+        internalType: "contract IEntryPoint",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "dest",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "func",
+        type: "bytes",
+      },
+    ],
+    name: "execute",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address[]",
+        name: "dest",
+        type: "address[]",
+      },
+      {
+        internalType: "bytes[]",
+        name: "func",
+        type: "bytes[]",
+      },
+    ],
+    name: "executeBatch",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getDeposit",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getNonce",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "anOwner",
+        type: "address",
+      },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "uint256[]",
+        name: "",
+        type: "uint256[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "",
+        type: "uint256[]",
+      },
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+    ],
+    name: "onERC1155BatchReceived",
+    outputs: [
+      {
+        internalType: "bytes4",
+        name: "",
+        type: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+    ],
+    name: "onERC1155Received",
+    outputs: [
+      {
+        internalType: "bytes4",
+        name: "",
+        type: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+    ],
+    name: "onERC721Received",
+    outputs: [
+      {
+        internalType: "bytes4",
+        name: "",
+        type: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes4",
+        name: "interfaceId",
+        type: "bytes4",
+      },
+    ],
+    name: "supportsInterface",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+    ],
+    name: "tokensReceived",
+    outputs: [],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newImplementation",
+        type: "address",
+      },
+    ],
+    name: "upgradeTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newImplementation",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "sender",
+            type: "address",
+          },
+          {
+            internalType: "uint256",
+            name: "nonce",
+            type: "uint256",
+          },
+          {
+            internalType: "bytes",
+            name: "initCode",
+            type: "bytes",
+          },
+          {
+            internalType: "bytes",
+            name: "callData",
+            type: "bytes",
+          },
+          {
+            internalType: "uint256",
+            name: "callGasLimit",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "verificationGasLimit",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "preVerificationGas",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "maxFeePerGas",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "maxPriorityFeePerGas",
+            type: "uint256",
+          },
+          {
+            internalType: "bytes",
+            name: "paymasterAndData",
+            type: "bytes",
+          },
+          {
+            internalType: "bytes",
+            name: "signature",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct UserOperation",
+        name: "userOp",
+        type: "tuple",
+      },
+      {
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "missingAccountFunds",
+        type: "uint256",
+      },
+    ],
+    name: "validateUserOp",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "validationData",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address payable",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "withdrawDepositTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    stateMutability: "payable",
+    type: "receive",
+  },
+] as const;

--- a/packages/core/src/abis/SimpleAccountAbi_v7.ts
+++ b/packages/core/src/abis/SimpleAccountAbi_v7.ts
@@ -1,4 +1,4 @@
-export const SimpleAccountAbi = [
+export const SimpleAccountAbi_v7 = [
   {
     inputs: [
       {
@@ -11,45 +11,98 @@ export const SimpleAccountAbi = [
     type: "constructor",
   },
   {
-    anonymous: false,
     inputs: [
       {
-        indexed: false,
         internalType: "address",
-        name: "previousAdmin",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "address",
-        name: "newAdmin",
+        name: "target",
         type: "address",
       },
     ],
-    name: "AdminChanged",
-    type: "event",
+    name: "AddressEmptyCode",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ECDSAInvalidSignature",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "length",
+        type: "uint256",
+      },
+    ],
+    name: "ECDSAInvalidSignatureLength",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "s",
+        type: "bytes32",
+      },
+    ],
+    name: "ECDSAInvalidSignatureS",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "implementation",
+        type: "address",
+      },
+    ],
+    name: "ERC1967InvalidImplementation",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1967NonPayable",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "FailedInnerCall",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidInitialization",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NotInitializing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "UUPSUnauthorizedCallContext",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "slot",
+        type: "bytes32",
+      },
+    ],
+    name: "UUPSUnsupportedProxiableUUID",
+    type: "error",
   },
   {
     anonymous: false,
     inputs: [
       {
-        indexed: true,
-        internalType: "address",
-        name: "beacon",
-        type: "address",
-      },
-    ],
-    name: "BeaconUpgraded",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
         indexed: false,
-        internalType: "uint8",
+        internalType: "uint64",
         name: "version",
-        type: "uint8",
+        type: "uint64",
       },
     ],
     name: "Initialized",
@@ -86,6 +139,19 @@ export const SimpleAccountAbi = [
     ],
     name: "Upgraded",
     type: "event",
+  },
+  {
+    inputs: [],
+    name: "UPGRADE_INTERFACE_VERSION",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
   },
   {
     inputs: [],
@@ -136,6 +202,11 @@ export const SimpleAccountAbi = [
         internalType: "address[]",
         name: "dest",
         type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "value",
+        type: "uint256[]",
       },
       {
         internalType: "bytes[]",
@@ -348,57 +419,6 @@ export const SimpleAccountAbi = [
     inputs: [
       {
         internalType: "address",
-        name: "",
-        type: "address",
-      },
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
-      {
-        internalType: "bytes",
-        name: "",
-        type: "bytes",
-      },
-      {
-        internalType: "bytes",
-        name: "",
-        type: "bytes",
-      },
-    ],
-    name: "tokensReceived",
-    outputs: [],
-    stateMutability: "pure",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "newImplementation",
-        type: "address",
-      },
-    ],
-    name: "upgradeTo",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
         name: "newImplementation",
         type: "address",
       },
@@ -438,14 +458,9 @@ export const SimpleAccountAbi = [
             type: "bytes",
           },
           {
-            internalType: "uint256",
-            name: "callGasLimit",
-            type: "uint256",
-          },
-          {
-            internalType: "uint256",
-            name: "verificationGasLimit",
-            type: "uint256",
+            internalType: "bytes32",
+            name: "accountGasLimits",
+            type: "bytes32",
           },
           {
             internalType: "uint256",
@@ -453,14 +468,9 @@ export const SimpleAccountAbi = [
             type: "uint256",
           },
           {
-            internalType: "uint256",
-            name: "maxFeePerGas",
-            type: "uint256",
-          },
-          {
-            internalType: "uint256",
-            name: "maxPriorityFeePerGas",
-            type: "uint256",
+            internalType: "bytes32",
+            name: "gasFees",
+            type: "bytes32",
           },
           {
             internalType: "bytes",
@@ -473,7 +483,7 @@ export const SimpleAccountAbi = [
             type: "bytes",
           },
         ],
-        internalType: "struct UserOperation",
+        internalType: "struct PackedUserOperation",
         name: "userOp",
         type: "tuple",
       },

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -1,4 +1,3 @@
-import { sepolia } from "@alchemy/aa-core";
 import {
   createPublicClient,
   custom,
@@ -7,6 +6,7 @@ import {
   type Chain,
 } from "viem";
 import { describe, it } from "vitest";
+import { sepolia } from "../../chains/index.js";
 import { createBundlerClientFromExisting } from "../../client/bundlerClient.js";
 import { createSmartAccountClient } from "../../client/smartAccountClient.js";
 import { LocalAccountSigner } from "../../signer/local-account.js";

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -2,7 +2,6 @@ import type { Address } from "abitype";
 import {
   getContract,
   http,
-  toHex,
   trim,
   type GetContractReturnType,
   type Hash,
@@ -380,7 +379,7 @@ export abstract class BaseSmartContractAccount<
       );
     }
 
-    return toHex(trim(storage));
+    return trim(storage);
   }
 
   private async _getAccountInitCode(): Promise<Hash> {

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -2,6 +2,7 @@ import type { Address } from "abitype";
 import {
   getContract,
   http,
+  toHex,
   trim,
   type GetContractReturnType,
   type Hash,
@@ -10,11 +11,12 @@ import {
   type PublicClient,
   type Transport,
 } from "viem";
-import { EntryPointAbi } from "../abis/EntryPointAbi.js";
+import { EntryPointAbi_v6 as EntryPointAbi } from "../abis/EntryPointAbi_v6.js";
 import {
   createBundlerClient,
   type BundlerClient,
 } from "../client/bundlerClient.js";
+import { getEntryPoint } from "../entrypoint/index.js";
 import {
   BatchExecutionNotSupportedError,
   FailedToGetStorageSlotError,
@@ -25,8 +27,7 @@ import { InvalidRpcUrlError } from "../errors/client.js";
 import { Logger } from "../logger.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import { wrapSignatureWith6492 } from "../signer/utils.js";
-import type { BatchUserOperationCallData } from "../types.js";
-import { getDefaultEntryPointAddress } from "../utils/defaults.js";
+import type { BatchUserOperationCallData, NullAddress } from "../types.js";
 import { createBaseSmartAccountParamsSchema } from "./schema.js";
 import type {
   BaseSmartAccountParams,
@@ -62,14 +63,14 @@ export abstract class BaseSmartContractAccount<
     | BundlerClient<TTransport>
     | BundlerClient<HttpTransport>;
 
-  constructor(params_: BaseSmartAccountParams<TTransport>) {
+  constructor(params_: BaseSmartAccountParams<TTransport, TSigner>) {
     const params = createBaseSmartAccountParamsSchema<
       TTransport,
       TSigner
     >().parse(params_);
 
     this.entryPointAddress =
-      params.entryPointAddress ?? getDefaultEntryPointAddress(params.chain);
+      params.entryPointAddress ?? getEntryPoint(params.chain).address;
 
     const rpcUrl =
       typeof params.rpcClient === "string"
@@ -115,7 +116,7 @@ export abstract class BaseSmartContractAccount<
     this.accountAddress = params.accountAddress;
     this.factoryAddress = params.factoryAddress;
     this.signer = params.signer as TSigner;
-    this.accountInitCode = params.initCode;
+    this.accountInitCode = params.initCode as Hex;
 
     this.entryPoint = getContract({
       address: this.entryPointAddress,
@@ -363,7 +364,7 @@ export abstract class BaseSmartContractAccount<
     return [factoryAddress, factoryCalldata];
   }
 
-  protected async getImplementationAddress(): Promise<"0x0" | Address> {
+  protected async getImplementationAddress(): Promise<NullAddress | Address> {
     const accountAddress = await this.getAddress();
 
     const storage = await this.rpcProvider.getStorageAt({
@@ -379,7 +380,7 @@ export abstract class BaseSmartContractAccount<
       );
     }
 
-    return trim(storage);
+    return toHex(trim(storage));
   }
 
   private async _getAccountInitCode(): Promise<Hash> {

--- a/packages/core/src/account/schema.ts
+++ b/packages/core/src/account/schema.ts
@@ -2,6 +2,8 @@ import { Address } from "abitype/zod";
 import { isHex, type Transport } from "viem";
 import z from "zod";
 import { createPublicErc4337ClientSchema } from "../client/schema.js";
+import { isEntryPointVersion } from "../entrypoint/index.js";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import { isSigner } from "../signer/schema.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import { ChainSchema } from "../utils/index.js";
@@ -24,9 +26,15 @@ export const createBaseSmartAccountParamsSchema = <
     ),
     initCode: z
       .string()
-      .refine(isHex, "initCode must be a valid hex.")
+      .refine(
+        (x) => isHex(x, { strict: true }),
+        "initCode must be a valid hex."
+      )
       .optional()
       .describe("Optional override for the account init code."),
+    entryPointVersion: z
+      .custom<EntryPointVersion>(isEntryPointVersion)
+      .optional(),
   });
 
 export const SimpleSmartAccountParamsSchema = <

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -24,6 +24,7 @@ import type {
 import { AccountRequiresOwnerError } from "../errors/account.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import type { BatchUserOperationCallData } from "../types.js";
+import { getDefaultSimpleAccountFactoryAddress } from "../utils/defaults.js";
 import { BaseSmartContractAccount } from "./base.js";
 import { SimpleSmartAccountParamsSchema } from "./schema.js";
 import {
@@ -39,6 +40,7 @@ class SimpleSmartContractAccount<
 > extends BaseSmartContractAccount<TTransport, TSigner> {
   protected index: bigint;
   protected entryPointVersion: EntryPointVersion;
+  protected factoryAddress: Address;
 
   constructor(params: SimpleSmartAccountParams<TTransport, TSigner>) {
     SimpleSmartAccountParamsSchema().parse(params);
@@ -55,6 +57,7 @@ class SimpleSmartContractAccount<
     this.index = params.salt ?? 0n;
     this.entryPointVersion =
       params.entryPointVersion ?? defaultEntryPointVersion;
+    this.factoryAddress = params.factoryAddress as Address;
   }
 
   getDummySignature(): `0x${string}` {
@@ -157,6 +160,10 @@ export async function createSimpleSmartAccount<
 export async function createSimpleSmartAccount({
   chain,
   entryPoint = getEntryPoint(chain),
+  factoryAddress = getDefaultSimpleAccountFactoryAddress(
+    chain,
+    entryPoint.version
+  ),
   ...params
 }: CreateSimpleAccountParams): Promise<SimpleSmartAccount> {
   if (!params.signer) throw new AccountRequiresOwnerError("SimpleAccount");
@@ -164,6 +171,7 @@ export async function createSimpleSmartAccount({
     SimpleSmartAccountParamsSchema().parse({
       chain,
       entryPointAddress: entryPoint.address,
+      factoryAddress,
       ...params,
     })
   );
@@ -172,6 +180,7 @@ export async function createSimpleSmartAccount({
     chain,
     entryPointAddress: entryPoint.address,
     entryPointVersion: entryPoint.version,
+    factoryAddress,
     ...params,
   });
 

--- a/packages/core/src/account/simple.ts
+++ b/packages/core/src/account/simple.ts
@@ -3,14 +3,24 @@ import {
   concatHex,
   encodeFunctionData,
   isHex,
+  type Chain,
   type FallbackTransport,
   type Hex,
   type Transport,
 } from "viem";
-import { SimpleAccountAbi } from "../abis/SimpleAccountAbi.js";
+import { SimpleAccountAbi_v6 } from "../abis/SimpleAccountAbi_v6.js";
+import { SimpleAccountAbi_v7 } from "../abis/SimpleAccountAbi_v7.js";
 import { SimpleAccountFactoryAbi } from "../abis/SimpleAccountFactoryAbi.js";
 import { createBundlerClient } from "../client/bundlerClient.js";
-import { getVersion060EntryPoint } from "../entrypoint/0.6.js";
+import {
+  defaultEntryPointVersion,
+  getEntryPoint,
+} from "../entrypoint/index.js";
+import type {
+  DefaultEntryPointVersion,
+  EntryPointParameter,
+  EntryPointVersion,
+} from "../entrypoint/types.js";
 import { AccountRequiresOwnerError } from "../errors/account.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import type { BatchUserOperationCallData } from "../types.js";
@@ -28,19 +38,23 @@ class SimpleSmartContractAccount<
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > extends BaseSmartContractAccount<TTransport, TSigner> {
   protected index: bigint;
+  protected entryPointVersion: EntryPointVersion;
 
   constructor(params: SimpleSmartAccountParams<TTransport, TSigner>) {
-    SimpleSmartAccountParamsSchema<TTransport>().parse(params);
+    SimpleSmartAccountParamsSchema().parse(params);
 
     // This is a hack for now, we should kill the SimpleSmart Account when we kill Base Account
     const client = createBundlerClient({
       transport: params.transport as TTransport,
       chain: params.chain,
     });
+
     // @ts-expect-error zod custom type not recognized as required params for signers
     super({ ...params, rpcClient: client });
     this.signer = params.signer as TSigner;
     this.index = params.salt ?? 0n;
+    this.entryPointVersion =
+      params.entryPointVersion ?? defaultEntryPointVersion;
   }
 
   getDummySignature(): `0x${string}` {
@@ -53,7 +67,10 @@ class SimpleSmartContractAccount<
     data: Hex
   ): Promise<`0x${string}`> {
     return encodeFunctionData({
-      abi: SimpleAccountAbi,
+      abi:
+        this.entryPointVersion === "0.6.0"
+          ? SimpleAccountAbi_v6
+          : SimpleAccountAbi_v7,
       functionName: "execute",
       args: [target, value, data],
     });
@@ -73,7 +90,10 @@ class SimpleSmartContractAccount<
     );
 
     return encodeFunctionData({
-      abi: SimpleAccountAbi,
+      abi:
+        this.entryPointVersion === "0.6.0"
+          ? SimpleAccountAbi_v6
+          : SimpleAccountAbi_v7,
       functionName: "executeBatch",
       args: [targets, datas],
     });
@@ -97,36 +117,63 @@ class SimpleSmartContractAccount<
   }
 }
 
-export type SimpleSmartAccount<TSigner extends SmartAccountSigner> =
-  SmartContractAccountWithSigner<"SimpleAccount", TSigner>;
+export type SimpleSmartAccount<
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends EntryPointVersion = EntryPointVersion
+> = SmartContractAccountWithSigner<
+  "SimpleAccount",
+  TSigner,
+  TEntryPointVersion
+>;
 
-export const createSimpleSmartAccount = async <
+export type CreateSimpleAccountParams<
   TTransport extends Transport = Transport,
-  TSigner extends SmartAccountSigner = SmartAccountSigner
->({
-  chain,
-  entryPoint = getVersion060EntryPoint(chain),
-  ...params
-}: Omit<
-  SimpleSmartAccountParams<TTransport, TSigner>,
-  "rpcClient" | "chain" | "accountAddress" | "entryPointAddress"
-> &
-  Pick<
-    ToSmartContractAccountParams,
-    "chain" | "transport" | "accountAddress" | "entryPoint"
-  >): Promise<SimpleSmartAccount<TSigner>> => {
-  if (!params.signer) throw new AccountRequiresOwnerError("SimpleAccount");
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+> = Pick<
+  ToSmartContractAccountParams<
+    "SimpleAccount",
+    TTransport,
+    Chain,
+    TEntryPointVersion
+  >,
+  "chain" | "transport"
+> & {
+  signer: TSigner;
+  salt?: bigint;
+  accountAddress?: Address;
+  factoryAddress?: Address;
+  initCode?: Hex;
+} & EntryPointParameter<TEntryPointVersion, Chain>;
 
-  // @ts-expect-error zod custom type not recognized as required params for signers
-  const simpleAccount = new SimpleSmartContractAccount<TTransport>({
+export async function createSimpleSmartAccount<
+  TTransport extends Transport = Transport,
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+>(
+  config: CreateSimpleAccountParams<TTransport, TSigner, TEntryPointVersion>
+): Promise<SimpleSmartAccount<TSigner, TEntryPointVersion>>;
+
+export async function createSimpleSmartAccount({
+  chain,
+  entryPoint = getEntryPoint(chain),
+  ...params
+}: CreateSimpleAccountParams): Promise<SimpleSmartAccount> {
+  if (!params.signer) throw new AccountRequiresOwnerError("SimpleAccount");
+  const simpleAccount = new SimpleSmartContractAccount(
+    SimpleSmartAccountParamsSchema().parse({
+      chain,
+      entryPointAddress: entryPoint.address,
+      ...params,
+    })
+  );
+
+  const parsedParams = SimpleSmartAccountParamsSchema().parse({
     chain,
     entryPointAddress: entryPoint.address,
+    entryPointVersion: entryPoint.version,
     ...params,
   });
-  const parsedParams = SimpleSmartAccountParamsSchema<
-    TTransport,
-    TSigner
-  >().parse({ chain, entryPointAddress: entryPoint.address, ...params });
 
   const base = await toSmartContractAccount({
     source: "SimpleAccount",
@@ -141,7 +188,7 @@ export const createSimpleSmartAccount = async <
       ),
     entryPoint,
     getAccountInitCode: async () => {
-      if (parsedParams.initCode) return parsedParams.initCode;
+      if (parsedParams.initCode) return parsedParams.initCode as Hex;
       return simpleAccount.getAccountInitCode();
     },
     getDummySignature: simpleAccount.getDummySignature.bind(simpleAccount),
@@ -156,6 +203,6 @@ export const createSimpleSmartAccount = async <
 
   return {
     ...base,
-    getSigner: () => simpleAccount.getSigner() as TSigner,
+    getSigner: () => simpleAccount.getSigner(),
   };
-};
+}

--- a/packages/core/src/account/smartContractAccount.ts
+++ b/packages/core/src/account/smartContractAccount.ts
@@ -103,6 +103,7 @@ export type SmartContractAccount<
   getInitCode: () => Promise<Hex>;
   isAccountDeployed: () => Promise<boolean>;
   getFactoryAddress: () => Address;
+  getFactoryData: () => Hex;
   getEntryPoint: () => EntryPointDef<TEntryPointVersion>;
   getImplementationAddress: () => Promise<NullAddress | Address>;
 };
@@ -279,11 +280,13 @@ export async function toSmartContractAccount({
       return signMessage({ message: { raw: hexToBytes(uoHash) } });
     });
 
-  const [factoryAddress] = parseFactoryAddressFromAccountInitCode(
+  const [factoryAddress, factoryData] = parseFactoryAddressFromAccountInitCode(
     await getAccountInitCode()
   );
 
   const getFactoryAddress = () => factoryAddress;
+
+  const getFactoryData = () => factoryData;
 
   const encodeUpgradeToAndCall_ =
     encodeUpgradeToAndCall ??
@@ -382,6 +385,7 @@ export async function toSmartContractAccount({
     // and allow for generating the UO hash based on the EP version
     signUserOperationHash: signUserOperationHash_,
     getFactoryAddress,
+    getFactoryData,
     encodeBatchExecute:
       encodeBatchExecute ??
       (() => {

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -135,6 +135,7 @@ export interface ISmartContractAccount<
   getSigner(): TSigner;
 
   /**
+   *
    * @returns the address of the factory contract for the smart account
    */
   getFactoryAddress(): Address;

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -135,13 +135,17 @@ export interface ISmartContractAccount<
   getSigner(): TSigner;
 
   /**
-   *
    * @returns the address of the factory contract for the smart account
+   *
+   * The factory address of the smart account created by the factory
    */
   getFactoryAddress(): Address;
 
   /**
    * @returns the address of the entry point contract for the smart account
+   *
+   * The entrypoint address is the address ERC 4337 entrypoint singleton contract
+   * that this smart account and the connected bundler client use
    */
   getEntryPointAddress(): Address;
 

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -135,17 +135,15 @@ export interface ISmartContractAccount<
   getSigner(): TSigner;
 
   /**
-   * @returns the address of the factory contract for the smart account
-   *
    * The factory address of the smart account created by the factory
+   * @returns the address of the factory contract for the smart account
    */
   getFactoryAddress(): Address;
 
   /**
-   * @returns the address of the entry point contract for the smart account
-   *
    * The entrypoint address is the address ERC 4337 entrypoint singleton contract
    * that this smart account and the connected bundler client use
+   * @returns the address of the entry point contract for the smart account
    */
   getEntryPointAddress(): Address;
 

--- a/packages/core/src/actions/bundler/estimateUserOperationGas.ts
+++ b/packages/core/src/actions/bundler/estimateUserOperationGas.ts
@@ -7,8 +7,8 @@ import type {
 } from "../../types";
 
 export const estimateUserOperationGas = async <
-  TEntryPointVersion extends EntryPointVersion,
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>,
+  TEntryPointVersion extends EntryPointVersion
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/bundler/estimateUserOperationGas.ts
+++ b/packages/core/src/actions/bundler/estimateUserOperationGas.ts
@@ -1,16 +1,18 @@
 import type { Address, Chain, Client, StateOverride, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type {
   UserOperationEstimateGasResponse,
   UserOperationRequest,
 } from "../../types";
 
 export const estimateUserOperationGas = async <
+  TEntryPointVersion extends EntryPointVersion,
   TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient,
   args: {
-    request: UserOperationRequest;
+    request: UserOperationRequest<TEntryPointVersion>;
     entryPoint: Address;
     stateOverride?: StateOverride;
   }

--- a/packages/core/src/actions/bundler/getUserOperationByHash.ts
+++ b/packages/core/src/actions/bundler/getUserOperationByHash.ts
@@ -1,5 +1,6 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationResponse } from "../../types";
 
 export const getUserOperationByHash = async <
@@ -9,7 +10,7 @@ export const getUserOperationByHash = async <
   args: {
     hash: Hex;
   }
-): Promise<UserOperationResponse | null> => {
+): Promise<UserOperationResponse<EntryPointVersion> | null> => {
   return client.request({
     method: "eth_getUserOperationByHash",
     params: [args.hash],

--- a/packages/core/src/actions/bundler/sendRawUserOperation.ts
+++ b/packages/core/src/actions/bundler/sendRawUserOperation.ts
@@ -4,8 +4,8 @@ import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationRequest } from "../../types";
 
 export const sendRawUserOperation = async <
-  TEntryPointVersion extends EntryPointVersion,
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>,
+  TEntryPointVersion extends EntryPointVersion
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/bundler/sendRawUserOperation.ts
+++ b/packages/core/src/actions/bundler/sendRawUserOperation.ts
@@ -1,13 +1,15 @@
 import type { Address, Chain, Client, Hex, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationRequest } from "../../types";
 
 export const sendRawUserOperation = async <
+  TEntryPointVersion extends EntryPointVersion,
   TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient,
   args: {
-    request: UserOperationRequest;
+    request: UserOperationRequest<TEntryPointVersion>;
     entryPoint: Address;
   }
 ): Promise<Hex> => {

--- a/packages/core/src/actions/smartAccount/buildUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperation.ts
@@ -1,5 +1,9 @@
-import type { Chain, Client, Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount.js";
+import type { Address, Chain, Client, Hex, Transport } from "viem";
+import {
+  parseFactoryAddressFromAccountInitCode,
+  type GetEntryPointFromAccount,
+  type SmartContractAccount,
+} from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
@@ -8,7 +12,7 @@ import type { Deferrable } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import type { SendUserOperationParameters } from "./types";
 
-export const buildUserOperation: <
+export async function buildUserOperation<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
@@ -16,11 +20,12 @@ export const buildUserOperation: <
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: SendUserOperationParameters<TAccount, TContext>
-) => Promise<UserOperationStruct> = async (client, args) => {
+): Promise<UserOperationStruct<TEntryPointVersion>> {
   const { account = client.account, overrides, uo, context } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -34,20 +39,46 @@ export const buildUserOperation: <
     );
   }
 
+  const entryPoint = account.getEntryPoint();
+  const getInitCode = account.getInitCode();
+  const getFactoryAndData = getInitCode.then((initCode) =>
+    initCode === "0x"
+      ? ["0x0" as Address, "0x" as Hex]
+      : parseFactoryAddressFromAccountInitCode(initCode)
+  );
+
+  const callData = Array.isArray(uo)
+    ? account.encodeBatchExecute(uo)
+    : typeof uo === "string"
+    ? uo
+    : account.encodeExecute(uo);
+
+  const signature = account.getDummySignature();
+
+  const nonce = account.getNonce(overrides?.nonceKey);
+
+  const _uo =
+    entryPoint.version === "0.6.0"
+      ? ({
+          initCode: getInitCode,
+          sender: account.address,
+          nonce,
+          callData,
+          signature,
+        } as Deferrable<UserOperationStruct<TEntryPointVersion>>)
+      : ({
+          factory: getFactoryAndData.then(([factory]) => factory),
+          factoryData: getFactoryAndData.then(([, data]) => data),
+          sender: account.address,
+          nonce,
+          callData,
+          signature,
+        } as Deferrable<UserOperationStruct<TEntryPointVersion>>);
+
   return _runMiddlewareStack(client, {
-    uo: {
-      initCode: account.getInitCode(),
-      sender: account.address,
-      nonce: account.getNonce(overrides?.nonceKey),
-      callData: Array.isArray(uo)
-        ? account.encodeBatchExecute(uo)
-        : typeof uo === "string"
-        ? uo
-        : account.encodeExecute(uo),
-      signature: account.getDummySignature(),
-    } as Deferrable<UserOperationStruct>,
+    uo: _uo,
     overrides,
     account,
     context,
   });
-};
+}

--- a/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
+++ b/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
@@ -1,6 +1,7 @@
 import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
+import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import type { UserOperationStruct } from "../../types.js";
 import { buildUserOperation } from "./buildUserOperation.js";
@@ -19,6 +20,12 @@ export const checkGasSponsorshipEligibility: <
   client: Client<TTransport, TChain, TAccount>,
   args: SendUserOperationParameters<TAccount, TContext>
 ) => Promise<boolean> = async (client, args) => {
+  const { account = client.account } = args;
+
+  if (!account) {
+    throw new AccountNotFoundError();
+  }
+
   if (!isBaseSmartAccountClient(client)) {
     throw new IncompatibleClientError(
       "BaseSmartAccountClient",
@@ -28,10 +35,16 @@ export const checkGasSponsorshipEligibility: <
   }
 
   return buildUserOperation(client, args)
-    .then(
-      (userOperationStruct: UserOperationStruct) =>
-        userOperationStruct.paymasterAndData !== "0x" &&
-        userOperationStruct.paymasterAndData !== null
+    .then((userOperationStruct) =>
+      account.getEntryPoint().version === "0.6.0"
+        ? (userOperationStruct as UserOperationStruct<"0.6.0">)
+            .paymasterAndData !== "0x" &&
+          (userOperationStruct as UserOperationStruct<"0.6.0">)
+            .paymasterAndData !== null
+        : (userOperationStruct as UserOperationStruct<"0.7.0">)
+            .paymasterData !== "0x" &&
+          (userOperationStruct as UserOperationStruct<"0.7.0">)
+            .paymasterData !== null
     )
     .catch(() => false);
 };

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -1,16 +1,23 @@
 import type { Chain, Client, Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../../account/smartContractAccount";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import type { SendUserOperationResult } from "../../client/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
-import type { UserOperationOverrides, UserOperationStruct } from "../../types";
+import type {
+  UserOperationOverrides,
+  UserOperationRequest,
+  UserOperationStruct,
+} from "../../types";
 import { bigIntMax, bigIntMultiply } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { DropAndReplaceUserOperationParameters } from "./types";
 
-export const dropAndReplaceUserOperation: <
+export async function dropAndReplaceUserOperation<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
@@ -18,11 +25,12 @@ export const dropAndReplaceUserOperation: <
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: DropAndReplaceUserOperationParameters<TAccount, TContext>
-) => Promise<SendUserOperationResult> = async (client, args) => {
+): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account, uoToDrop, overrides } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -35,13 +43,26 @@ export const dropAndReplaceUserOperation: <
     );
   }
 
-  const uoToSubmit = {
-    initCode: uoToDrop.initCode,
-    sender: uoToDrop.sender,
-    nonce: uoToDrop.nonce,
-    callData: uoToDrop.callData,
-    signature: uoToDrop.signature,
-  } as UserOperationStruct;
+  const entryPoint = account.getEntryPoint();
+
+  const uoToSubmit = (
+    entryPoint.version === "0.6.0"
+      ? {
+          initCode: (uoToDrop as UserOperationRequest<"0.6.0">).initCode,
+          sender: (uoToDrop as UserOperationRequest<"0.6.0">).sender,
+          nonce: (uoToDrop as UserOperationRequest<"0.6.0">).nonce,
+          callData: (uoToDrop as UserOperationRequest<"0.6.0">).callData,
+          signature: (uoToDrop as UserOperationRequest<"0.6.0">).signature,
+        }
+      : {
+          factory: (uoToDrop as UserOperationRequest<"0.7.0">).factory,
+          factoryData: (uoToDrop as UserOperationRequest<"0.7.0">).factoryData,
+          sender: (uoToDrop as UserOperationRequest<"0.7.0">).sender,
+          nonce: (uoToDrop as UserOperationRequest<"0.7.0">).nonce,
+          callData: (uoToDrop as UserOperationRequest<"0.7.0">).callData,
+          signature: (uoToDrop as UserOperationRequest<"0.7.0">).signature,
+        }
+  ) as UserOperationStruct<TEntryPointVersion>;
 
   // Run once to get the fee estimates
   // This can happen at any part of the middleware stack, so we want to run it all
@@ -54,17 +75,24 @@ export const dropAndReplaceUserOperation: <
     }
   );
 
-  const _overrides: UserOperationOverrides = {
+  const _overrides = {
     ...overrides,
     maxFeePerGas: bigIntMax(
       BigInt(maxFeePerGas ?? 0n),
-      bigIntMultiply(uoToDrop.maxFeePerGas, 1.1)
+      bigIntMultiply(
+        (uoToDrop as UserOperationRequest<TEntryPointVersion>).maxFeePerGas,
+        1.1
+      )
     ),
     maxPriorityFeePerGas: bigIntMax(
       BigInt(maxPriorityFeePerGas ?? 0n),
-      bigIntMultiply(uoToDrop.maxPriorityFeePerGas, 1.1)
+      bigIntMultiply(
+        (uoToDrop as UserOperationRequest<TEntryPointVersion>)
+          .maxPriorityFeePerGas,
+        1.1
+      )
     ),
-  };
+  } as UserOperationOverrides<TEntryPointVersion>;
 
   const uoToSend = await _runMiddlewareStack(client, {
     uo: uoToSubmit,
@@ -72,5 +100,8 @@ export const dropAndReplaceUserOperation: <
     account,
   });
 
-  return _sendUserOperation(client, { uoStruct: uoToSend, account });
-};
+  return _sendUserOperation(client, {
+    uoStruct: uoToSend,
+    account,
+  });
+}

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -55,8 +55,14 @@ export async function dropAndReplaceUserOperation<
           signature: (uoToDrop as UserOperationRequest<"0.6.0">).signature,
         }
       : {
-          factory: (uoToDrop as UserOperationRequest<"0.7.0">).factory,
-          factoryData: (uoToDrop as UserOperationRequest<"0.7.0">).factoryData,
+          ...((uoToDrop as UserOperationRequest<"0.7.0">).factory &&
+          (uoToDrop as UserOperationRequest<"0.7.0">).factoryData
+            ? {
+                factory: (uoToDrop as UserOperationRequest<"0.7.0">).factory,
+                factoryData: (uoToDrop as UserOperationRequest<"0.7.0">)
+                  .factoryData,
+              }
+            : {}),
           sender: (uoToDrop as UserOperationRequest<"0.7.0">).sender,
           nonce: (uoToDrop as UserOperationRequest<"0.7.0">).nonce,
           callData: (uoToDrop as UserOperationRequest<"0.7.0">).callData,

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -85,18 +85,11 @@ export async function dropAndReplaceUserOperation<
     ...overrides,
     maxFeePerGas: bigIntMax(
       BigInt(maxFeePerGas ?? 0n),
-      bigIntMultiply(
-        (uoToDrop as UserOperationRequest<TEntryPointVersion>).maxFeePerGas,
-        1.1
-      )
+      bigIntMultiply(uoToDrop.maxFeePerGas, 1.1)
     ),
     maxPriorityFeePerGas: bigIntMax(
       BigInt(maxPriorityFeePerGas ?? 0n),
-      bigIntMultiply(
-        (uoToDrop as UserOperationRequest<TEntryPointVersion>)
-          .maxPriorityFeePerGas,
-        1.1
-      )
+      bigIntMultiply(uoToDrop.maxPriorityFeePerGas, 1.1)
     ),
   } as UserOperationOverrides<TEntryPointVersion>;
 

--- a/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
+++ b/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
@@ -69,7 +69,7 @@ export async function _runMiddlewareStack<
     client.middleware.signUserOperation
   )(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
 
-  return resolveProperties(result) as Promise<
+  return resolveProperties<
     UserOperationStruct<GetEntryPointFromAccount<TAccount>>
-  >;
+  >(result);
 }

--- a/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
+++ b/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
@@ -1,6 +1,7 @@
 import type { Chain, Transport } from "viem";
 import type {
   GetAccountParameter,
+  GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../../../account/smartContractAccount";
 import type { BaseSmartAccountClient } from "../../../client/smartAccountClient";
@@ -8,6 +9,7 @@ import { AccountNotFoundError } from "../../../errors/account.js";
 import { overridePaymasterDataMiddleware } from "../../../middleware/defaults/overridePaymasterData.js";
 import type {
   UserOperationOverrides,
+  UserOperationOverridesParameter,
   UserOperationStruct,
 } from "../../../types";
 import { resolveProperties, type Deferrable } from "../../../utils/index.js";
@@ -22,7 +24,7 @@ const asyncPipe =
     return result;
   };
 
-export const _runMiddlewareStack: <
+export async function _runMiddlewareStack<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
@@ -30,30 +32,44 @@ export const _runMiddlewareStack: <
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: BaseSmartAccountClient<TTransport, TChain, TAccount>,
   args: {
-    uo: Deferrable<UserOperationStruct>;
-    overrides?: UserOperationOverrides;
+    uo: Deferrable<UserOperationStruct<TEntryPointVersion>>;
     context?: TContext;
-  } & GetAccountParameter<TAccount>
-) => Promise<UserOperationStruct> = async (client, args) => {
+  } & GetAccountParameter<TAccount> &
+    UserOperationOverridesParameter<TEntryPointVersion>
+): Promise<UserOperationStruct<TEntryPointVersion>> {
   const { uo, overrides, account = client.account, context } = args;
   if (!account) {
     throw new AccountNotFoundError();
   }
+
+  const entryPoint = account.getEntryPoint();
+
+  const overridePaymasterData =
+    overrides &&
+    ((entryPoint.version === "0.6.0" &&
+      (overrides as UserOperationOverrides<"0.6.0">).paymasterAndData !=
+        null) ||
+      (entryPoint.version === "0.7.0" &&
+        (overrides as UserOperationOverrides<"0.7.0">).paymasterData != null));
+
   const result = await asyncPipe(
     client.middleware.dummyPaymasterAndData,
     client.middleware.feeEstimator,
     client.middleware.gasEstimator,
     client.middleware.customMiddleware,
-    overrides?.paymasterAndData
+    overridePaymasterData
       ? overridePaymasterDataMiddleware
       : client.middleware.paymasterAndData,
     client.middleware.userOperationSimulator,
     client.middleware.signUserOperation
   )(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
 
-  return resolveProperties<UserOperationStruct>(result);
-};
+  return resolveProperties(result) as Promise<
+    UserOperationStruct<GetEntryPointFromAccount<TAccount>>
+  >;
+}

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -46,13 +46,7 @@ export async function _sendUserOperation<
   console.log("request", client.chain.name, request);
 
   request.signature = await account.signUserOperationHash(
-    entryPoint.version === "0.6.0"
-      ? entryPoint.getUserOperationHash(
-          request as UserOperationRequest<"0.6.0">
-        )
-      : entryPoint.getUserOperationHash(
-          request as UserOperationRequest<"0.7.0">
-        )
+    entryPoint.getUserOperationHash(request)
   );
 
   return {

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -1,6 +1,7 @@
 import type { Chain, Transport } from "viem";
 import type {
   GetAccountParameter,
+  GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../../../account/smartContractAccount";
 import type { BaseSmartAccountClient } from "../../../client/smartAccountClient";
@@ -8,19 +9,22 @@ import type { SendUserOperationResult } from "../../../client/types";
 import { AccountNotFoundError } from "../../../errors/account.js";
 import { ChainNotFoundError } from "../../../errors/client.js";
 import { InvalidUserOperationError } from "../../../errors/useroperation.js";
-import type { UserOperationStruct } from "../../../types";
+import type { UserOperationRequest, UserOperationStruct } from "../../../types";
 import { deepHexlify, isValidRequest } from "../../../utils/index.js";
 
-export const _sendUserOperation: <
+export async function _sendUserOperation<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: BaseSmartAccountClient<TTransport, TChain, TAccount>,
-  args: { uoStruct: UserOperationStruct } & GetAccountParameter<TAccount>
-) => Promise<SendUserOperationResult> = async (client, args) => {
+  args: {
+    uoStruct: UserOperationStruct<TEntryPointVersion>;
+  } & GetAccountParameter<TAccount>
+): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -30,16 +34,27 @@ export const _sendUserOperation: <
     throw new ChainNotFoundError();
   }
 
-  const request = deepHexlify(args.uoStruct);
+  const entryPoint = account.getEntryPoint();
+
+  const request = deepHexlify(
+    args.uoStruct
+  ) as UserOperationRequest<TEntryPointVersion>;
   if (!isValidRequest(request)) {
     throw new InvalidUserOperationError(args.uoStruct);
   }
 
+  request.signature = await account.signUserOperationHash(
+    entryPoint.version === "0.6.0"
+      ? entryPoint.getUserOperationHash(
+          request as UserOperationRequest<"0.6.0">
+        )
+      : entryPoint.getUserOperationHash(
+          request as UserOperationRequest<"0.7.0">
+        )
+  );
+
   return {
-    hash: await client.sendRawUserOperation(
-      request,
-      account.getEntryPoint().address
-    ),
+    hash: await client.sendRawUserOperation(request, entryPoint.address),
     request,
   };
-};
+}

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -43,6 +43,8 @@ export async function _sendUserOperation<
     throw new InvalidUserOperationError(args.uoStruct);
   }
 
+  console.log("request", client.chain.name, request);
+
   request.signature = await account.signUserOperationHash(
     entryPoint.version === "0.6.0"
       ? entryPoint.getUserOperationHash(

--- a/packages/core/src/actions/smartAccount/sendTransaction.ts
+++ b/packages/core/src/actions/smartAccount/sendTransaction.ts
@@ -13,10 +13,7 @@ import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { TransactionMissingToParamError } from "../../errors/transaction.js";
-import type {
-  UserOperationOverrides,
-  UserOperationStruct,
-} from "../../types.js";
+import type { UserOperationOverrides } from "../../types.js";
 import { buildUserOperationFromTx } from "./buildUserOperationFromTx.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
@@ -62,7 +59,7 @@ export async function sendTransaction<
   );
   const { hash } = await _sendUserOperation(client, {
     account: account as SmartContractAccount,
-    uoStruct: uoStruct as UserOperationStruct<TEntryPointVersion>,
+    uoStruct,
   });
 
   return waitForUserOperationTransaction(client, { hash });

--- a/packages/core/src/actions/smartAccount/sendTransactions.ts
+++ b/packages/core/src/actions/smartAccount/sendTransactions.ts
@@ -8,19 +8,17 @@ import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { SendTransactionsParameters } from "./types";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
-export const sendTransactions: <
+export async function sendTransactions<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
-    | undefined
+  TContext extends Record<string, any> | undefined = Record<string, any>
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: SendTransactionsParameters<TAccount, TContext>
-) => Promise<Hex> = async (client, args) => {
+): Promise<Hex> {
   const { requests, overrides, account = client.account } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -41,9 +39,9 @@ export const sendTransactions: <
   });
 
   const { hash } = await _sendUserOperation(client, {
-    account: account as SmartContractAccount,
+    account,
     uoStruct,
   });
 
   return waitForUserOperationTransaction(client, { hash });
-};
+}

--- a/packages/core/src/actions/smartAccount/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/sendUserOperation.ts
@@ -1,5 +1,8 @@
 import type { Chain, Client, Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount.js";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import type { SendUserOperationResult } from "../../client/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
@@ -16,11 +19,15 @@ export const sendUserOperation: <
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: SendUserOperationParameters<TAccount, TContext>
-) => Promise<SendUserOperationResult> = async (client, args) => {
+) => Promise<SendUserOperationResult<TEntryPointVersion>> = async (
+  client,
+  args
+) => {
   const { account = client.account } = args;
 
   if (!account) {
@@ -36,5 +43,8 @@ export const sendUserOperation: <
   }
 
   const uoStruct = await buildUserOperation(client, args);
-  return _sendUserOperation(client, { account, uoStruct });
+  return _sendUserOperation(client, {
+    account,
+    uoStruct,
+  });
 };

--- a/packages/core/src/actions/smartAccount/signMessage.ts
+++ b/packages/core/src/actions/smartAccount/signMessage.ts
@@ -24,6 +24,5 @@ export const signMessage: <
   if (!account) {
     throw new AccountNotFoundError();
   }
-
   return account.signMessage({ message });
 };

--- a/packages/core/src/actions/smartAccount/types.ts
+++ b/packages/core/src/actions/smartAccount/types.ts
@@ -1,13 +1,18 @@
 import type { Hex, RpcTransactionRequest } from "viem";
 import type {
   GetAccountParameter,
+  GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
 import type { UpgradeToData } from "../../client/types";
 import type {
+  DefaultEntryPointVersion,
+  EntryPointVersion,
+} from "../../entrypoint/types";
+import type {
   BatchUserOperationCallData,
   UserOperationCallData,
-  UserOperationOverrides,
+  UserOperationOverridesParameter,
   UserOperationRequest,
   UserOperationStruct,
 } from "../../types";
@@ -18,13 +23,14 @@ export type UpgradeAccountParams<
   TAccount extends SmartContractAccount | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   upgradeTo: UpgradeToData;
-  overrides?: UserOperationOverrides;
   waitForTx?: boolean;
 } & GetAccountParameter<TAccount> &
-  GetContextParameter<TContext>;
+  GetContextParameter<TContext> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion UpgradeAccountParams
 
 //#region SendUserOperationParameters
@@ -32,19 +38,23 @@ export type SendUserOperationParameters<
   TAccount extends SmartContractAccount | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   uo: UserOperationCallData | BatchUserOperationCallData;
-  overrides?: UserOperationOverrides;
 } & GetAccountParameter<TAccount> &
-  GetContextParameter<TContext>;
+  GetContextParameter<TContext> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendUserOperationParameters
 
 //#region SignUserOperationParameters
 export type SignUserOperationParameters<
-  TAccount extends SmartContractAccount | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
-  uoStruct: UserOperationStruct;
+  uoStruct: UserOperationStruct<TEntryPointVersion>;
 } & GetAccountParameter<TAccount>;
 //#endregion SignUserOperationParameters
 
@@ -53,12 +63,13 @@ export type SendTransactionsParameters<
   TAccount extends SmartContractAccount | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   requests: RpcTransactionRequest[];
-  overrides?: UserOperationOverrides;
 } & GetAccountParameter<TAccount> &
-  GetContextParameter<TContext>;
+  GetContextParameter<TContext> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendTransactionsParameters
 
 //#region DropAndReplaceUserOperationParameters
@@ -66,12 +77,13 @@ export type DropAndReplaceUserOperationParameters<
   TAccount extends SmartContractAccount | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
-  uoToDrop: UserOperationRequest;
-  overrides?: UserOperationOverrides;
+  uoToDrop: UserOperationRequest<TEntryPointVersion>;
 } & GetAccountParameter<TAccount> &
-  GetContextParameter<TContext>;
+  GetContextParameter<TContext> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion DropAndReplaceUserOperationParameters
 
 //#region WaitForUserOperationTxParameters
@@ -81,11 +93,12 @@ export type WaitForUserOperationTxParameters = {
 //#endregion WaitForUserOperationTxParameters
 
 //#region BuildUserOperationFromTransactionsResult
-export type BuildUserOperationFromTransactionsResult = {
-  uoStruct: UserOperationStruct;
+export type BuildUserOperationFromTransactionsResult<
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+> = {
+  uoStruct: UserOperationStruct<TEntryPointVersion>;
   batch: BatchUserOperationCallData;
-  overrides: UserOperationOverrides;
-};
+} & UserOperationOverridesParameter<TEntryPointVersion, true>;
 //#endregion BuildUserOperationFromTransactionsResult
 
 export type GetContextParameter<

--- a/packages/core/src/client/decorators/bundlerClient.ts
+++ b/packages/core/src/client/decorators/bundlerClient.ts
@@ -12,10 +12,7 @@ import { getSupportedEntryPoints } from "../../actions/bundler/getSupportedEntry
 import { getUserOperationByHash } from "../../actions/bundler/getUserOperationByHash.js";
 import { getUserOperationReceipt } from "../../actions/bundler/getUserOperationReceipt.js";
 import { sendRawUserOperation } from "../../actions/bundler/sendRawUserOperation.js";
-import type {
-  DefaultEntryPointVersion,
-  EntryPointVersion,
-} from "../../entrypoint/types.js";
+import type { EntryPointVersion } from "../../entrypoint/types.js";
 import type {
   UserOperationEstimateGasResponse,
   UserOperationReceipt,
@@ -69,7 +66,7 @@ export type BundlerActions = {
    * @returns the gas estimates for the given response (see: {@link UserOperationEstimateGasResponse})
    */
   estimateUserOperationGas<
-    TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+    TEntryPointVersion extends EntryPointVersion = EntryPointVersion
   >(
     request: UserOperationRequest<TEntryPointVersion>,
     entryPoint: Address,
@@ -84,7 +81,7 @@ export type BundlerActions = {
    * @returns the hash of the sent UserOperation
    */
   sendRawUserOperation<
-    TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+    TEntryPointVersion extends EntryPointVersion = EntryPointVersion
   >(
     request: UserOperationRequest<TEntryPointVersion>,
     entryPoint: Address

--- a/packages/core/src/client/decorators/bundlerClient.ts
+++ b/packages/core/src/client/decorators/bundlerClient.ts
@@ -13,9 +13,15 @@ import { getUserOperationByHash } from "../../actions/bundler/getUserOperationBy
 import { getUserOperationReceipt } from "../../actions/bundler/getUserOperationReceipt.js";
 import { sendRawUserOperation } from "../../actions/bundler/sendRawUserOperation.js";
 import type {
+  DefaultEntryPointVersion,
+  EntryPointVersion,
+} from "../../entrypoint/types.js";
+import type {
   UserOperationEstimateGasResponse,
   UserOperationReceipt,
   UserOperationRequest,
+  UserOperationRequest_v6,
+  UserOperationRequest_v7,
   UserOperationResponse,
 } from "../../types.js";
 
@@ -23,12 +29,16 @@ import type {
 export type BundlerRpcSchema = [
   {
     Method: "eth_sendUserOperation";
-    Parameters: [UserOperationRequest, Address];
+    Parameters: [UserOperationRequest_v6 | UserOperationRequest_v7, Address];
     ReturnType: Hash;
   },
   {
     Method: "eth_estimateUserOperationGas";
-    Parameters: [UserOperationRequest, Address, StateOverride?];
+    Parameters: [
+      UserOperationRequest_v6 | UserOperationRequest_v7,
+      Address,
+      StateOverride?
+    ];
     ReturnType: UserOperationEstimateGasResponse;
   },
   {
@@ -39,7 +49,7 @@ export type BundlerRpcSchema = [
   {
     Method: "eth_getUserOperationByHash";
     Parameters: [Hash];
-    ReturnType: UserOperationResponse | null;
+    ReturnType: UserOperationResponse<EntryPointVersion> | null;
   },
   {
     Method: "eth_supportedEntryPoints";
@@ -58,8 +68,10 @@ export type BundlerActions = {
    * @params stateOverride - the state override to use for the estimation
    * @returns the gas estimates for the given response (see: {@link UserOperationEstimateGasResponse})
    */
-  estimateUserOperationGas(
-    request: UserOperationRequest,
+  estimateUserOperationGas<
+    TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+  >(
+    request: UserOperationRequest<TEntryPointVersion>,
     entryPoint: Address,
     stateOverride?: StateOverride
   ): Promise<UserOperationEstimateGasResponse>;
@@ -71,8 +83,10 @@ export type BundlerActions = {
    * @param entryPoint - the entry point address the op will be sent to
    * @returns the hash of the sent UserOperation
    */
-  sendRawUserOperation(
-    request: UserOperationRequest,
+  sendRawUserOperation<
+    TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+  >(
+    request: UserOperationRequest<TEntryPointVersion>,
     entryPoint: Address
   ): Promise<Hash>;
 
@@ -82,19 +96,20 @@ export type BundlerActions = {
    * @param hash - the hash of the UserOperation to fetch
    * @returns - {@link UserOperationResponse}
    */
-  getUserOperationByHash(hash: Hash): Promise<UserOperationResponse | null>;
+  getUserOperationByHash(
+    hash: Hash
+  ): Promise<UserOperationResponse<EntryPointVersion> | null>;
 
   /**
    * calls `eth_getUserOperationReceipt` and returns the {@link UserOperationReceipt}
    *
    * @param hash - the hash of the UserOperation to get the receipt for
-   * @returns - {@link UserOperationResponse}
+   * @returns - {@link UserOperationReceipt}
    */
   getUserOperationReceipt(hash: Hash): Promise<UserOperationReceipt | null>;
 
   /**
-   * calls `eth_supportedEntryPoints` and returns the entry points the RPC
-   * supports
+   * calls `eth_supportedEntryPoints` and returns the entry points the RPC supports
    * @returns - {@link Address}[]
    */
   getSupportedEntryPoints(): Promise<Address[]>;

--- a/packages/core/src/client/decorators/smartAccountClient.ts
+++ b/packages/core/src/client/decorators/smartAccountClient.ts
@@ -1,15 +1,16 @@
-import type {
-  Address,
-  Chain,
-  Client,
-  Hex,
-  SendTransactionParameters,
-  Transport,
-  TypedData,
-  WaitForTransactionReceiptParameters,
+import {
+  type Address,
+  type Chain,
+  type Client,
+  type Hex,
+  type SendTransactionParameters,
+  type Transport,
+  type TypedData,
+  type WaitForTransactionReceiptParameters,
 } from "viem";
 import type {
   GetAccountParameter,
+  GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
 import { buildUserOperation } from "../../actions/smartAccount/buildUserOperation.js";
@@ -58,19 +59,20 @@ export type BaseSmartAccountClientActions<
     | undefined,
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   buildUserOperation: (
     args: SendUserOperationParameters<TAccount, TContext>
-  ) => Promise<UserOperationStruct>;
+  ) => Promise<UserOperationStruct<TEntryPointVersion>>;
   buildUserOperationFromTx: (
     args: SendTransactionParameters<TChain, TAccount>,
-    overrides?: UserOperationOverrides,
+    overrides?: UserOperationOverrides<TEntryPointVersion>,
     context?: TContext
-  ) => Promise<UserOperationStruct>;
+  ) => Promise<UserOperationStruct<TEntryPointVersion>>;
   buildUserOperationFromTxs: (
     args: SendTransactionsParameters<TAccount, TContext>
-  ) => Promise<BuildUserOperationFromTransactionsResult>;
+  ) => Promise<BuildUserOperationFromTransactionsResult<TEntryPointVersion>>;
   checkGasSponsorshipEligibility: <
     TContext extends Record<string, any> | undefined =
       | Record<string, any>
@@ -80,15 +82,15 @@ export type BaseSmartAccountClientActions<
   ) => Promise<boolean>;
   signUserOperation: (
     args: SignUserOperationParameters<TAccount>
-  ) => Promise<UserOperationRequest>;
+  ) => Promise<UserOperationRequest<TEntryPointVersion>>;
   dropAndReplaceUserOperation: (
     args: DropAndReplaceUserOperationParameters<TAccount, TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   // TODO: for v4 we should combine override and context into an `opts` parameter
   // which wraps both of these properties so we can use GetContextParameter
   sendTransaction: <TChainOverride extends Chain | undefined = undefined>(
     args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
-    overrides?: UserOperationOverrides,
+    overrides?: UserOperationOverrides<TEntryPointVersion>,
     context?: TContext
   ) => Promise<Hex>;
   sendTransactions: (
@@ -96,7 +98,7 @@ export type BaseSmartAccountClientActions<
   ) => Promise<Hex>;
   sendUserOperation: (
     args: SendUserOperationParameters<TAccount, TContext>
-  ) => Promise<SendUserOperationResult>;
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   waitForUserOperationTransaction: (
     args: WaitForTransactionReceiptParameters
   ) => Promise<Hex>;
@@ -118,13 +120,11 @@ export type BaseSmartAccountClientActions<
     args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>
   ) => Promise<Hex>;
 } & (IsUndefined<TAccount> extends false
-  ? {
-      getAddress: () => Address;
-    }
+  ? { getAddress: () => Address }
   : {
       getAddress: (args: GetAccountParameter<TAccount>) => Address;
     });
-//#endregion SmartAccountClientActions
+// #endregion SmartAccountClientActions
 
 export const smartAccountClientActions: <
   TTransport extends Transport = Transport,

--- a/packages/core/src/client/types.ts
+++ b/packages/core/src/client/types.ts
@@ -1,6 +1,7 @@
 import type { Address } from "abitype";
 import type { Hash, Hex } from "viem";
 import type { z } from "zod";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import type {
   ClientMiddleware,
   ClientMiddlewareFn,
@@ -15,9 +16,11 @@ export type ConnectorData = {
 export type ConnectionConfig = z.input<typeof ConnectionConfigSchema>;
 
 //#region SendUserOperationResult
-export type SendUserOperationResult = {
+export type SendUserOperationResult<
+  TEntryPointVersion extends EntryPointVersion
+> = {
   hash: Hash;
-  request: UserOperationRequest;
+  request: UserOperationRequest<TEntryPointVersion>;
 };
 //#endregion SendUserOperationResult
 

--- a/packages/core/src/entrypoint/0.6.ts
+++ b/packages/core/src/entrypoint/0.6.ts
@@ -1,28 +1,105 @@
-import type { Address, Chain } from "viem";
-import type { UserOperationRequest } from "../types";
 import {
-  getDefaultEntryPointAddress,
-  getUserOperationHash,
-  packUo,
-} from "../utils/index.js";
-import type { EntryPointDef } from "./types";
+  encodeAbiParameters,
+  hexToBigInt,
+  keccak256,
+  type Address,
+  type Chain,
+  type Hash,
+  type Hex,
+} from "viem";
+import {
+  arbitrum,
+  arbitrumGoerli,
+  arbitrumSepolia,
+  base,
+  baseGoerli,
+  baseSepolia,
+  goerli,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  polygonMumbai,
+  sepolia,
+} from "viem/chains";
+import { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6.js";
+import type { UserOperationRequest } from "../types.js";
+import type { SupportedEntryPoint } from "./types.js";
 
-export const getVersion060EntryPoint: (
-  chain: Chain,
-  address?: Address
-) => EntryPointDef<UserOperationRequest> = (
-  chain: Chain,
-  address = getDefaultEntryPointAddress(chain)
-) => {
-  return {
-    version: "0.6.0",
-    address,
-    chain,
-    packUserOperation: (userOperation: UserOperationRequest) => {
-      return packUo(userOperation);
-    },
-    getUserOperationHash: (userOperation: UserOperationRequest) => {
-      return getUserOperationHash(userOperation, address, chain.id);
-    },
-  } satisfies EntryPointDef<UserOperationRequest>;
+const packUserOperation = (request: UserOperationRequest<"0.6.0">): Hex => {
+  const hashedInitCode = keccak256(request.initCode);
+  const hashedCallData = keccak256(request.callData);
+  const hashedPaymasterAndData = keccak256(request.paymasterAndData);
+
+  return encodeAbiParameters(
+    [
+      { type: "address" },
+      { type: "uint256" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "bytes32" },
+    ],
+    [
+      request.sender as Address,
+      hexToBigInt(request.nonce),
+      hashedInitCode,
+      hashedCallData,
+      hexToBigInt(request.callGasLimit),
+      hexToBigInt(request.verificationGasLimit),
+      hexToBigInt(request.preVerificationGas),
+      hexToBigInt(request.maxFeePerGas),
+      hexToBigInt(request.maxPriorityFeePerGas),
+      hashedPaymasterAndData,
+    ]
+  );
 };
+
+export default {
+  version: "0.6.0",
+
+  address: {
+    [mainnet.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [sepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [goerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [polygon.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [polygonMumbai.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [polygonAmoy.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [optimism.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [optimismGoerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [optimismSepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [arbitrum.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [arbitrumGoerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [arbitrumSepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [base.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [baseGoerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [baseSepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+  },
+
+  abi: EntryPointAbi_v6,
+
+  getUserOperationHash: (
+    request: UserOperationRequest<"0.6.0">,
+    entryPointAddress: Address,
+    chainId: number
+  ): Hash => {
+    const encoded = encodeAbiParameters(
+      [{ type: "bytes32" }, { type: "address" }, { type: "uint256" }],
+      [
+        keccak256(packUserOperation(request)),
+        entryPointAddress,
+        BigInt(chainId),
+      ]
+    );
+
+    return keccak256(encoded);
+  },
+
+  packUserOperation,
+} as SupportedEntryPoint<"0.6.0", Chain, typeof EntryPointAbi_v6>;

--- a/packages/core/src/entrypoint/0.6.ts
+++ b/packages/core/src/entrypoint/0.6.ts
@@ -102,4 +102,4 @@ export default {
   },
 
   packUserOperation,
-} as SupportedEntryPoint<"0.6.0", Chain, typeof EntryPointAbi_v6>;
+} satisfies SupportedEntryPoint<"0.6.0", Chain, typeof EntryPointAbi_v6>;

--- a/packages/core/src/entrypoint/0.7.ts
+++ b/packages/core/src/entrypoint/0.7.ts
@@ -135,7 +135,7 @@ export default {
   },
 
   packUserOperation,
-} as SupportedEntryPoint<"0.7.0", Chain, typeof EntryPointAbi_v7>;
+} satisfies SupportedEntryPoint<"0.7.0", Chain, typeof EntryPointAbi_v7>;
 
 export function packAccountGasLimits(
   data:

--- a/packages/core/src/entrypoint/0.7.ts
+++ b/packages/core/src/entrypoint/0.7.ts
@@ -1,0 +1,172 @@
+import {
+  concat,
+  encodeAbiParameters,
+  hexToBigInt,
+  isAddress,
+  keccak256,
+  pad,
+  type Address,
+  type Chain,
+  type Hash,
+  type Hex,
+} from "viem";
+import {
+  arbitrum,
+  arbitrumGoerli,
+  arbitrumSepolia,
+  base,
+  baseGoerli,
+  baseSepolia,
+  goerli,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  polygonMumbai,
+  sepolia,
+} from "viem/chains";
+import { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7.js";
+import type {
+  UserOperationRequest,
+  UserOperationRequest_v7,
+} from "../types.js";
+import type { SupportedEntryPoint } from "./types.js";
+
+const packUserOperation = (request: UserOperationRequest<"0.7.0">): Hex => {
+  const initCode = concat([request.factory, request.factoryData]);
+  const accountGasLimits = packAccountGasLimits(
+    (({ verificationGasLimit, callGasLimit }) => ({
+      verificationGasLimit,
+      callGasLimit,
+    }))(request)
+  );
+
+  const gasFees = packAccountGasLimits(
+    (({ maxPriorityFeePerGas, maxFeePerGas }) => ({
+      maxPriorityFeePerGas,
+      maxFeePerGas,
+    }))(request)
+  );
+
+  const paymasterAndData = isAddress(request.paymaster)
+    ? packPaymasterData(
+        (({
+          paymaster,
+          paymasterVerificationGasLimit,
+          paymasterPostOpGasLimit,
+          paymasterData,
+        }) => ({
+          paymaster,
+          paymasterVerificationGasLimit,
+          paymasterPostOpGasLimit,
+          paymasterData,
+        }))(request)
+      )
+    : "0x";
+
+  return encodeAbiParameters(
+    [
+      { type: "address" },
+      { type: "uint256" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+      { type: "uint256" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+    ],
+    [
+      request.sender as Address,
+      hexToBigInt(request.nonce),
+      keccak256(initCode),
+      keccak256(request.callData),
+      accountGasLimits,
+      hexToBigInt(request.preVerificationGas),
+      gasFees,
+      paymasterAndData,
+    ]
+  );
+};
+
+export default {
+  version: "0.7.0",
+
+  address: {
+    [mainnet.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [sepolia.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [goerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [polygon.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [polygonMumbai.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [polygonAmoy.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [optimism.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [optimismGoerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [optimismSepolia.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [arbitrum.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [arbitrumGoerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [arbitrumSepolia.id]: "0x000000071727De22E5E9d8BAf0edAc6f37da032",
+    [base.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [baseGoerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [baseSepolia.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+  },
+
+  abi: EntryPointAbi_v7,
+
+  getUserOperationHash: (
+    request: UserOperationRequest<"0.7.0">,
+    entryPointAddress: Address,
+    chainId: number
+  ): Hash => {
+    const encoded = encodeAbiParameters(
+      [{ type: "bytes32" }, { type: "address" }, { type: "uint256" }],
+      [
+        keccak256(packUserOperation(request)),
+        entryPointAddress,
+        BigInt(chainId),
+      ]
+    );
+
+    return keccak256(encoded);
+  },
+
+  packUserOperation,
+} as SupportedEntryPoint<"0.7.0", Chain, typeof EntryPointAbi_v7>;
+
+export function packAccountGasLimits(
+  data:
+    | Pick<UserOperationRequest_v7, "verificationGasLimit" | "callGasLimit">
+    | Pick<UserOperationRequest_v7, "maxPriorityFeePerGas" | "maxFeePerGas">
+): Hex {
+  return concat(Object.values(data).map((v) => pad(v, { size: 16 })));
+}
+
+export function packPaymasterData({
+  paymaster,
+  paymasterVerificationGasLimit,
+  paymasterPostOpGasLimit,
+  paymasterData,
+}: Pick<
+  UserOperationRequest_v7,
+  | "paymaster"
+  | "paymasterVerificationGasLimit"
+  | "paymasterPostOpGasLimit"
+  | "paymasterData"
+>): Hex {
+  return concat([
+    paymaster,
+    pad(paymasterVerificationGasLimit, { size: 16 }),
+    pad(paymasterPostOpGasLimit, { size: 16 }),
+    paymasterData,
+  ]);
+}
+
+export function unpackAccountGasLimits(accountGasLimits: string): {
+  verificationGasLimit: number;
+  callGasLimit: number;
+} {
+  return {
+    verificationGasLimit: parseInt(accountGasLimits.slice(2, 34), 16),
+    callGasLimit: parseInt(accountGasLimits.slice(34), 16),
+  };
+}

--- a/packages/core/src/entrypoint/index.ts
+++ b/packages/core/src/entrypoint/index.ts
@@ -66,9 +66,6 @@ export function getEntryPoint<
       version: entryPoint.version,
       address,
       chain,
-      // we should fix this so it's not required
-      // this is why satisfies didn't work before
-      overrides: undefined,
       abi: entryPoint.abi,
       getUserOperationHash: (r) =>
         entryPoint.getUserOperationHash(r, address, chain.id),
@@ -79,9 +76,6 @@ export function getEntryPoint<
       version: entryPoint.version,
       address,
       chain,
-      // we should fix this so it's not required
-      // this is why satisfies didn't work before
-      overrides: undefined,
       abi: entryPoint.abi,
       getUserOperationHash: (r) =>
         entryPoint.getUserOperationHash(r, address, chain.id),

--- a/packages/core/src/entrypoint/index.ts
+++ b/packages/core/src/entrypoint/index.ts
@@ -1,0 +1,170 @@
+import { type Chain } from "viem";
+import { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6.js";
+import { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7.js";
+import { EntryPointNotFoundError } from "../errors/entrypoint.js";
+import EntryPoint_v6 from "./0.6.js";
+import EntryPoint_v7 from "./0.7.js";
+import type {
+  DefaultEntryPointVersion,
+  EntryPointDef,
+  EntryPointDefRegistry,
+  EntryPointRegistry,
+  EntryPointVersion,
+  GetEntryPointOptions,
+  SupportedEntryPoint,
+} from "./types.js";
+
+export const defaultEntryPointVersion: DefaultEntryPointVersion = "0.6.0";
+
+export const entryPointRegistry: EntryPointRegistry = {
+  "0.6.0": EntryPoint_v6,
+  "0.7.0": EntryPoint_v7,
+};
+
+export const isEntryPointVersion = (
+  value: any
+): value is keyof EntryPointRegistry => {
+  return Object.keys(entryPointRegistry).includes(value);
+};
+
+export function getEntryPoint<
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion,
+  TChain extends Chain = Chain
+>(
+  chain: TChain,
+  options: GetEntryPointOptions<TEntryPointVersion>
+): EntryPointDefRegistry<TChain>[TEntryPointVersion];
+
+export function getEntryPoint<
+  TEntryPointVersion extends DefaultEntryPointVersion = DefaultEntryPointVersion,
+  TChain extends Chain = Chain
+>(
+  chain: TChain,
+  options?: GetEntryPointOptions<TEntryPointVersion>
+): EntryPointDefRegistry<TChain>[TEntryPointVersion];
+
+export function getEntryPoint<TChain extends Chain = Chain>(
+  chain: TChain,
+  options?: GetEntryPointOptions<DefaultEntryPointVersion>
+): EntryPointDefRegistry<TChain>[DefaultEntryPointVersion];
+
+export function getEntryPoint<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain
+>(
+  chain: TChain,
+  options: GetEntryPointOptions<TEntryPointVersion>
+): EntryPointDefRegistry<TChain>[EntryPointVersion] {
+  const { version = defaultEntryPointVersion, addressOverride } = options ?? {
+    version: defaultEntryPointVersion,
+  };
+
+  const entryPoint = entryPointRegistry[version ?? defaultEntryPointVersion];
+  const address = addressOverride || entryPoint.address[chain.id];
+  if (!address) {
+    throw new EntryPointNotFoundError(chain, version);
+  }
+
+  if (version === "0.6.0") {
+    const v6 = entryPoint as SupportedEntryPoint<
+      "0.6.0",
+      TChain,
+      typeof EntryPointAbi_v6
+    >;
+    return {
+      version: v6.version,
+      address,
+      chain,
+      abi: v6.abi,
+      getUserOperationHash: (r) =>
+        v6.getUserOperationHash(r, address, chain.id),
+      packUserOperation: v6.packUserOperation,
+    } as EntryPointDef<"0.6.0", TChain, typeof EntryPointAbi_v6>;
+  } else if (version === "0.7.0") {
+    const v7 = entryPoint as SupportedEntryPoint<
+      "0.7.0",
+      TChain,
+      typeof EntryPointAbi_v7
+    >;
+    return {
+      version: v7.version,
+      address,
+      chain,
+      abi: v7.abi,
+      getUserOperationHash: (r) =>
+        v7.getUserOperationHash(r, address, chain.id),
+      packUserOperation: v7.packUserOperation,
+    } as EntryPointDef<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+  }
+
+  throw new EntryPointNotFoundError(chain, version);
+}
+
+// // =================================================================================
+// // TODO: Add tests for the following cases
+
+// const chain: Chain = mainnet;
+
+// // 1. left and right hand side version type should match, as well as the param
+
+// // === Error ===
+// const ep1_a: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   version: "0.7.0",
+// }); // error
+// const ep1_b: EntryPointDef<"0.7.0"> = getEntryPoint(chain); // error
+// const ep1_c: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   version: "0.7.0",
+// }); // error
+// const ep1_d: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain, {
+//   version: "0.7.0",
+// }); // error
+
+// // === Valid ===
+// const ep1a: EntryPointDef<"0.6.0"> = getEntryPoint(chain);
+// const ep1b: EntryPointDef<"0.6.0"> = getEntryPoint(chain, { version: "0.6.0" });
+// const ep1c: EntryPointDef<"0.7.0"> = getEntryPoint(chain, { version: "0.7.0" });
+// const ep1d: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+// const ep1e: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+//   version: "0.6.0",
+// });
+// const ep1f: EntryPointDef<"0.7.0"> = getEntryPoint(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+//   version: "0.7.0",
+// });
+
+// // 2. If non-default type is specified, version option param of the type is required
+
+// // === Error ===
+// const ep2_a: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain); // error
+// const ep2_b: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+
+// // === Valid ===
+// const ep2a: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain, {
+//   version: "0.7.0",
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+// const ep2b: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain, {
+//   version: "0.6.0",
+// });
+// const ep2c: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain);
+// const ep2d: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+// const ep2e: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain, {
+//   version: "0.7.0",
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+
+// // 3. type needs to be only one of EntryPointVersion type not the union type itself
+
+// // === Error ===
+// const ep3_a: EntryPointDef<EntryPointVersion> = getEntryPoint(chain, {
+//   version: "0.6.0",
+// }); // error
+
+// // =================================================================================

--- a/packages/core/src/entrypoint/index.ts
+++ b/packages/core/src/entrypoint/index.ts
@@ -1,17 +1,13 @@
 import { type Chain } from "viem";
-import { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6.js";
-import { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7.js";
 import { EntryPointNotFoundError } from "../errors/entrypoint.js";
 import EntryPoint_v6 from "./0.6.js";
 import EntryPoint_v7 from "./0.7.js";
 import type {
   DefaultEntryPointVersion,
-  EntryPointDef,
   EntryPointDefRegistry,
   EntryPointRegistry,
   EntryPointVersion,
   GetEntryPointOptions,
-  SupportedEntryPoint,
 } from "./types.js";
 
 export const defaultEntryPointVersion: DefaultEntryPointVersion = "0.6.0";
@@ -65,36 +61,32 @@ export function getEntryPoint<
     throw new EntryPointNotFoundError(chain, version);
   }
 
-  if (version === "0.6.0") {
-    const v6 = entryPoint as SupportedEntryPoint<
-      "0.6.0",
-      TChain,
-      typeof EntryPointAbi_v6
-    >;
+  if (entryPoint.version === "0.6.0") {
     return {
-      version: v6.version,
+      version: entryPoint.version,
       address,
       chain,
-      abi: v6.abi,
+      // we should fix this so it's not required
+      // this is why satisfies didn't work before
+      overrides: undefined,
+      abi: entryPoint.abi,
       getUserOperationHash: (r) =>
-        v6.getUserOperationHash(r, address, chain.id),
-      packUserOperation: v6.packUserOperation,
-    } as EntryPointDef<"0.6.0", TChain, typeof EntryPointAbi_v6>;
-  } else if (version === "0.7.0") {
-    const v7 = entryPoint as SupportedEntryPoint<
-      "0.7.0",
-      TChain,
-      typeof EntryPointAbi_v7
-    >;
+        entryPoint.getUserOperationHash(r, address, chain.id),
+      packUserOperation: entryPoint.packUserOperation,
+    };
+  } else if (entryPoint.version === "0.7.0") {
     return {
-      version: v7.version,
+      version: entryPoint.version,
       address,
       chain,
-      abi: v7.abi,
+      // we should fix this so it's not required
+      // this is why satisfies didn't work before
+      overrides: undefined,
+      abi: entryPoint.abi,
       getUserOperationHash: (r) =>
-        v7.getUserOperationHash(r, address, chain.id),
-      packUserOperation: v7.packUserOperation,
-    } as EntryPointDef<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+        entryPoint.getUserOperationHash(r, address, chain.id),
+      packUserOperation: entryPoint.packUserOperation,
+    };
   }
 
   throw new EntryPointNotFoundError(chain, version);

--- a/packages/core/src/entrypoint/types.ts
+++ b/packages/core/src/entrypoint/types.ts
@@ -10,7 +10,7 @@ import type {
 } from "viem";
 import type { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6";
 import type { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7";
-import type { UserOperationOverrides, UserOperationRequest } from "../types";
+import type { UserOperationRequest } from "../types";
 import type { EQ, IsOneOf, OneOf } from "../utils";
 
 export interface EntryPointRegistryBase<T> {
@@ -73,7 +73,6 @@ export type EntryPointDef<
   version: TEntryPointVersion;
   address: Address;
   chain: TChain;
-  overrides: UserOperationOverrides<TEntryPointVersion> | undefined;
   abi: GetContractParameters<Transport, TChain, Account, TAbi>["abi"];
   getUserOperationHash: (
     request: UserOperationRequest<TEntryPointVersion>

--- a/packages/core/src/entrypoint/types.ts
+++ b/packages/core/src/entrypoint/types.ts
@@ -1,9 +1,119 @@
-import type { Address, Chain, Hex } from "viem";
+import type {
+  Abi,
+  Account,
+  Address,
+  Chain,
+  GetContractParameters,
+  Hash,
+  Hex,
+  Transport,
+} from "viem";
+import type { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6";
+import type { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7";
+import type { UserOperationOverrides, UserOperationRequest } from "../types";
+import type { EQ, IsOneOf, OneOf } from "../utils";
 
-export type EntryPointDef<EntryPointUserOperation> = {
-  version: string;
-  address: Address;
-  chain: Chain;
-  packUserOperation: (userOperation: EntryPointUserOperation) => Hex;
-  getUserOperationHash: (userOperation: EntryPointUserOperation) => Hex;
+export interface EntryPointRegistryBase<T> {
+  "0.6.0": T;
+  "0.7.0": T;
+}
+export type EntryPointVersion = keyof EntryPointRegistryBase<unknown>;
+export type DefaultEntryPointVersion = OneOf<"0.6.0", EntryPointVersion>;
+
+export type SupportedEntryPoint<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain,
+  TAbi extends Abi | readonly unknown[] = Abi
+> = {
+  version: TEntryPointVersion;
+  address: Record<TChain["id"], Address>;
+  abi: GetContractParameters<Transport, TChain, Account, TAbi>["abi"];
+
+  /**
+   * Generates a hash for a UserOperation valid from entry point version 0.6 onwards
+   *
+   * @param request - the UserOperation to get the hash for
+   * @param entryPointAddress - the entry point address that will be used to execute the UserOperation
+   * @param chainId - the chain on which this UserOperation will be executed
+   * @returns the hash of the UserOperation
+   */
+  getUserOperationHash: (
+    request: UserOperationRequest<TEntryPointVersion>,
+    entryPointAddress: Address,
+    chainId: number
+  ) => Hash;
+
+  /**
+   * Pack the user operation data into bytes for hashing for entry point version 0.6 onwards
+   * Reference:
+   * v6: https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.6/test/UserOp.ts#L16-L61
+   * v7: https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.7/test/UserOp.ts#L28-L67
+   *
+   * @param request - the UserOperation to get the hash for
+   * @returns the hash of the UserOperation
+   */
+  packUserOperation: (
+    userOperation: UserOperationRequest<TEntryPointVersion>
+  ) => Hex;
 };
+
+export interface EntryPointRegistry<TChain extends Chain = Chain>
+  extends EntryPointRegistryBase<
+    SupportedEntryPoint<EntryPointVersion, TChain, Abi>
+  > {
+  "0.6.0": SupportedEntryPoint<"0.6.0", TChain, typeof EntryPointAbi_v6>;
+  "0.7.0": SupportedEntryPoint<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+}
+
+export type EntryPointDef<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain,
+  TAbi extends Abi | readonly unknown[] = Abi
+> = {
+  version: TEntryPointVersion;
+  address: Address;
+  chain: TChain;
+  overrides: UserOperationOverrides<TEntryPointVersion> | undefined;
+  abi: GetContractParameters<Transport, TChain, Account, TAbi>["abi"];
+  getUserOperationHash: (
+    request: UserOperationRequest<TEntryPointVersion>
+  ) => Hex;
+  packUserOperation: (
+    userOperation: UserOperationRequest<TEntryPointVersion>
+  ) => Hex;
+};
+
+export interface EntryPointDefRegistry<TChain extends Chain = Chain>
+  extends EntryPointRegistryBase<
+    EntryPointDef<EntryPointVersion, TChain, Abi>
+  > {
+  "0.6.0": EntryPointDef<"0.6.0", TChain, typeof EntryPointAbi_v6>;
+  "0.7.0": EntryPointDef<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+}
+
+export type GetEntryPointOptions<
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+> = EQ<TEntryPointVersion, DefaultEntryPointVersion> extends true
+  ?
+      | {
+          addressOverride?: Address;
+          version?: OneOf<TEntryPointVersion, EntryPointVersion>;
+        }
+      | undefined
+  : {
+      addressOverride?: Address;
+      version: OneOf<TEntryPointVersion, EntryPointVersion>;
+    };
+
+export type EntryPointParameter<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain
+> = EQ<TEntryPointVersion, DefaultEntryPointVersion> extends true
+  ? {
+      entryPoint?: EntryPointDef<TEntryPointVersion, TChain>;
+    }
+  : {
+      entryPoint: IsOneOf<TEntryPointVersion, EntryPointVersion> extends true
+        ? EntryPointDef<TEntryPointVersion, TChain>
+        : never;
+    };

--- a/packages/core/src/errors/account.ts
+++ b/packages/core/src/errors/account.ts
@@ -1,4 +1,5 @@
 import type { Chain } from "viem";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import { BaseError } from "./base.js";
 
 export class AccountNotFoundError extends BaseError {
@@ -12,10 +13,10 @@ export class AccountNotFoundError extends BaseError {
 
 export class DefaultFactoryNotDefinedError extends BaseError {
   override name = "DefaultFactoryNotDefinedError";
-  constructor(accountType: string, chain: Chain) {
+  constructor(accountType: string, chain: Chain, version: EntryPointVersion) {
     super(
       [
-        `No default factory for ${accountType} found on chain ${chain.name}`,
+        `No default factory for ${accountType} found on chain ${chain.name} for entrypoint version ${version}`,
         "Supply an override via the `factoryAddress` parameter when creating an account",
       ].join("\n")
     );

--- a/packages/core/src/errors/entrypoint.ts
+++ b/packages/core/src/errors/entrypoint.ts
@@ -2,14 +2,24 @@ import type { Chain } from "viem";
 import { BaseError } from "./base.js";
 
 export class EntryPointNotFoundError extends BaseError {
-  override name = "EntrypointNotFoundError";
+  override name = "EntryPointNotFoundError";
 
-  constructor(chain: Chain) {
+  constructor(chain: Chain, entryPointVersion: any) {
     super(
       [
-        `No default entry point exists for ${chain.name}.`,
+        `No default entry point v${entryPointVersion} exists for ${chain.name}.`,
         `Supply an override.`,
       ].join("\n")
+    );
+  }
+}
+
+export class InvalidEntryPointError extends BaseError {
+  override name = "InvalidEntryPointError";
+
+  constructor(chain: Chain, entryPointVersion: any) {
+    super(
+      `Invalid entry point: unexpected version ${entryPointVersion} for ${chain.name}.`
     );
   }
 }

--- a/packages/core/src/errors/useroperation.ts
+++ b/packages/core/src/errors/useroperation.ts
@@ -1,9 +1,10 @@
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import type { UserOperationStruct } from "../types.js";
 import { BaseError } from "./base.js";
 
 export class InvalidUserOperationError extends BaseError {
   override name = "InvalidUserOperationError";
-  constructor(uo: UserOperationStruct) {
+  constructor(uo: UserOperationStruct<EntryPointVersion>) {
     super(
       `Request is missing parameters. All properties on UserOperationStruct must be set. uo: ${JSON.stringify(
         uo,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,12 @@ export {
   convertCoinTypeToChain,
   convertCoinTypeToChainId,
 } from "./ens/utils.js";
-export * from "./entrypoint/index.js";
+export {
+  defaultEntryPointVersion,
+  entryPointRegistry,
+  getEntryPoint,
+  isEntryPointVersion,
+} from "./entrypoint/index.js";
 export type * from "./entrypoint/types.js";
 export {
   AccountNotFoundError,
@@ -94,7 +99,10 @@ export {
   IncompatibleClientError,
   InvalidRpcUrlError,
 } from "./errors/client.js";
-export * from "./errors/entrypoint.js";
+export {
+  EntryPointNotFoundError,
+  InvalidEntryPointError,
+} from "./errors/entrypoint.js";
 export { InvalidSignerTypeError } from "./errors/signer.js";
 export {
   FailedToFindTransactionError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,10 @@ export type { Abi } from "abitype";
 export type { Address, HttpTransport } from "viem";
 export * as chains from "viem/chains";
 
-export { EntryPointAbi } from "./abis/EntryPointAbi.js";
-export { SimpleAccountAbi } from "./abis/SimpleAccountAbi.js";
+export { EntryPointAbi_v6 } from "./abis/EntryPointAbi_v6.js";
+export { EntryPointAbi_v7 } from "./abis/EntryPointAbi_v7.js";
+export { SimpleAccountAbi_v6 } from "./abis/SimpleAccountAbi_v6.js";
+export { SimpleAccountAbi_v7 } from "./abis/SimpleAccountAbi_v7.js";
 export { SimpleAccountFactoryAbi } from "./abis/SimpleAccountFactoryAbi.js";
 export { BaseSmartContractAccount } from "./account/base.js";
 export { createSimpleSmartAccount } from "./account/simple.js";
@@ -71,8 +73,8 @@ export {
   convertCoinTypeToChain,
   convertCoinTypeToChainId,
 } from "./ens/utils.js";
-export { getVersion060EntryPoint } from "./entrypoint/0.6.js";
-export { type EntryPointDef } from "./entrypoint/types.js";
+export * from "./entrypoint/index.js";
+export type * from "./entrypoint/types.js";
 export {
   AccountNotFoundError,
   AccountRequiresOwnerError,
@@ -92,7 +94,7 @@ export {
   IncompatibleClientError,
   InvalidRpcUrlError,
 } from "./errors/client.js";
-export { EntryPointNotFoundError as EntrypointNotFoundError } from "./errors/entrypoint.js";
+export * from "./errors/entrypoint.js";
 export { InvalidSignerTypeError } from "./errors/signer.js";
 export {
   FailedToFindTransactionError,
@@ -134,10 +136,8 @@ export {
   defineReadOnly,
   filterUndefined,
   getChain,
-  getDefaultEntryPointAddress,
   getDefaultSimpleAccountFactoryAddress,
   getDefaultUserOperationFeeOptions,
-  getUserOperationHash,
   isBigNumberish,
   isMultiplier,
   isValidRequest,

--- a/packages/core/src/middleware/defaults/feeEstimator.ts
+++ b/packages/core/src/middleware/defaults/feeEstimator.ts
@@ -18,7 +18,7 @@ export const defaultFeeEstimator: <C extends MiddlewareClient>(
     // for more information about maxFeePerGas and maxPriorityFeePerGas
 
     const feeData = await client.estimateFeesPerGas();
-    if (!feeData.maxFeePerGas || !feeData.maxPriorityFeePerGas) {
+    if (!feeData.maxFeePerGas || feeData.maxPriorityFeePerGas == null) {
       throw new Error(
         "feeData is missing maxFeePerGas or maxPriorityFeePerGas"
       );

--- a/packages/core/src/middleware/defaults/overridePaymasterData.ts
+++ b/packages/core/src/middleware/defaults/overridePaymasterData.ts
@@ -1,10 +1,28 @@
+import type { UserOperationOverrides, UserOperationStruct } from "../../types";
 import type { ClientMiddlewareFn } from "../types";
 
 export const overridePaymasterDataMiddleware: ClientMiddlewareFn = async (
   struct,
-  { overrides }
+  { overrides, account }
 ) => {
-  struct.paymasterAndData =
-    overrides?.paymasterAndData != null ? overrides?.paymasterAndData : "0x";
+  const entryPoint = account.getEntryPoint();
+
+  if (entryPoint.version === "0.6.0") {
+    const _struct = struct as UserOperationStruct<"0.6.0">;
+    _struct.paymasterAndData =
+      _struct?.paymasterAndData != null ? _struct.paymasterAndData : "0x";
+  } else {
+    const _struct = struct as UserOperationStruct<"0.7.0">;
+    const _overrides = overrides as UserOperationOverrides<"0.7.0">;
+
+    _struct.paymaster =
+      _overrides?.paymaster != null ? _overrides?.paymaster : "0x";
+    _struct.paymasterData =
+      _overrides?.paymasterData != null ? _overrides.paymasterData : "0x";
+    _struct.paymasterPostOpGasLimit = _overrides?.paymasterPostOpGasLimit;
+    _struct.paymasterVerificationGasLimit =
+      _overrides?.paymasterVerificationGasLimit;
+  }
+
   return struct;
 };

--- a/packages/core/src/middleware/defaults/paymasterAndData.ts
+++ b/packages/core/src/middleware/defaults/paymasterAndData.ts
@@ -8,9 +8,6 @@ export const defaultPaymasterAndData: ClientMiddlewareFn = async (
   const entryPoint = account.getEntryPoint();
   if (entryPoint.version === "0.6.0") {
     (struct as UserOperationStruct<"0.6.0">).paymasterAndData = "0x";
-  } else {
-    (struct as UserOperationStruct<"0.7.0">).paymaster = "0x0";
-    (struct as UserOperationStruct<"0.7.0">).paymasterData = "0x";
   }
   return struct;
 };

--- a/packages/core/src/middleware/defaults/paymasterAndData.ts
+++ b/packages/core/src/middleware/defaults/paymasterAndData.ts
@@ -1,6 +1,16 @@
+import type { UserOperationStruct } from "../../types";
 import type { ClientMiddlewareFn } from "../types";
 
-export const defaultPaymasterAndData: ClientMiddlewareFn = async (struct) => {
-  struct.paymasterAndData = "0x";
+export const defaultPaymasterAndData: ClientMiddlewareFn = async (
+  struct,
+  { account }
+) => {
+  const entryPoint = account.getEntryPoint();
+  if (entryPoint.version === "0.6.0") {
+    (struct as UserOperationStruct<"0.6.0">).paymasterAndData = "0x";
+  } else {
+    (struct as UserOperationStruct<"0.7.0">).paymaster = "0x0";
+    (struct as UserOperationStruct<"0.7.0">).paymasterData = "0x";
+  }
   return struct;
 };

--- a/packages/core/src/middleware/types.ts
+++ b/packages/core/src/middleware/types.ts
@@ -1,4 +1,7 @@
-import type { SmartContractAccount } from "../account/smartContractAccount";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../account/smartContractAccount";
 import type {
   UserOperationFeeOptions,
   UserOperationOverrides,
@@ -12,16 +15,20 @@ export type ClientMiddlewareFn<
   TContext extends Record<string, any> | undefined =
     | Record<string, any>
     | undefined
-> = <TAccount extends SmartContractAccount, C extends MiddlewareClient>(
-  struct: Deferrable<UserOperationStruct>,
+> = <
+  TAccount extends SmartContractAccount,
+  C extends MiddlewareClient,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+>(
+  struct: Deferrable<UserOperationStruct<TEntryPointVersion>>,
   args: {
-    overrides?: UserOperationOverrides;
+    overrides?: UserOperationOverrides<TEntryPointVersion>;
     context?: TContext;
     feeOptions?: UserOperationFeeOptions;
     account: TAccount;
     client: C;
   }
-) => Promise<Deferrable<UserOperationStruct>>;
+) => Promise<Deferrable<UserOperationStruct<TEntryPointVersion>>>;
 //#endregion ClientMiddlewareFn
 
 //#region ClientMiddleware

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,7 @@ import type {
   BigNumberishRangeSchema,
   BigNumberishSchema,
   MultiplierSchema,
+  NoUndefined,
 } from "./utils";
 
 export type EmptyHex = `0x`;
@@ -95,13 +96,20 @@ export type UserOperationOverrides<
         paymasterAndData: UserOperationStruct<"0.6.0">["paymasterAndData"];
       }
     : TEntryPointVersion extends "0.7.0"
-    ? {
-        paymaster: UserOperationStruct<"0.7.0">["paymaster"];
-        paymasterData: UserOperationStruct<"0.7.0">["paymasterData"];
-        paymasterPostOpGasLimit: UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"];
-        paymasterVerificationGasLimit: UserOperationStruct<"0.7.0">["paymasterVerificationGasLimit"];
-        paymasterGas: UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"];
-      }
+    ?
+        | {
+            paymaster: NoUndefined<UserOperationStruct<"0.7.0">["paymaster"]>;
+            paymasterData: NoUndefined<
+              UserOperationStruct<"0.7.0">["paymasterData"]
+            >;
+            paymasterPostOpGasLimit: NoUndefined<
+              UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"]
+            >;
+            paymasterVerificationGasLimit: NoUndefined<
+              UserOperationStruct<"0.7.0">["paymasterVerificationGasLimit"]
+            >;
+          }
+        | undefined
     : never)
 >;
 //#endregion UserOperationOverrides
@@ -144,9 +152,9 @@ export interface UserOperationRequest_v7 {
   /* anti-replay parameter. nonce of the transaction, returned from the entry point for this address */
   nonce: Hex;
   /* account factory, only for new accounts */
-  factory: Address | NullAddress;
+  factory?: Address;
   /* data for account factory (only if account factory exists) */
-  factoryData: Hex | EmptyHex;
+  factoryData?: Hex;
   /* the data to pass to the sender during the main execution call */
   callData: Hex;
   /* the amount of gas to allocate the main execution call */
@@ -160,13 +168,13 @@ export interface UserOperationRequest_v7 {
   /* maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas) */
   maxPriorityFeePerGas: Hex;
   /* address of paymaster contract, (or empty, if account pays for itself) */
-  paymaster: Address | NullAddress;
+  paymaster?: Address;
   /* the amount of gas to allocate for the paymaster validation code */
-  paymasterVerificationGasLimit: Hex;
+  paymasterVerificationGasLimit?: Hex;
   /* the amount of gas to allocate for the paymaster post-operation code */
-  paymasterPostOpGasLimit: Hex;
+  paymasterPostOpGasLimit?: Hex;
   /* data for paymaster (only if paymaster exists) */
-  paymasterData: Hex | EmptyHex;
+  paymasterData?: Hex;
   /* data passed into the account to verify authorization */
   signature: Hex;
 }
@@ -332,9 +340,9 @@ export interface UserOperationStruct_v7 {
   /* anti-replay parameter. nonce of the transaction, returned from the entry point for this address */
   nonce: BigNumberish;
   /* account factory, only for new accounts */
-  factory: string | "0x";
+  factory?: string;
   /* data for account factory (only if account factory exists) */
-  factoryData: BytesLike | "0x";
+  factoryData?: BytesLike;
   /* the data to pass to the sender during the main execution call */
   callData: BytesLike;
   /* the amount of gas to allocate the main execution call */
@@ -348,13 +356,13 @@ export interface UserOperationStruct_v7 {
   /* maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas) */
   maxPriorityFeePerGas?: BigNumberish;
   /* address of paymaster contract, (or empty, if account pays for itself) */
-  paymaster: string | "0x";
+  paymaster?: string;
   /* the amount of gas to allocate for the paymaster validation code */
   paymasterVerificationGasLimit?: BigNumberish;
   /* the amount of gas to allocate for the paymaster post-operation code */
   paymasterPostOpGasLimit?: BigNumberish;
   /* data for paymaster (only if paymaster exists) */
-  paymasterData: BytesLike | "0x";
+  paymasterData?: BytesLike;
   /* data passed into the account to verify authorization */
   signature: BytesLike;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import {
   type Address,
   type Hash,
+  type Hex,
   type StateOverride,
   type TransactionReceipt,
 } from "viem";
@@ -9,15 +10,15 @@ import type {
   UserOperationFeeOptionsFieldSchema,
   UserOperationFeeOptionsSchema,
 } from "./client/schema";
+import type { EntryPointVersion } from "./entrypoint/types";
 import type {
   BigNumberishRangeSchema,
   BigNumberishSchema,
-  HexSchema,
   MultiplierSchema,
 } from "./utils";
 
-export type Hex = z.input<typeof HexSchema>;
 export type EmptyHex = `0x`;
+export type NullAddress = `0x0`;
 
 // based on @account-abstraction/common
 export type PromiseOrValue<T> = T | Promise<T>;
@@ -52,34 +53,63 @@ export type UserOperationFeeOptions = z.input<
   typeof UserOperationFeeOptionsSchema
 >;
 
+export type UserOperationOverridesParameter<
+  TEntryPointVersion extends EntryPointVersion,
+  Required extends boolean = false
+> = Required extends true
+  ? { overrides: UserOperationOverrides<TEntryPointVersion> }
+  : { overrides?: UserOperationOverrides<TEntryPointVersion> };
+
 //#region UserOperationOverrides
-export type UserOperationOverrides = Partial<{
-  callGasLimit: UserOperationStruct["callGasLimit"] | Multiplier;
-  maxFeePerGas: UserOperationStruct["maxFeePerGas"] | Multiplier;
-  maxPriorityFeePerGas:
-    | UserOperationStruct["maxPriorityFeePerGas"]
-    | Multiplier;
-  preVerificationGas: UserOperationStruct["preVerificationGas"] | Multiplier;
-  verificationGasLimit:
-    | UserOperationStruct["verificationGasLimit"]
-    | Multiplier;
-  paymasterAndData: UserOperationStruct["paymasterAndData"];
-  /**
-   * This can be used to override the key used when calling `entryPoint.getNonce`
-   * It is useful when you want to use parallel nonces for user operations
-   *
-   * NOTE: not all bundlers fully support this feature and it could be that your bundler will still only include
-   * one user operation for your account in a bundle
-   */
-  nonceKey: bigint;
-  stateOverride: StateOverride;
-}>;
+// Note: entry point version is required for UserOperationOverrides
+export type UserOperationOverrides<
+  TEntryPointVersion extends EntryPointVersion
+> = Partial<
+  {
+    callGasLimit:
+      | UserOperationStruct<TEntryPointVersion>["callGasLimit"]
+      | Multiplier;
+    maxFeePerGas:
+      | UserOperationStruct<TEntryPointVersion>["maxFeePerGas"]
+      | Multiplier;
+    maxPriorityFeePerGas:
+      | UserOperationStruct<TEntryPointVersion>["maxPriorityFeePerGas"]
+      | Multiplier;
+    preVerificationGas:
+      | UserOperationStruct<TEntryPointVersion>["preVerificationGas"]
+      | Multiplier;
+    verificationGasLimit:
+      | UserOperationStruct<TEntryPointVersion>["verificationGasLimit"]
+      | Multiplier;
+    /**
+     * This can be used to override the key used when calling `entryPoint.getNonce`
+     * It is useful when you want to use parallel nonces for user operations
+     *
+     * NOTE: not all bundlers fully support this feature and it could be that your bundler will still only include
+     * one user operation for your account in a bundle
+     */
+    nonceKey: bigint;
+    stateOverride: StateOverride;
+  } & (TEntryPointVersion extends "0.6.0"
+    ? {
+        paymasterAndData: UserOperationStruct<"0.6.0">["paymasterAndData"];
+      }
+    : TEntryPointVersion extends "0.7.0"
+    ? {
+        paymaster: UserOperationStruct<"0.7.0">["paymaster"];
+        paymasterData: UserOperationStruct<"0.7.0">["paymasterData"];
+        paymasterPostOpGasLimit: UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"];
+        paymasterVerificationGasLimit: UserOperationStruct<"0.7.0">["paymasterVerificationGasLimit"];
+        paymasterGas: UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"];
+      }
+    : never)
+>;
 //#endregion UserOperationOverrides
 
-//#region UserOperationRequest
-// represents the request as it needs to be formatted for RPC requests
-// Reference: https://eips.ethereum.org/EIPS/eip-4337#definitions
-export interface UserOperationRequest {
+//#region UserOperationRequest_v6
+// represents the request as it needs to be formatted for v0.6 RPC requests
+// Reference: https://github.com/ethereum/ERCs/blob/8dd085d159cb123f545c272c0d871a5339550e79/ERCS/erc-4337.md#definitions
+export interface UserOperationRequest_v6 {
   /* the origin of the request */
   sender: Address;
   /* nonce (as hex) of the transaction, returned from the entry point for this Address */
@@ -103,6 +133,54 @@ export interface UserOperationRequest {
   /* Data passed into the account along with the nonce during the verification step */
   signature: Hex;
 }
+//#endregion UserOperationRequest_v6
+
+//#region UserOperationRequest_v7
+// represents the request as it needs to be formatted for v0.7 RPC requests
+// Reference: https://eips.ethereum.org/EIPS/eip-4337#definitions
+export interface UserOperationRequest_v7 {
+  /* the account making the operation */
+  sender: Address;
+  /* anti-replay parameter. nonce of the transaction, returned from the entry point for this address */
+  nonce: Hex;
+  /* account factory, only for new accounts */
+  factory: Address | NullAddress;
+  /* data for account factory (only if account factory exists) */
+  factoryData: Hex | EmptyHex;
+  /* the data to pass to the sender during the main execution call */
+  callData: Hex;
+  /* the amount of gas to allocate the main execution call */
+  callGasLimit: Hex;
+  /* the amount of gas to allocate for the verification step */
+  verificationGasLimit: Hex;
+  /* extra gas to pay the bunder */
+  preVerificationGas: Hex;
+  /* maximum fee per gas (similar to EIP-1559 max_fee_per_gas) */
+  maxFeePerGas: Hex;
+  /* maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas) */
+  maxPriorityFeePerGas: Hex;
+  /* address of paymaster contract, (or empty, if account pays for itself) */
+  paymaster: Address | NullAddress;
+  /* the amount of gas to allocate for the paymaster validation code */
+  paymasterVerificationGasLimit: Hex;
+  /* the amount of gas to allocate for the paymaster post-operation code */
+  paymasterPostOpGasLimit: Hex;
+  /* data for paymaster (only if paymaster exists) */
+  paymasterData: Hex | EmptyHex;
+  /* data passed into the account to verify authorization */
+  signature: Hex;
+}
+//#endregion UserOperationRequest_v7
+
+//#region UserOperationRequest
+// Reference: https://eips.ethereum.org/EIPS/eip-4337#definitions
+export type UserOperationRequest<TEntryPointVersion extends EntryPointVersion> =
+  TEntryPointVersion extends "0.6.0"
+    ? UserOperationRequest_v6
+    : TEntryPointVersion extends "0.7.0"
+    ? UserOperationRequest_v7
+    : never;
+
 //#endregion UserOperationRequest
 
 //#region UserOperationEstimateGasResponse
@@ -117,9 +195,11 @@ export interface UserOperationEstimateGasResponse {
 //#endregion UserOperationEstimateGasResponse
 
 //#region UserOperationResponse
-export interface UserOperationResponse {
+export interface UserOperationResponse<
+  TEntryPointVersion extends EntryPointVersion
+> {
   /* the User Operation */
-  userOperation: UserOperationRequest;
+  userOperation: UserOperationRequest<TEntryPointVersion>;
   /* the address of the entry point contract that executed the user operation */
   entryPoint: Address;
   /* the block number the user operation was included in */
@@ -214,13 +294,13 @@ export interface UserOperationReceiptLog {
   transactionHash: Hash;
 }
 
-//#region UserOperationStruct
-// based on @account-abstraction/common
-// this is used for building requests
-export interface UserOperationStruct {
+//#region UserOperationStruct_v6
+// https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.6/test/UserOperation.ts
+// this is used for building requests for v0.6 entry point contract
+export interface UserOperationStruct_v6 {
   /* the origin of the request */
   sender: string;
-  /* nonce of the transaction, returned from the entry point for this Address */
+  /* nonce of the transaction, returned from the entry point for this address */
   nonce: BigNumberish;
   /* the initCode for creating the sender if it does not exist yet, otherwise "0x" */
   initCode: BytesLike | "0x";
@@ -241,4 +321,54 @@ export interface UserOperationStruct {
   /* Data passed into the account along with the nonce during the verification step */
   signature: BytesLike;
 }
+//#endregion UserOperationStruct_v6
+
+//#region UserOperationStruct_v7
+// based on https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.7/test/UserOperation.ts
+// this is used for building requests for v0.7 entry point contract
+export interface UserOperationStruct_v7 {
+  /* the account making the operation */
+  sender: string;
+  /* anti-replay parameter. nonce of the transaction, returned from the entry point for this address */
+  nonce: BigNumberish;
+  /* account factory, only for new accounts */
+  factory: string | "0x";
+  /* data for account factory (only if account factory exists) */
+  factoryData: BytesLike | "0x";
+  /* the data to pass to the sender during the main execution call */
+  callData: BytesLike;
+  /* the amount of gas to allocate the main execution call */
+  callGasLimit?: BigNumberish;
+  /* the amount of gas to allocate for the verification step */
+  verificationGasLimit?: BigNumberish;
+  /* extra gas to pay the bunder */
+  preVerificationGas?: BigNumberish;
+  /* maximum fee per gas (similar to EIP-1559 max_fee_per_gas) */
+  maxFeePerGas?: BigNumberish;
+  /* maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas) */
+  maxPriorityFeePerGas?: BigNumberish;
+  /* address of paymaster contract, (or empty, if account pays for itself) */
+  paymaster: string | "0x";
+  /* the amount of gas to allocate for the paymaster validation code */
+  paymasterVerificationGasLimit?: BigNumberish;
+  /* the amount of gas to allocate for the paymaster post-operation code */
+  paymasterPostOpGasLimit?: BigNumberish;
+  /* data for paymaster (only if paymaster exists) */
+  paymasterData: BytesLike | "0x";
+  /* data passed into the account to verify authorization */
+  signature: BytesLike;
+}
+//#endregion UserOperationStruct_v7
+
+//#region UserOperationStruct
+export type UserOperationStruct<TEntryPointVersion extends EntryPointVersion> =
+  TEntryPointVersion extends "0.6.0"
+    ? UserOperationStruct_v6
+    : TEntryPointVersion extends "0.7.0"
+    ? UserOperationStruct_v7
+    : never;
 //#endregion UserOperationStruct
+
+export type UserOperationStructUnion =
+  | UserOperationStruct_v6
+  | UserOperationStruct_v7;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,25 @@ export type UserOperationOverridesParameter<
   ? { overrides: UserOperationOverrides<TEntryPointVersion> }
   : { overrides?: UserOperationOverrides<TEntryPointVersion> };
 
+export type UserOperationPaymasterOverrides<
+  TEntryPointVersion extends EntryPointVersion
+> = TEntryPointVersion extends "0.6.0"
+  ? {
+      paymasterAndData: UserOperationStruct<"0.6.0">["paymasterAndData"];
+    }
+  : TEntryPointVersion extends "0.7.0"
+  ? {
+      paymaster: NoUndefined<UserOperationStruct<"0.7.0">["paymaster"]>;
+      paymasterData: NoUndefined<UserOperationStruct<"0.7.0">["paymasterData"]>;
+      paymasterPostOpGasLimit: NoUndefined<
+        UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"]
+      >;
+      paymasterVerificationGasLimit: NoUndefined<
+        UserOperationStruct<"0.7.0">["paymasterVerificationGasLimit"]
+      >;
+    }
+  : {};
+
 //#region UserOperationOverrides
 // Note: entry point version is required for UserOperationOverrides
 export type UserOperationOverrides<
@@ -91,26 +110,7 @@ export type UserOperationOverrides<
      */
     nonceKey: bigint;
     stateOverride: StateOverride;
-  } & (TEntryPointVersion extends "0.6.0"
-    ? {
-        paymasterAndData: UserOperationStruct<"0.6.0">["paymasterAndData"];
-      }
-    : TEntryPointVersion extends "0.7.0"
-    ?
-        | {
-            paymaster: NoUndefined<UserOperationStruct<"0.7.0">["paymaster"]>;
-            paymasterData: NoUndefined<
-              UserOperationStruct<"0.7.0">["paymasterData"]
-            >;
-            paymasterPostOpGasLimit: NoUndefined<
-              UserOperationStruct<"0.7.0">["paymasterPostOpGasLimit"]
-            >;
-            paymasterVerificationGasLimit: NoUndefined<
-              UserOperationStruct<"0.7.0">["paymasterVerificationGasLimit"]
-            >;
-          }
-        | undefined
-    : never)
+  } & UserOperationPaymasterOverrides<TEntryPointVersion>
 >;
 //#endregion UserOperationOverrides
 

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -12,42 +12,14 @@ import {
   optimismGoerli,
   optimismSepolia,
   polygon,
-  polygonMumbai,
   polygonAmoy,
+  polygonMumbai,
   sepolia,
 } from "../chains/index.js";
+import { defaultEntryPointVersion } from "../entrypoint/index.js";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import { DefaultFactoryNotDefinedError } from "../errors/account.js";
-import { EntryPointNotFoundError } from "../errors/entrypoint.js";
 import type { UserOperationFeeOptions } from "../types";
-
-/**
- * Utility method returning the entry point contract address given a {@link Chain} object
- *
- * @param chain - a {@link Chain} object
- * @returns a {@link abi.Address} for the given chain
- * @throws if the chain doesn't have an address currently deployed
- */
-export const getDefaultEntryPointAddress = (chain: Chain): Address => {
-  switch (chain.id) {
-    case mainnet.id:
-    case sepolia.id:
-    case goerli.id:
-    case polygon.id:
-    case polygonMumbai.id:
-    case polygonAmoy.id:
-    case optimism.id:
-    case optimismGoerli.id:
-    case optimismSepolia.id:
-    case arbitrum.id:
-    case arbitrumGoerli.id:
-    case arbitrumSepolia.id:
-    case base.id:
-    case baseGoerli.id:
-    case baseSepolia.id:
-      return "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
-  }
-  throw new EntryPointNotFoundError(chain);
-};
 
 /**
  * Utility method returning the default simple account factory address given a {@link Chain} object
@@ -57,29 +29,54 @@ export const getDefaultEntryPointAddress = (chain: Chain): Address => {
  * @throws if the chain doesn't have an address currently deployed
  */
 export const getDefaultSimpleAccountFactoryAddress = (
-  chain: Chain
+  chain: Chain,
+  version: EntryPointVersion = defaultEntryPointVersion
 ): Address => {
-  switch (chain.id) {
-    case mainnet.id:
-    case polygon.id:
-    case optimism.id:
-    case optimismSepolia.id:
-    case arbitrum.id:
-    case base.id:
-    case baseGoerli.id:
-    case baseSepolia.id:
-    case arbitrumSepolia.id:
-      return "0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232";
-    case sepolia.id:
-    case goerli.id:
-    case polygonMumbai.id:
-    case polygonAmoy.id:
-    case optimismGoerli.id:
-    case arbitrumGoerli.id:
-      return "0x9406Cc6185a346906296840746125a0E44976454";
+  switch (version) {
+    case "0.6.0":
+      switch (chain.id) {
+        case mainnet.id:
+        case polygon.id:
+        case optimism.id:
+        case optimismSepolia.id:
+        case arbitrum.id:
+        case base.id:
+        case baseGoerli.id:
+        case baseSepolia.id:
+        case arbitrumSepolia.id:
+          return "0x15Ba39375ee2Ab563E8873C8390be6f2E2F50232";
+        case sepolia.id:
+        case goerli.id:
+        case polygonMumbai.id:
+        case polygonAmoy.id:
+        case optimismGoerli.id:
+        case arbitrumGoerli.id:
+          return "0x9406Cc6185a346906296840746125a0E44976454";
+        default:
+          break;
+      }
+      break;
+    case "0.7.0":
+      switch (chain.id) {
+        case mainnet.id:
+        case polygon.id:
+        case polygonMumbai.id:
+        case polygonAmoy.id:
+        case optimism.id:
+        case optimismSepolia.id:
+        case arbitrum.id:
+        case arbitrumSepolia.id:
+        case base.id:
+        case baseSepolia.id:
+        case sepolia.id:
+          return "0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985";
+        default:
+          break;
+      }
+      break;
   }
 
-  throw new DefaultFactoryNotDefinedError("SimpleAccount", chain);
+  throw new DefaultFactoryNotDefinedError("SimpleAccount", chain, version);
 };
 
 export const minPriorityFeePerBidDefaults = new Map<number, bigint>([

--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -11,7 +11,7 @@ export const ChainSchema = z.custom<Chain>(
 );
 
 export const HexSchema = z.custom<`0x${string}` | "0x">((val) => {
-  return isHex(val);
+  return isHex(val, { strict: true });
 });
 
 //#region BigNumberish

--- a/packages/core/src/utils/testUtils.ts
+++ b/packages/core/src/utils/testUtils.ts
@@ -7,15 +7,16 @@ import {
   createBundlerClientFromExisting,
   type BundlerClient,
 } from "../client/bundlerClient.js";
-import { getVersion060EntryPoint } from "../entrypoint/0.6.js";
+import { getEntryPoint } from "../entrypoint/index.js";
+import type { DefaultEntryPointVersion } from "../entrypoint/types.js";
 
 export const createDummySmartContractAccount = async <C extends BundlerClient>(
   client: C
-): Promise<SmartContractAccount> => {
+): Promise<SmartContractAccount<"dummy", DefaultEntryPointVersion>> => {
   return toSmartContractAccount({
     source: "dummy",
     accountAddress: "0x1234567890123456789012345678901234567890",
-    entryPoint: getVersion060EntryPoint(client.chain),
+    entryPoint: getEntryPoint(client.chain),
     chain: client.chain,
     transport: custom(client),
     signMessage: async () => "0xdeadbeef",

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -88,7 +88,3 @@ export type IsOneOf<T, Union> = IsMemberOrSubtypeOfAComponent<
 >;
 
 export type OneOf<T1, T2> = IsOneOf<T1, T2> extends true ? T1 : never;
-
-export type Interface<T> = {
-  [K in keyof T]: any;
-};

--- a/packages/core/src/utils/userop.ts
+++ b/packages/core/src/utils/userop.ts
@@ -1,30 +1,86 @@
+import { isAddress, toHex } from "viem";
+import type { EntryPointVersion } from "../entrypoint/types";
 import type {
   BigNumberish,
   Multiplier,
   UserOperationFeeOptionsField,
   UserOperationRequest,
   UserOperationStruct,
+  UserOperationStruct_v6,
+  UserOperationStruct_v7,
 } from "../types";
 import { bigIntClamp, bigIntMultiply } from "./bigint.js";
-import { isBigNumberish } from "./index.js";
+import { allEqual, isBigNumberish } from "./index.js";
 
 /**
- * Utility method for asserting a {@link UserOperationStruct} is a {@link UserOperationRequest}
+ * Utility method for asserting a {@link UserOperationStruct} has valid fields for the given entry point version
  *
  * @param request a {@link UserOperationStruct} to validate
- * @returns a type guard that asserts the {@link UserOperationStruct} is a {@link UserOperationRequest}
+ * @param entryPointVersion a {@link EntryPointVersion} entry point version
+ * @returns a type guard that asserts the {@link UserOperationRequest} is valid
  */
-export function isValidRequest(
-  request: UserOperationStruct
-): request is UserOperationRequest {
+export function isValidRequest<TEntryPointVersion extends EntryPointVersion>(
+  request: UserOperationStruct<TEntryPointVersion>
+): request is UserOperationRequest<TEntryPointVersion> {
   // These are the only ones marked as optional in the interface above
   return (
-    !!request.callGasLimit &&
-    !!request.maxFeePerGas &&
-    request.maxPriorityFeePerGas != null &&
-    !!request.preVerificationGas &&
-    !!request.verificationGasLimit
+    BigInt(request.callGasLimit || 0n) > 0n &&
+    BigInt(request.maxFeePerGas || 0n) > 0n &&
+    BigInt(request.preVerificationGas || 0n) > 0n &&
+    BigInt(request.verificationGasLimit || 0n) > 0n &&
+    isValidPaymasterAndData(request) &&
+    isValidFactoryAndData(request)
   );
+}
+
+/**
+ * Utility method for asserting a {@link UserOperationRequest} has valid fields for the paymaster data
+ *
+ * @param request a {@link UserOperationRequest} to validate
+ * @param entryPointVersion a {@link EntryPointVersion} entry point version
+ * @returns a type guard that asserts the {@link UserOperationRequest} is a {@link UserOperationRequest}
+ */
+export function isValidPaymasterAndData<
+  TEntryPointVersion extends EntryPointVersion
+>(request: UserOperationStruct<TEntryPointVersion>): boolean {
+  if (!("paymaster" in request)) {
+    const { paymasterAndData } = request as UserOperationStruct_v6;
+    return paymasterAndData != null;
+  }
+
+  const {
+    paymaster,
+    paymasterData,
+    paymasterPostOpGasLimit,
+    paymasterVerificationGasLimit,
+  } = request as UserOperationStruct_v7;
+  // either all exist, or none.
+  return allEqual(
+    isAddress(paymaster),
+    toHex(paymasterData || "0x") !== "0x",
+    BigInt(paymasterPostOpGasLimit || 0n) > 0n,
+    BigInt(paymasterVerificationGasLimit || 0n) > 0n
+  );
+}
+
+/**
+ * Utility method for asserting a {@link UserOperationStruct} has valid fields for the paymaster data
+ *
+ * @param request a {@link UserOperationRequest} to validate
+ * @param entryPointVersion a {@link EntryPointVersion} entry point version
+ * @returns a type guard that asserts the {@link UserOperationStruct} is a {@link UserOperationRequest}
+ */
+export function isValidFactoryAndData<
+  TEntryPointVersion extends EntryPointVersion
+>(request: UserOperationStruct<TEntryPointVersion>): boolean {
+  if (!("factory" in request)) {
+    const { initCode } = request as UserOperationStruct_v6;
+    return initCode != null;
+  }
+
+  const { factory, factoryData } = request as UserOperationStruct_v7;
+  // either all exist, or none.
+  return allEqual(isAddress(factory), toHex(factoryData || "0x") !== "0x");
 }
 
 export function applyUserOpOverride(

--- a/packages/ethers/src/provider-adapter.ts
+++ b/packages/ethers/src/provider-adapter.ts
@@ -7,11 +7,12 @@ import {
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { createPublicClient, custom, http } from "viem";
+import { createPublicClient, custom, http, type Transport } from "viem";
 import { AccountSigner } from "./account-signer.js";
 import type { EthersProviderAdapterOpts } from "./types.js";
 
 /** Lightweight Adapter for SmartAccountProvider to enable Signer Creation */
+// TODO: Add support for strong entry point version type
 export class EthersProviderAdapter extends JsonRpcProvider {
   readonly accountProvider: SmartAccountClient;
 
@@ -58,11 +59,11 @@ export class EthersProviderAdapter extends JsonRpcProvider {
    */
   connectToAccount<TAccount extends SmartContractAccount>(
     account: TAccount
-  ): AccountSigner {
+  ): AccountSigner<TAccount> {
     return new AccountSigner<TAccount>(this, account);
   }
 
-  getBundlerClient(): BundlerClient {
+  getBundlerClient(): BundlerClient<Transport> {
     return createBundlerClientFromExisting(
       createPublicClient({
         transport: custom(this.accountProvider.transport),

--- a/packages/ethers/src/types.ts
+++ b/packages/ethers/src/types.ts
@@ -1,5 +1,6 @@
 import {
   type BundlerClient,
+  type EntryPointVersion,
   type SmartAccountClient,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -8,12 +9,17 @@ import type { Chain, Transport } from "viem";
 export type EthersProviderAdapterOpts<
   TTransport extends Transport = Transport,
   TChain extends Chain = Chain,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<EntryPointVersion> | undefined =
+    | SmartContractAccount<EntryPointVersion>
     | undefined
 > = {
   account?: TAccount;
 } & (
-  | { rpcProvider: string | BundlerClient; chainId: number }
-  | { accountProvider: SmartAccountClient<TTransport, TChain, TAccount> }
+  | {
+      rpcProvider: string | BundlerClient<TTransport>;
+      chainId: number;
+    }
+  | {
+      accountProvider: SmartAccountClient<TTransport, TChain, TAccount>;
+    }
 );

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
@@ -24,15 +24,15 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     isType: true,
   });
   addImport("@alchemy/aa-core", {
-    name: "UserOperationOverrides",
-    isType: true,
-  });
-  addImport("@alchemy/aa-core", {
     name: "GetAccountParameter",
     isType: true,
   });
   addImport("@alchemy/aa-core", {
     name: "SendUserOperationResult",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
+    name: "EntryPointVersion",
     isType: true,
   });
   addImport("@alchemy/aa-core", { name: "AccountNotFoundError" });
@@ -46,15 +46,15 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     .map((n) => {
       const argsParamString =
         n.inputs.length > 0
-          ? dedent`{ 
-                  args, 
-                  overrides, 
-                  account = client.account 
+          ? dedent`{
+                  args,
+                  overrides,
+                  account = client.account
               }`
-          : dedent`{ 
-              overrides, 
-              account = client.account 
-          }`;
+          : dedent`{
+                  overrides,
+                  account = client.account
+              }`;
       const argsEncodeString = n.inputs.length > 0 ? "args," : "";
 
       providerFunctionDefs.push(dedent`
@@ -62,33 +62,37 @@ export const PluginActionsGenPhase: Phase = async (input) => {
             n.name
           )}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${
         n.name
-      }">, "args"> & { 
-            overrides?: UserOperationOverrides; 
-          } & GetAccountParameter<TAccount> & GetContextParameter<TContext>) => Promise<SendUserOperationResult>
-        `);
+      }">, "args"> & UserOperationOverridesParameter<TEntryPointVersion> &
+          GetAccountParameter<TAccount> & GetContextParameter<TContext>) =>
+            Promise<SendUserOperationResult<TEntryPointVersion>>
+      `);
       const methodName = camelCase(n.name);
       return dedent`
               ${methodName}(${argsParamString}) {
                 if (!account) {
                   throw new AccountNotFoundError();
-                } 
+                }
                 if (!isSmartAccountClient(client)) {
                   throw new IncompatibleClientError("SmartAccountClient", "${methodName}", client);
                 }
-  
+
                 const uo = encodeFunctionData({
                   abi: ${executionAbiConst},
                   functionName: "${n.name}",
                   ${argsEncodeString}
                 });
-  
+
                 return client.sendUserOperation({ uo, overrides, account, context });
               }
             `;
     });
 
   addType(
-    "ExecutionActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined, TContext extends Record<string, any> | undefined = Record<string, any> | undefined>",
+    `ExecutionActions<
+      TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined,
+      TContext extends Record<string, any> | undefined = Record<string, any> | undefined,
+      TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+    >`,
     dedent`{
         ${providerFunctionDefs.join(";\n\n")}
       }`
@@ -103,9 +107,11 @@ export const PluginActionsGenPhase: Phase = async (input) => {
   });
 
   addType(
-    `${pluginConfig.name}Actions<TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
-    | undefined, TContext extends Record<string, any> | undefined = Record<string, any> | undefined>`,
+    `${pluginConfig.name}Actions<
+      TAccount extends SmartContractAccount | undefined =
+          | SmartContractAccount
+          | undefined,
+      TContext extends Record<string, any> | undefined = Record<string, any> | undefined>`,
     dedent`
     ExecutionActions<TAccount, TContext> & ManagementActions<TAccount, TContext> & ReadAndEncodeActions${
       hasReadMethods ? "<TAccount>" : ""
@@ -116,6 +122,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
 
   input.content.push(dedent`
     export const ${camelCase(pluginConfig.name)}Actions: <
+        TEntryPointVersion extends EntryPointVersion,
         TTransport extends Transport = Transport,
         TChain extends Chain | undefined = Chain | undefined,
         TAccount extends SmartContractAccount | undefined =
@@ -123,7 +130,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
             | undefined,
         TContext extends Record<string, any> | undefined = Record<string, any> | undefined
     >(
-        client: Client<TTransport, TChain, TAccount>
+      client: Client<TTransport, TChain, TAccount>
     ) => ${
       pluginConfig.name
     }Actions<TAccount, TContext> = (client) => ({ ${providerFunctions.join(

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
@@ -122,7 +122,6 @@ export const PluginActionsGenPhase: Phase = async (input) => {
 
   input.content.push(dedent`
     export const ${camelCase(pluginConfig.name)}Actions: <
-        TEntryPointVersion extends EntryPointVersion,
         TTransport extends Transport = Transport,
         TChain extends Chain | undefined = Chain | undefined,
         TAccount extends SmartContractAccount | undefined =

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
@@ -47,14 +47,16 @@ export const PluginActionsGenPhase: Phase = async (input) => {
       const argsParamString =
         n.inputs.length > 0
           ? dedent`{
-                  args,
-                  overrides,
-                  account = client.account
-              }`
+                args,
+                overrides,
+                context,
+                account = client.account
+            }`
           : dedent`{
-                  overrides,
-                  account = client.account
-              }`;
+                overrides,
+                context,
+                account = client.account
+            }`;
       const argsEncodeString = n.inputs.length > 0 ? "args," : "";
 
       providerFunctionDefs.push(dedent`

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts
@@ -24,11 +24,16 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
       true
     );
     addType(
-      "ManagementActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined, TContext extends Record<string, any> | undefined = Record<string,any> | undefined>",
+      `ManagementActions<
+        TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined,
+        TContext extends Record<string, any> | undefined = Record<string,any> | undefined,
+        TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+      >`,
       dedent`{
-      install${pluginConfig.name}: (args: {
-        overrides?: UserOperationOverrides
-      } & Install${pluginConfig.name}Params & GetAccountParameter<TAccount> & GetContextParameter<TContext>) => Promise<SendUserOperationResult>
+      install${pluginConfig.name}: (args:
+        UserOperationOverridesParameter<TEntryPointVersion> &
+        Install${pluginConfig.name}Params & GetAccountParameter<TAccount> & GetContextParameter<TContext>) =>
+          Promise<SendUserOperationResult<TEntryPointVersion>>
     }`
     );
 

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/read-actions.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/read-actions.ts
@@ -48,8 +48,12 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
       const readMethodName = `read${pascalCase(n.name)}`;
       accountFunctionActionDefs.push(
         n.inputs.length > 0
-          ? dedent`${readMethodName}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> & GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
-          : dedent`${readMethodName}: (args: GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          ? dedent`${readMethodName}: (
+            args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> &
+              GetAccountParameter<TEntryPointVersion, TAccount>
+          ) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          : dedent`${readMethodName}: (args: GetAccountParameter<TEntryPointVersion, TAccount>) =>
+              Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
       );
 
       methodContent.push(dedent`
@@ -76,7 +80,11 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
   });
 
   const typeName = input.hasReadMethods
-    ? "ReadAndEncodeActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>"
+    ? `ReadAndEncodeActions<
+        TEntryPointVersion extends EntryPointVersion,
+        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+          SmartContractAccount<TEntryPointVersion> | undefined
+      >`
     : "ReadAndEncodeActions";
 
   addType(

--- a/site/packages/aa-core/accounts/index.md
+++ b/site/packages/aa-core/accounts/index.md
@@ -84,6 +84,6 @@ export type SmartContractAccount<Name extends string = string> =
     isAccountDeployed: () => Promise<boolean>;
     getFactoryAddress: () => Address;
     getEntrypoint: () => Address;
-    getImplementationAddress: () => Promise<"0x0" | Address>;
+    getImplementationAddress: () => Promise<NullAddress | Address>;
   };
 ```


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various files across packages to introduce versioning changes related to entry points, smart accounts, and APIs.

### Detailed summary
- Renamed entry point ABI files to include version suffix
- Updated `HexSchema` to use strict hex validation
- Added `API_KEY_STAGING` constant in test constants
- Modified functions to use `Promise<NullAddress | Address>`
- Updated function signatures to include versioning information
- Introduced new error classes for entry point and user operation
- Refactored middleware functions to handle different entry point versions

> The following files were skipped due to too many changes: `packages/core/src/utils/testUtils.ts`, `packages/core/src/errors/account.ts`, `packages/accounts/src/msca/plugin-manager/decorator.ts`, `packages/core/src/account/schema.ts`, `packages/ethers/src/types.ts`, `packages/alchemy/src/middleware/userOperationSimulator.ts`, `packages/accounts/src/light-account/decorator.ts`, `packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts`, `packages/core/src/middleware/types.ts`, `packages/ethers/src/provider-adapter.ts`, `packages/core/src/actions/smartAccount/sendTransactions.ts`, `packages/core/src/middleware/defaults/overridePaymasterData.ts`, `packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts`, `packages/accounts/src/msca/plugins/multisig/actions/proposeUserOperation.ts`, `packages/accounts/src/msca/plugins/multisig/types.ts`, `packages/accounts/src/msca/plugin-manager/installPlugin.ts`, `packages/core/src/actions/smartAccount/sendUserOperation.ts`, `packages/plugingen/src/commands/generate/phases/plugin-actions/read-actions.ts`, `packages/accounts/plugingen/phases/plugin-actions/management-actions.ts`, `packages/accounts/src/light-account/actions/transferOwnership.ts`, `packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts`, `packages/accounts/src/nani-account/account.ts`, `packages/core/src/actions/smartAccount/signUserOperation.ts`, `packages/accounts/src/msca/plugins/multi-owner/plugin.ts`, `packages/accounts/src/msca/plugins/multisig/plugin.ts`, `packages/core/src/index.ts`, `packages/accounts/src/msca/plugins/multisig/utils/splitAggregatedSignature.ts`, `packages/accounts/src/msca/account/multisigAccount.ts`, `packages/core/src/actions/smartAccount/sendTransaction.ts`, `packages/accounts/src/msca/utils.ts`, `packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts`, `packages/core/src/__tests__/utils.test.ts`, `packages/core/src/account/base.ts`, `packages/core/src/actions/smartAccount/internal/sendUserOperation.ts`, `packages/ethers/src/account-signer.ts`, `packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts`, `packages/core/src/utils/types.ts`, `packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts`, `packages/core/src/actions/smartAccount/buildUserOperation.ts`, `packages/core/src/utils/index.ts`, `packages/accounts/src/msca/account/multiOwnerAccount.ts`, `packages/core/src/client/decorators/bundlerClient.ts`, `packages/core/src/utils/defaults.ts`, `packages/accounts/plugingen/phases/plugin-actions/index.ts`, `packages/accounts/src/msca/plugins/session-key/plugin.ts`, `packages/core/src/client/decorators/smartAccountClient.ts`, `packages/accounts/src/light-account/account.ts`, `packages/core/src/utils/userop.ts`, `packages/alchemy/src/client/types.ts`, `packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts`, `packages/core/src/entrypoint/0.6.ts`, `packages/accounts/src/msca/plugins/session-key/extension.ts`, `packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts`, `packages/core/src/entrypoint/types.ts`, `packages/core/src/actions/smartAccount/types.ts`, `packages/core/src/entrypoint/0.7.ts`, `packages/core/src/entrypoint/index.ts`, `packages/core/e2e-tests/simple-account-staging.e2e.test.ts`, `packages/core/src/account/simple.ts`, `packages/core/src/abis/SimpleAccountAbi_v7.ts`, `packages/core/src/account/smartContractAccount.ts`, `packages/alchemy/src/middleware/gasManager.ts`, `packages/core/src/types.ts`, `packages/core/src/abis/EntryPointAbi_v7.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206854921431396
  - https://app.asana.com/0/0/1206826573496436
  - https://app.asana.com/0/0/1206826573496426
  - https://app.asana.com/0/0/1206924039831384