### PR TITLE
docs(fix): fix broken links in readme and aa-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ There are currently 5 SDKs that are part of the `aa-sdk` suite:
 
 The core SDK also implements an EIP-1193 provider interface to easily plug into any popular dapp or wallet connect libraries such as RainbowKit, Wagmi, and Web3Modal. It also includes [`ethers.js`](https://docs.ethers.org/v5/) adapters to provide full support for `ethers.js`` apps.
 
-The `aa-sdk` is modular at every layer of the stack and can be easily extended to fit your custom needs. You can plug in any [smart account](https://accountkit.alchemy.com/smart-accounts/custom/using-your-own) implementation, [Signer](https://accountkit.alchemy.com/signers/overview), [Gas Manager API](https://accountkit.alchemy.com/getting-started/overview.html#gas-manager-api) and RPC Provider.
+The `aa-sdk` is modular at every layer of the stack and can be easily extended to fit your custom needs. You can plug in any [smart account](https://accountkit.alchemy.com/smart-accounts/custom/using-your-own) implementation, [Signer](https://accountkit.alchemy.com/signers/choosing-a-signer.html), [Gas Manager API](https://accountkit.alchemy.com/getting-started/overview.html#gas-manager-api) and RPC Provider.
 
 ## Getting started
 
-The `aa-sdk` is part of [Account Kit](https://accountkit.alchemy.com). Check out this [quickstart guide](https://accountkit.alchemy.com/getting-started.html) to get started, or an [overview](https://accountkit.alchemy.com/overview/package-overview.html) of each of the SDKs in this repo.
+The `aa-sdk` is part of [Account Kit](https://accountkit.alchemy.com). Check out this [quickstart guide](https://accountkit.alchemy.com/getting-started/setup.html) to get started, or an [overview](https://accountkit.alchemy.com/packages/) of each of the SDKs in this repo.
 
 ## Contributing
 

--- a/site/.vitepress/sidebar/packages/aa-core.ts
+++ b/site/.vitepress/sidebar/packages/aa-core.ts
@@ -121,7 +121,6 @@ export const aaCoreSidebar: DefaultTheme.SidebarItem = {
     {
       text: "Bundler Actions",
       collapsed: true,
-      link: "/packages/aa-core/bundler-client/actions/bundlerActions",
       base: "/packages/aa-core/bundler-client/actions",
       items: [
         {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates links in the `aa-core` documentation for Signer and Gas Manager API. It also corrects links in the `Getting started` section for Account Kit. 

### Detailed summary
- Updated Signer link in `aa-core` documentation
- Corrected Gas Manager API link in `aa-core` documentation
- Updated Account Kit quickstart guide link
- Updated Account Kit overview link

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->