### PR TITLE
refactor: [Entrypoint 0.7 SDK] make EP version generic backwards compatible and remove in places

### DIFF
--- a/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
@@ -25,14 +25,14 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
     );
     addType(
       `ManagementActions<
-        TEntryPointVersion extends EntryPointVersion,
-        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-          SmartContractAccount<TEntryPointVersion> | undefined,
+        TAccount extends SmartContractAccount | undefined =
+          SmartContractAccount | undefined,
+        TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
       >`,
       dedent`{
       install${contract.name}: (
         args: { overrides?: UserOperationOverrides<TEntryPointVersion> } &
-          Install${contract.name}Params & GetAccountParameter<TEntryPointVersion, TAccount>
+          Install${contract.name}Params & GetAccountParameter<TAccount>
       ) => Promise<SendUserOperationResult<TEntryPointVersion>>
     }`
     );
@@ -129,7 +129,7 @@ const addImports = (
     isType: true,
   });
   addImport("@alchemy/aa-core", {
-    name: "EntryPointVersion",
+    name: "GetEntryPointFromAccount",
     isType: true,
   });
   // TODO: after plugingen becomes its own cli tool package, this should be changed to

--- a/packages/accounts/plugingen/phases/plugin-actions/read-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/read-actions.ts
@@ -45,8 +45,8 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
       const readMethodName = `read${pascalCase(n.name)}`;
       accountFunctionActionDefs.push(
         n.inputs.length > 0
-          ? dedent`${readMethodName}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> & GetAccountParameter<TEntryPointVersion, TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
-          : dedent`${readMethodName}: (args: GetAccountParameter<TEntryPointVersion, TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          ? dedent`${readMethodName}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> & GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          : dedent`${readMethodName}: (args: GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
       );
 
       methodContent.push(dedent`
@@ -74,9 +74,8 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
 
   const typeName = input.hasReadMethods
     ? `ReadAndEncodeActions<
-        TEntryPointVersion extends EntryPointVersion,
-        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-          SmartContractAccount<TEntryPointVersion> | undefined
+        TAccount extends SmartContractAccount | undefined =
+          SmartContractAccount | undefined,
       >`
     : "ReadAndEncodeActions";
 

--- a/packages/accounts/src/light-account/actions/transferOwnership.ts
+++ b/packages/accounts/src/light-account/actions/transferOwnership.ts
@@ -2,8 +2,8 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
-  type EntryPointVersion,
   type GetAccountParameter,
+  type GetEntryPointFromAccount,
   type SmartAccountSigner,
   type UserOperationOverridesParameter,
 } from "@alchemy/aa-core";
@@ -11,36 +11,27 @@ import type { Chain, Client, Hex, Transport } from "viem";
 import type { LightAccount } from "../account";
 
 export type TransferLightAccountOwnershipParams<
-  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined =
-    | LightAccount<TEntryPointVersion, TSigner>
-    | undefined
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   newOwner: TSigner;
   waitForTxn?: boolean;
-} & GetAccountParameter<
-  TEntryPointVersion,
-  TAccount,
-  LightAccount<TEntryPointVersion>
-> &
+} & GetAccountParameter<TAccount, LightAccount<TSigner>> &
   UserOperationOverridesParameter<TEntryPointVersion>;
 
 export const transferOwnership: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined =
-    | LightAccount<TEntryPointVersion, TSigner>
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: TransferLightAccountOwnershipParams<
-    TEntryPointVersion,
-    TSigner,
-    TAccount
-  >
+  args: TransferLightAccountOwnershipParams<TSigner, TAccount>
 ) => Promise<Hex> = async (
   client,
   { newOwner, waitForTxn, overrides, account = client.account }

--- a/packages/accounts/src/light-account/client.ts
+++ b/packages/accounts/src/light-account/client.ts
@@ -1,13 +1,12 @@
 import {
   createSmartAccountClient,
-  type EntryPointVersion,
   type SmartAccountClient,
   type SmartAccountClientActions,
   type SmartAccountClientConfig,
   type SmartAccountSigner,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
-import { type Chain, type Transport } from "viem";
+import { type Chain, type CustomTransport, type Transport } from "viem";
 import {
   createLightAccount,
   type CreateLightAccountParams,
@@ -19,26 +18,18 @@ import {
 } from "./decorator.js";
 
 export type CreateLightAccountClientParams<
-  TEntryPointVersion extends EntryPointVersion,
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = {
-  transport: CreateLightAccountParams<
-    TEntryPointVersion,
-    Transport,
-    TSigner
-  >["transport"];
-  chain: CreateLightAccountParams<
-    TEntryPointVersion,
-    Transport,
-    TSigner
-  >["chain"];
+  transport: CreateLightAccountParams<TTransport, TSigner>["transport"];
+  chain: CreateLightAccountParams<TTransport, TSigner>["chain"];
   account: Omit<
-    CreateLightAccountParams<TEntryPointVersion, Transport, TSigner>,
+    CreateLightAccountParams<TTransport, TSigner>,
     "transport" | "chain"
   >;
 } & Omit<
-  SmartAccountClientConfig<TEntryPointVersion, Transport, TChain>,
+  SmartAccountClientConfig<TTransport, TChain>,
   "transport" | "account" | "chain"
 >;
 
@@ -46,54 +37,30 @@ export function createLightAccountClient<
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateLightAccountClientParams<EntryPointVersion, TChain, TSigner>
+  args: CreateLightAccountClientParams<Transport, TChain, TSigner>
 ): Promise<
   SmartAccountClient<
-    EntryPointVersion,
-    Transport,
-    TChain,
-    LightAccount<EntryPointVersion, TSigner>,
-    SmartAccountClientActions<
-      EntryPointVersion,
-      TChain,
-      SmartContractAccount<EntryPointVersion>
-    > &
-      LightAccountClientActions<
-        EntryPointVersion,
-        TSigner,
-        LightAccount<EntryPointVersion, TSigner>
-      >
+    CustomTransport,
+    Chain,
+    LightAccount<TSigner>,
+    SmartAccountClientActions<Chain, SmartContractAccount> &
+      LightAccountClientActions<TSigner, LightAccount<TSigner>>
   >
 >;
 
-export async function createLightAccountClient<
-  TChain extends Chain | undefined = Chain | undefined,
-  TSigner extends SmartAccountSigner = SmartAccountSigner
->({
+export async function createLightAccountClient({
   account,
   transport,
   chain,
   ...clientConfig
-}: CreateLightAccountClientParams<EntryPointVersion, TChain, TSigner>): Promise<
-  SmartAccountClient<
-    EntryPointVersion,
-    Transport,
-    TChain,
-    LightAccount<EntryPointVersion>
-  >
-> {
+}: CreateLightAccountClientParams): Promise<SmartAccountClient> {
   const lightAccount = await createLightAccount({
     ...account,
     transport,
     chain,
   });
 
-  return createSmartAccountClient<
-    EntryPointVersion,
-    Transport,
-    TChain,
-    LightAccount<EntryPointVersion>
-  >({
+  return createSmartAccountClient({
     ...clientConfig,
     transport,
     chain: chain,

--- a/packages/accounts/src/light-account/decorator.ts
+++ b/packages/accounts/src/light-account/decorator.ts
@@ -1,4 +1,4 @@
-import type { EntryPointVersion, SmartAccountSigner } from "@alchemy/aa-core";
+import type { SmartAccountSigner } from "@alchemy/aa-core";
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { LightAccount } from "./account";
 import {
@@ -7,33 +7,25 @@ import {
 } from "./actions/transferOwnership.js";
 
 export type LightAccountClientActions<
-  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined =
-    | LightAccount<TEntryPointVersion, TSigner>
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 > = {
   transferOwnership: (
-    args: TransferLightAccountOwnershipParams<
-      TEntryPointVersion,
-      TSigner,
-      TAccount
-    >
+    args: TransferLightAccountOwnershipParams<TSigner, TAccount>
   ) => Promise<Hex>;
 };
 
 export const lightAccountClientActions: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined =
-    | LightAccount<TEntryPointVersion, TSigner>
+  TAccount extends LightAccount<TSigner> | undefined =
+    | LightAccount<TSigner>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => LightAccountClientActions<TEntryPointVersion, TSigner, TAccount> = (
-  client
-) => ({
+) => LightAccountClientActions<TSigner, TAccount> = (client) => ({
   transferOwnership: async (args) => transferOwnership(client, args),
 });

--- a/packages/accounts/src/light-account/utils.ts
+++ b/packages/accounts/src/light-account/utils.ts
@@ -15,7 +15,6 @@ import {
   polygonAmoy,
   polygonMumbai,
   sepolia,
-  type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import { fromHex, type Address, type Chain } from "viem";
@@ -96,10 +95,7 @@ export const LightAccountUnsupported1271Factories = new Set(
   LightAccountUnsupported1271Impls.map((x) => x.factoryAddress)
 );
 
-export const getLightAccountVersion = async <
-  TEntryPointVersion extends EntryPointVersion,
-  A extends SmartContractAccount<TEntryPointVersion>
->(
+export const getLightAccountVersion = async <A extends SmartContractAccount>(
   account: A
 ) => {
   const implAddress = await account.getImplementationAddress();

--- a/packages/accounts/src/msca/account-loupe/decorator.ts
+++ b/packages/accounts/src/msca/account-loupe/decorator.ts
@@ -2,7 +2,6 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
-  type EntryPointVersion,
   type GetAccountParameter,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -16,9 +15,8 @@ import type {
 } from "./types.js";
 
 export type AccountLoupeActions<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 > = {
   /// @notice Gets the validation functions and plugin address for a selector
@@ -26,10 +24,7 @@ export type AccountLoupeActions<
   /// @param selector The selector to get the configuration for
   /// @return The configuration for this selector
   getExecutionFunctionConfig(
-    args: { selector: FunctionReference } & GetAccountParameter<
-      TEntryPointVersion,
-      TAccount
-    >
+    args: { selector: FunctionReference } & GetAccountParameter<TAccount>
   ): Promise<ExecutionFunctionConfig>;
 
   /// @notice Gets the pre and post execution hooks for a selector
@@ -38,7 +33,7 @@ export type AccountLoupeActions<
   getExecutionHooks(
     args: {
       selector: FunctionReference;
-    } & GetAccountParameter<TEntryPointVersion, TAccount>
+    } & GetAccountParameter<TAccount>
   ): Promise<ReadonlyArray<ExecutionHooks>>;
 
   /// @notice Gets the pre user op and runtime validation hooks associated with a selector
@@ -46,26 +41,25 @@ export type AccountLoupeActions<
   /// @return preUserOpValidationHooks The pre user op validation hooks for this selector
   /// @return preRuntimeValidationHooks The pre runtime validation hooks for this selector
   getPreValidationHooks(
-    args: { selector: Hash } & GetAccountParameter<TEntryPointVersion, TAccount>
+    args: { selector: Hash } & GetAccountParameter<TAccount>
   ): Promise<Readonly<PreValidationHooks>>;
 
   /// @notice Gets an array of all installed plugins
   /// @return The addresses of all installed plugins
   getInstalledPlugins(
-    args: GetAccountParameter<TEntryPointVersion, TAccount>
+    args: GetAccountParameter<TAccount>
   ): Promise<ReadonlyArray<Address>>;
 };
 
 export const accountLoupeActions: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => AccountLoupeActions<TEntryPointVersion, TAccount> = (client) => ({
+) => AccountLoupeActions<TAccount> = (client) => ({
   getExecutionFunctionConfig: async ({
     selector,
     account = client.account,

--- a/packages/accounts/src/msca/account/standardExecutor.ts
+++ b/packages/accounts/src/msca/account/standardExecutor.ts
@@ -1,9 +1,9 @@
-import type { EntryPointVersion, SmartContractAccount } from "@alchemy/aa-core";
+import type { SmartContractAccount } from "@alchemy/aa-core";
 import { encodeFunctionData } from "viem";
 import { IStandardExecutorAbi } from "../abis/IStandardExecutor.js";
 
 export const standardExecutor: Pick<
-  SmartContractAccount<EntryPointVersion>,
+  SmartContractAccount,
   "encodeExecute" | "encodeBatchExecute"
 > = {
   encodeExecute: async ({ target, data, value }) => {

--- a/packages/accounts/src/msca/client.ts
+++ b/packages/accounts/src/msca/client.ts
@@ -1,6 +1,5 @@
 import {
   createSmartAccountClient,
-  type EntryPointVersion,
   type SmartAccountClient,
   type SmartAccountClientActions,
   type SmartAccountSigner,
@@ -26,81 +25,42 @@ import {
 } from "./plugins/multi-owner/index.js";
 
 export type CreateMultiOwnerModularAccountClientParams<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = {
   account: Omit<
-    CreateMultiOwnerModularAccountParams<
-      TEntryPointVersion,
-      TTransport,
-      TSigner
-    >,
+    CreateMultiOwnerModularAccountParams<TTransport, TSigner>,
     "transport" | "chain"
   >;
 } & Omit<
-  CreateLightAccountClientParams<TEntryPointVersion, TChain, TSigner>,
+  CreateLightAccountClientParams<TTransport, TChain, TSigner>,
   "account"
 >;
 
 export function createMultiOwnerModularAccountClient<
-  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateMultiOwnerModularAccountClientParams<
-    TEntryPointVersion,
-    Transport,
-    TChain,
-    TSigner
-  >
+  args: CreateMultiOwnerModularAccountClientParams<Transport, TChain, TSigner>
 ): Promise<
   SmartAccountClient<
-    TEntryPointVersion,
     CustomTransport,
     Chain,
-    MultiOwnerModularAccount<TEntryPointVersion, TSigner>,
-    SmartAccountClientActions<
-      TEntryPointVersion,
-      Chain,
-      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-    > &
-      MultiOwnerPluginActions<
-        TEntryPointVersion,
-        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-      > &
-      PluginManagerActions<
-        TEntryPointVersion,
-        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-      > &
-      AccountLoupeActions<
-        TEntryPointVersion,
-        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-      >
+    MultiOwnerModularAccount<TSigner>,
+    SmartAccountClientActions<Chain, MultiOwnerModularAccount<TSigner>> &
+      MultiOwnerPluginActions<MultiOwnerModularAccount<TSigner>> &
+      PluginManagerActions<MultiOwnerModularAccount<TSigner>> &
+      AccountLoupeActions<MultiOwnerModularAccount<TSigner>>
   >
 >;
 
-export async function createMultiOwnerModularAccountClient<
-  TSigner extends SmartAccountSigner = SmartAccountSigner
->({
+export async function createMultiOwnerModularAccountClient({
   account,
   transport,
   chain,
   ...clientConfig
-}: CreateMultiOwnerModularAccountClientParams<
-  EntryPointVersion,
-  Transport,
-  Chain,
-  TSigner
->): Promise<
-  SmartAccountClient<
-    EntryPointVersion,
-    Transport,
-    Chain,
-    MultiOwnerModularAccount<EntryPointVersion, TSigner>
-  >
-> {
+}: CreateMultiOwnerModularAccountClientParams): Promise<SmartAccountClient> {
   const modularAccount = await createMultiOwnerModularAccount({
     ...account,
     transport,

--- a/packages/accounts/src/msca/plugin-manager/decorator.ts
+++ b/packages/accounts/src/msca/plugin-manager/decorator.ts
@@ -1,5 +1,5 @@
 import type {
-  EntryPointVersion,
+  GetEntryPointFromAccount,
   SendUserOperationResult,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -14,29 +14,28 @@ export { type InstallPluginParams } from "./installPlugin.js";
 export { type UninstallPluginParams } from "./uninstallPlugin.js";
 
 export type PluginManagerActions<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   installPlugin: (
-    params: InstallPluginParams<TEntryPointVersion, TAccount>
+    params: InstallPluginParams<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   uninstallPlugin: (
-    params: UninstallPluginParams<TEntryPointVersion, TAccount>
+    params: UninstallPluginParams<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 export const pluginManagerActions: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => PluginManagerActions<TEntryPointVersion, TAccount> = (client) => ({
+) => PluginManagerActions<TAccount> = (client) => ({
   installPlugin: async (params) => installPlugin(client, params),
   uninstallPlugin: async (params) => uninstallPlugin(client, params),
 });

--- a/packages/accounts/src/msca/plugin-manager/installPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/installPlugin.ts
@@ -2,8 +2,8 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
-  type EntryPointVersion,
   type GetAccountParameter,
+  type GetEntryPointFromAccount,
   type SmartAccountClient,
   type SmartContractAccount,
   type UserOperationOverridesParameter,
@@ -23,28 +23,27 @@ import { IPluginManagerAbi } from "../abis/IPluginManager.js";
 import type { FunctionReference } from "../account-loupe/types.js";
 
 export type InstallPluginParams<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   pluginAddress: Address;
   manifestHash?: Hash;
   pluginInitData?: Hash;
   dependencies?: FunctionReference[];
 } & UserOperationOverridesParameter<TEntryPointVersion> &
-  GetAccountParameter<TEntryPointVersion, TAccount>;
+  GetAccountParameter<TAccount>;
 
 export async function installPlugin<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: InstallPluginParams<TEntryPointVersion, TAccount>
+  args: InstallPluginParams<TAccount>
 ) {
   const { overrides, account = client.account, ...params } = args;
 
@@ -70,15 +69,14 @@ export async function installPlugin<
 }
 
 export async function encodeInstallPluginUserOperation<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
-  client: SmartAccountClient<TEntryPointVersion, TTransport, TChain, TAccount>,
-  params: Omit<InstallPluginParams<TEntryPointVersion>, "overrides" | "account">
+  client: SmartAccountClient<TTransport, TChain, TAccount>,
+  params: Omit<InstallPluginParams, "overrides" | "account">
 ) {
   const pluginManifest = await client.readContract({
     abi: IPluginAbi,

--- a/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
@@ -2,8 +2,8 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
-  type EntryPointVersion,
   type GetAccountParameter,
+  type GetEntryPointFromAccount,
   type SmartContractAccount,
   type UserOperationOverridesParameter,
 } from "@alchemy/aa-core";
@@ -18,27 +18,26 @@ import {
 import { IPluginManagerAbi } from "../abis/IPluginManager.js";
 
 export type UninstallPluginParams<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   pluginAddress: Address;
   config?: Hash;
   pluginUninstallData?: Hash;
 } & UserOperationOverridesParameter<TEntryPointVersion> &
-  GetAccountParameter<TEntryPointVersion, TAccount>;
+  GetAccountParameter<TAccount>;
 
 export async function uninstallPlugin<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: UninstallPluginParams<TEntryPointVersion, TAccount>
+  args: UninstallPluginParams<TAccount>
 ) {
   const { overrides, account = client.account, ...params } = args;
 
@@ -63,13 +62,8 @@ export async function uninstallPlugin<
   });
 }
 
-export async function encodeUninstallPluginUserOperation<
-  TEntryPointVersion extends EntryPointVersion
->(
-  params: Omit<
-    UninstallPluginParams<TEntryPointVersion>,
-    "account" | "overrides"
-  >
+export async function encodeUninstallPluginUserOperation(
+  params: Omit<UninstallPluginParams, "account" | "overrides">
 ) {
   return encodeFunctionData({
     abi: IPluginManagerAbi,

--- a/packages/accounts/src/msca/plugins/multi-owner/signer.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/signer.ts
@@ -1,7 +1,6 @@
 import type {
   Address,
   BundlerClient,
-  EntryPointVersion,
   SmartAccountSigner,
 } from "@alchemy/aa-core";
 import {
@@ -17,11 +16,10 @@ import {
 import { MultiOwnerPlugin, MultiOwnerPluginAbi } from "./plugin.js";
 
 export const multiOwnerMessageSigner = <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport,
   TSigner extends SmartAccountSigner
 >(
-  client: BundlerClient<TEntryPointVersion, TTransport>,
+  client: BundlerClient<TTransport>,
   accountAddress: Address,
   signer: () => TSigner,
   pluginAddress: Address = MultiOwnerPlugin.meta.addresses[client.chain.id]

--- a/packages/accounts/src/msca/plugins/session-key/plugin.ts
+++ b/packages/accounts/src/msca/plugins/session-key/plugin.ts
@@ -17,11 +17,11 @@ import {
   AccountNotFoundError,
   isSmartAccountClient,
   IncompatibleClientError,
-  type EntryPointVersion,
   type SmartContractAccount,
   type UserOperationOverrides,
   type GetAccountParameter,
   type SendUserOperationResult,
+  type GetEntryPointFromAccount,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
 import { MultiOwnerPlugin } from "../multi-owner/plugin.js";
@@ -33,10 +33,10 @@ import { type FunctionReference } from "../../account-loupe/types.js";
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 type ExecutionActions<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   executeWithSessionKey: (
     args: Pick<
@@ -47,7 +47,7 @@ type ExecutionActions<
       "args"
     > & {
       overrides?: UserOperationOverrides<TEntryPointVersion>;
-    } & GetAccountParameter<TEntryPointVersion, TAccount>
+    } & GetAccountParameter<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   addSessionKey: (
@@ -59,7 +59,7 @@ type ExecutionActions<
       "args"
     > & {
       overrides?: UserOperationOverrides<TEntryPointVersion>;
-    } & GetAccountParameter<TEntryPointVersion, TAccount>
+    } & GetAccountParameter<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   removeSessionKey: (
@@ -71,7 +71,7 @@ type ExecutionActions<
       "args"
     > & {
       overrides?: UserOperationOverrides<TEntryPointVersion>;
-    } & GetAccountParameter<TEntryPointVersion, TAccount>
+    } & GetAccountParameter<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   rotateSessionKey: (
@@ -83,7 +83,7 @@ type ExecutionActions<
       "args"
     > & {
       overrides?: UserOperationOverrides<TEntryPointVersion>;
-    } & GetAccountParameter<TEntryPointVersion, TAccount>
+    } & GetAccountParameter<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   updateKeyPermissions: (
@@ -95,7 +95,7 @@ type ExecutionActions<
       "args"
     > & {
       overrides?: UserOperationOverrides<TEntryPointVersion>;
-    } & GetAccountParameter<TEntryPointVersion, TAccount>
+    } & GetAccountParameter<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
@@ -112,16 +112,16 @@ export type InstallSessionKeyPluginParams = {
 };
 
 type ManagementActions<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   installSessionKeyPlugin: (
     args: {
       overrides?: UserOperationOverrides<TEntryPointVersion>;
     } & InstallSessionKeyPluginParams &
-      GetAccountParameter<TEntryPointVersion, TAccount>
+      GetAccountParameter<TAccount>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
@@ -178,12 +178,12 @@ type ReadAndEncodeActions = {
 };
 
 export type SessionKeyPluginActions<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
-> = ExecutionActions<TEntryPointVersion, TAccount> &
-  ManagementActions<TEntryPointVersion, TAccount> &
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+> = ExecutionActions<TAccount, TEntryPointVersion> &
+  ManagementActions<TAccount, TEntryPointVersion> &
   ReadAndEncodeActions;
 
 const addresses = {
@@ -224,15 +224,15 @@ export const SessionKeyPlugin: Plugin<typeof SessionKeyPluginAbi> = {
 };
 
 export const sessionKeyPluginActions: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>
-) => SessionKeyPluginActions<TEntryPointVersion, TAccount> = (client) => ({
+) => SessionKeyPluginActions<TAccount, TEntryPointVersion> = (client) => ({
   executeWithSessionKey({ args, overrides, account = client.account }) {
     if (!account) {
       throw new AccountNotFoundError();

--- a/packages/accounts/src/msca/plugins/session-key/utils.ts
+++ b/packages/accounts/src/msca/plugins/session-key/utils.ts
@@ -1,5 +1,4 @@
 import type {
-  EntryPointVersion,
   GetAccountParameter,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -10,18 +9,17 @@ import { SessionKeyPlugin } from "./plugin.js";
 // find predecessors for each keys and returned the struct `ISessionKeyPlugin.SessionKeyToRemove[]`
 // where SessionKeyToRemove = { sessionKey: Address, predecessor: Hex }
 export const buildSessionKeysToRemoveStruct: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: {
     keys: ReadonlyArray<Address>;
     pluginAddress?: Address;
-  } & GetAccountParameter<TEntryPointVersion, TAccount>
+  } & GetAccountParameter<TAccount>
 ) => Promise<{ sessionKey: Address; predecessor: Address }[]> = async (
   client,
   { keys, pluginAddress, account = client.account }

--- a/packages/accounts/src/msca/utils.ts
+++ b/packages/accounts/src/msca/utils.ts
@@ -17,7 +17,6 @@ import {
   polygonAmoy,
   polygonMumbai,
   sepolia,
-  type EntryPointVersion,
   type GetAccountParameter,
   type SmartAccountClient,
   type SmartAccountSigner,
@@ -74,25 +73,20 @@ export const getDefaultMultiOwnerModularAccountFactoryAddress = (
 };
 
 export async function getMSCAUpgradeToData<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
   TAccount extends
-    | SmartContractAccountWithSigner<TEntryPointVersion, string, TSigner>
-    | undefined =
-    | SmartContractAccountWithSigner<TEntryPointVersion, string, TSigner>
-    | undefined
+    | SmartContractAccountWithSigner<string, TSigner>
+    | undefined = SmartContractAccountWithSigner<string, TSigner> | undefined
 >(
-  client: SmartAccountClient<TEntryPointVersion, TTransport, TChain, TAccount>,
+  client: SmartAccountClient<TTransport, TChain, TAccount>,
   args: {
     multiOwnerPluginAddress?: Address;
-  } & GetAccountParameter<TEntryPointVersion, TAccount>
+  } & GetAccountParameter<TAccount>
 ): Promise<
   UpgradeToData & {
-    createMAAccount: () => Promise<
-      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-    >;
+    createMAAccount: () => Promise<MultiOwnerModularAccount<TSigner>>;
   }
 > {
   const { account: account_ = client.account, multiOwnerPluginAddress } = args;
@@ -100,11 +94,7 @@ export async function getMSCAUpgradeToData<
   if (!account_) {
     throw new AccountNotFoundError();
   }
-  const account = account_ as SmartContractAccountWithSigner<
-    TEntryPointVersion,
-    string,
-    TSigner
-  >;
+  const account = account_ as SmartContractAccountWithSigner<string, TSigner>;
 
   const chain = client.chain;
   if (!chain) {
@@ -130,16 +120,18 @@ export async function getMSCAUpgradeToData<
 }
 
 export async function getMAInitializationData<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain | undefined
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends SmartContractAccountWithSigner | undefined =
+    | SmartContractAccountWithSigner
+    | undefined
 >({
   client,
   multiOwnerPluginAddress,
   signerAddress,
 }: {
   multiOwnerPluginAddress?: Address;
-  client: SmartAccountClient<TEntryPointVersion, TTransport, TChain>;
+  client: SmartAccountClient<TTransport, TChain, TAccount>;
   signerAddress: Address | Address[];
 }): Promise<UpgradeToData> {
   if (!client.chain) {

--- a/packages/accounts/src/nani-account/account.ts
+++ b/packages/accounts/src/nani-account/account.ts
@@ -30,10 +30,7 @@ import { NaniAccountFactoryAbi } from "./abis/NaniAccountFactoryAbi.js";
 
 export type NaniSmartAccountParams<
   TTransport extends Transport | FallbackTransport = Transport
-> = Omit<
-  BaseSmartAccountParams<DefaultEntryPointVersion, TTransport>,
-  "rpcClient"
-> & {
+> = Omit<BaseSmartAccountParams<TTransport>, "rpcClient"> & {
   signer: SmartAccountSigner;
   index?: bigint;
   salt?: Hex;
@@ -42,9 +39,9 @@ export type NaniSmartAccountParams<
 };
 
 export type NaniAccount = SmartContractAccountWithSigner<
-  DefaultEntryPointVersion,
   "NaniAccount",
-  SmartAccountSigner
+  SmartAccountSigner,
+  "0.6.0"
 > & {
   encodeExecuteDelegate: (delegate: Address, data: Hex) => Hex;
   encodeTransferOwnership: (newOwner: Address) => Hex;
@@ -52,7 +49,7 @@ export type NaniAccount = SmartContractAccountWithSigner<
 
 class NaniAccount_<
   TTransport extends Transport | FallbackTransport = Transport
-> extends BaseSmartContractAccount<DefaultEntryPointVersion, TTransport> {
+> extends BaseSmartContractAccount<TTransport> {
   protected signer: SmartAccountSigner;
   private readonly index: bigint;
   protected salt?: Hex;

--- a/packages/accounts/src/nani-account/transferNaniAccountOwnership.ts
+++ b/packages/accounts/src/nani-account/transferNaniAccountOwnership.ts
@@ -2,7 +2,6 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
-  type DefaultEntryPointVersion,
   type GetAccountParameter,
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
@@ -28,7 +27,7 @@ export const transferOwnership: <
   args: {
     newOwner: TSigner;
     waitForTxn?: boolean;
-  } & GetAccountParameter<DefaultEntryPointVersion, TAccount>
+  } & GetAccountParameter<TAccount>
 ) => Promise<Hex> = async (
   client,
   { newOwner, waitForTxn = false, account: account_ = client.account }

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@alchemy/aa-accounts": "*",
+    "@alchemy/aa-core": "*",
     "typescript": "^5.0.4",
     "typescript-template": "*",
     "vitest": "^0.31.0"

--- a/packages/alchemy/src/actions/simulateUserOperationChanges.ts
+++ b/packages/alchemy/src/actions/simulateUserOperationChanges.ts
@@ -2,7 +2,7 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   deepHexlify,
-  type EntryPointVersion,
+  type GetEntryPointFromAccount,
   type SendUserOperationParameters,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -12,11 +12,11 @@ import type { AlchemyRpcSchema } from "../client/types";
 import type { SimulateUserOperationAssetChangesResponse } from "./types";
 
 export const simulateUserOperationChanges: <
-  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<
     Transport,
@@ -24,7 +24,7 @@ export const simulateUserOperationChanges: <
     TAccount,
     AlchemyRpcSchema<TEntryPointVersion>
   >,
-  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
+  args: SendUserOperationParameters<TAccount>
 ) => Promise<SimulateUserOperationAssetChangesResponse> = async (
   client,
   { account = client.account, overrides, ...params }

--- a/packages/alchemy/src/client/decorators/alchemyEnhancedApis.ts
+++ b/packages/alchemy/src/client/decorators/alchemyEnhancedApis.ts
@@ -1,4 +1,4 @@
-import type { EntryPointVersion, SmartContractAccount } from "@alchemy/aa-core";
+import type { SmartContractAccount } from "@alchemy/aa-core";
 import type { Alchemy } from "alchemy-sdk";
 import type { Chain, HttpTransport, Transport } from "viem";
 import { AlchemySdkClientSchema } from "../../schema.js";
@@ -17,19 +17,13 @@ export type AlchemyEnhancedApis = {
 export const alchemyEnhancedApiActions: (
   alchemy: Alchemy
 ) => <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
-  client: AlchemySmartAccountClient<
-    TEntryPointVersion,
-    TTransport,
-    TChain,
-    TAccount
-  >
+  client: AlchemySmartAccountClient<TTransport, TChain, TAccount>
 ) => AlchemyEnhancedApis = (alchemy) => (client) => {
   const alchemySdk = AlchemySdkClientSchema.parse(alchemy);
 

--- a/packages/alchemy/src/client/decorators/smartAccount.ts
+++ b/packages/alchemy/src/client/decorators/smartAccount.ts
@@ -1,5 +1,4 @@
 import type {
-  EntryPointVersion,
   SendUserOperationParameters,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -8,28 +7,24 @@ import { simulateUserOperationChanges } from "../../actions/simulateUserOperatio
 import type { SimulateUserOperationAssetChangesResponse } from "../../actions/types.js";
 
 export type AlchemySmartAccountClientActions<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 > = {
   simulateUserOperation: (
-    args: SendUserOperationParameters<TEntryPointVersion, TAccount>
+    args: SendUserOperationParameters<TAccount>
   ) => Promise<SimulateUserOperationAssetChangesResponse>;
 };
 
 export const alchemyActions: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => AlchemySmartAccountClientActions<TEntryPointVersion, TAccount> = (
-  client
-) => ({
+) => AlchemySmartAccountClientActions<TAccount> = (client) => ({
   simulateUserOperation: async (args) =>
     simulateUserOperationChanges(client, args),
 });

--- a/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
+++ b/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
@@ -1,7 +1,6 @@
 import {
   createSmartAccountClientFromExisting,
   getDefaultUserOperationFeeOptions,
-  type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import type { Chain, CustomTransport, Transport } from "viem";
@@ -16,31 +15,28 @@ import type {
 import type { ClientWithAlchemyMethods } from "../types";
 
 export type CreateAlchemySmartAccountClientFromRpcClient<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 > = Omit<
-  AlchemySmartAccountClientConfig<
-    TEntryPointVersion,
-    Transport,
-    Chain,
-    TAccount
-  >,
+  AlchemySmartAccountClientConfig<Transport, Chain, TAccount>,
   "rpcUrl" | "chain" | "apiKey" | "jwt"
-> & { client: ClientWithAlchemyMethods<TEntryPointVersion> };
+> & { client: ClientWithAlchemyMethods };
 
 /**
  * Helper method meant to be used internally to create an alchemy smart account client
  * from an existing Alchemy Rpc Client
  */
 export function createAlchemySmartAccountClientFromRpcClient<
-  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
->({
+>(
+  args: CreateAlchemySmartAccountClientFromRpcClient<TAccount>
+): AlchemySmartAccountClient<CustomTransport, TChain, TAccount>;
+
+export function createAlchemySmartAccountClientFromRpcClient({
   opts,
   account,
   useSimulation,
@@ -49,15 +45,7 @@ export function createAlchemySmartAccountClientFromRpcClient<
   gasEstimator,
   customMiddleware,
   client,
-}: CreateAlchemySmartAccountClientFromRpcClient<
-  TEntryPointVersion,
-  TAccount
->): AlchemySmartAccountClient<
-  TEntryPointVersion,
-  CustomTransport,
-  TChain,
-  TAccount
-> {
+}: CreateAlchemySmartAccountClientFromRpcClient): AlchemySmartAccountClient {
   const feeOptions =
     opts?.feeOptions ?? getDefaultUserOperationFeeOptions(client.chain);
 
@@ -91,10 +79,5 @@ export function createAlchemySmartAccountClientFromRpcClient<
             gasEstimator,
         },
       })),
-  }).extend(alchemyActions) as AlchemySmartAccountClient<
-    TEntryPointVersion,
-    CustomTransport,
-    TChain,
-    TAccount
-  >;
+  }).extend(alchemyActions);
 }

--- a/packages/alchemy/src/client/isAlchemySmartAccountClient.ts
+++ b/packages/alchemy/src/client/isAlchemySmartAccountClient.ts
@@ -1,26 +1,19 @@
 import {
   isSmartAccountClient,
-  type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import type { Chain, Client, Transport } from "viem";
 import type { AlchemySmartAccountClient } from "./smartAccountClient";
 
 export const isAlchemySmartAccountClient = <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-): client is AlchemySmartAccountClient<
-  TEntryPointVersion,
-  TTransport,
-  TChain,
-  TAccount
-> => {
+): client is AlchemySmartAccountClient<TTransport, TChain, TAccount> => {
   // TODO: the goal of this check is to make sure that the client supports certain RPC methods
   // we should probably do this by checking the client's transport and configured URL, since alchemy
   // clients have to be RPC clients. this is difficult to do though because the transport might

--- a/packages/alchemy/src/client/modularAccountClient.ts
+++ b/packages/alchemy/src/client/modularAccountClient.ts
@@ -10,7 +10,7 @@ import {
   type MultiOwnerPluginActions,
   type PluginManagerActions,
 } from "@alchemy/aa-accounts";
-import type { EntryPointVersion, SmartAccountSigner } from "@alchemy/aa-core";
+import type { SmartAccountSigner } from "@alchemy/aa-core";
 import {
   custom,
   type Chain,
@@ -28,66 +28,39 @@ import type {
 } from "./smartAccountClient";
 
 export type AlchemyModularAccountClientConfig<
-  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = Omit<
-  CreateMultiOwnerModularAccountParams<
-    TEntryPointVersion,
-    HttpTransport,
-    TSigner
-  >,
+  CreateMultiOwnerModularAccountParams<HttpTransport, TSigner>,
   "transport" | "chain"
 > &
   Omit<
-    AlchemySmartAccountClientConfig<
-      TEntryPointVersion,
-      Transport,
-      Chain,
-      LightAccount<TEntryPointVersion, TSigner>
-    >,
+    AlchemySmartAccountClientConfig<Transport, Chain, LightAccount<TSigner>>,
     "account"
   >;
 
 export function createModularAccountAlchemyClient<
-  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  params: AlchemyModularAccountClientConfig<TEntryPointVersion, TSigner>
+  params: AlchemyModularAccountClientConfig<TSigner>
 ): Promise<
   AlchemySmartAccountClient<
-    TEntryPointVersion,
     CustomTransport,
     Chain | undefined,
-    MultiOwnerModularAccount<TEntryPointVersion, TSigner>,
-    BaseAlchemyActions<
-      TEntryPointVersion,
-      Chain | undefined,
-      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-    > &
-      MultiOwnerPluginActions<
-        TEntryPointVersion,
-        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-      > &
-      PluginManagerActions<
-        TEntryPointVersion,
-        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-      > &
-      AccountLoupeActions<
-        TEntryPointVersion,
-        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
-      >
+    MultiOwnerModularAccount<TSigner>,
+    BaseAlchemyActions<Chain | undefined, MultiOwnerModularAccount<TSigner>> &
+      MultiOwnerPluginActions<MultiOwnerModularAccount<TSigner>> &
+      PluginManagerActions<MultiOwnerModularAccount<TSigner>> &
+      AccountLoupeActions<MultiOwnerModularAccount<TSigner>>
   >
 >;
 
-export async function createModularAccountAlchemyClient<
-  TEntryPointVersion extends EntryPointVersion
->(
-  config: AlchemyModularAccountClientConfig<TEntryPointVersion>
-): Promise<AlchemySmartAccountClient<TEntryPointVersion>> {
+export async function createModularAccountAlchemyClient(
+  config: AlchemyModularAccountClientConfig
+): Promise<AlchemySmartAccountClient> {
   const { chain, opts, ...connectionConfig } =
     AlchemyProviderConfigSchema.parse(config);
 
-  const client = createAlchemyPublicRpcClient<TEntryPointVersion>({
+  const client = createAlchemyPublicRpcClient({
     chain,
     connectionConfig,
   });

--- a/packages/alchemy/src/client/rpcClient.ts
+++ b/packages/alchemy/src/client/rpcClient.ts
@@ -1,21 +1,15 @@
-import {
-  createBundlerClient,
-  type ConnectionConfig,
-  type EntryPointVersion,
-} from "@alchemy/aa-core";
+import { createBundlerClient, type ConnectionConfig } from "@alchemy/aa-core";
 import { http, type Chain } from "viem";
 import { AlchemyChainSchema } from "../schema.js";
 import type { ClientWithAlchemyMethods } from "./types.js";
 
-export const createAlchemyPublicRpcClient = <
-  TEntryPointVersion extends EntryPointVersion
->({
+export const createAlchemyPublicRpcClient = ({
   chain: chain_,
   connectionConfig,
 }: {
   connectionConfig: ConnectionConfig;
   chain: Chain;
-}): ClientWithAlchemyMethods<TEntryPointVersion> => {
+}): ClientWithAlchemyMethods => {
   const chain = AlchemyChainSchema.parse(chain_);
 
   const rpcUrl =

--- a/packages/alchemy/src/client/smartAccountClient.ts
+++ b/packages/alchemy/src/client/smartAccountClient.ts
@@ -1,5 +1,5 @@
 import {
-  type EntryPointVersion,
+  type GetEntryPointFromAccount,
   type Prettify,
   type SmartAccountClient,
   type SmartAccountClientActions,
@@ -18,11 +18,10 @@ import { createAlchemyPublicRpcClient } from "./rpcClient.js";
 import type { AlchemyRpcSchema } from "./types.js";
 
 export type AlchemySmartAccountClientConfig<
-  version extends EntryPointVersion,
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
-  account extends SmartContractAccount<version> | undefined =
-    | SmartContractAccount<version>
+  account extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 > = {
   account?: account;
@@ -30,64 +29,58 @@ export type AlchemySmartAccountClientConfig<
   gasManagerConfig?: AlchemyGasManagerConfig;
 } & AlchemyProviderConfig &
   Pick<
-    SmartAccountClientConfig<version, transport, chain, account>,
+    SmartAccountClientConfig<transport, chain, account>,
     "customMiddleware" | "feeEstimator" | "gasEstimator"
   >;
 
 export type BaseAlchemyActions<
-  version extends EntryPointVersion,
   chain extends Chain | undefined = Chain | undefined,
-  account extends SmartContractAccount<version> | undefined =
-    | SmartContractAccount<version>
+  account extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
-> = SmartAccountClientActions<version, chain, account> &
-  AlchemySmartAccountClientActions<version, account>;
+> = SmartAccountClientActions<chain, account> &
+  AlchemySmartAccountClientActions<account>;
 
 export type AlchemySmartAccountClient_Base<
-  version extends EntryPointVersion,
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
-  account extends SmartContractAccount<version> | undefined =
-    | SmartContractAccount<version>
+  account extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined,
-  actions extends BaseAlchemyActions<
-    version,
+  actions extends BaseAlchemyActions<chain, account> = BaseAlchemyActions<
     chain,
     account
-  > = BaseAlchemyActions<version, chain, account>
+  >,
+  version extends GetEntryPointFromAccount<account> = GetEntryPointFromAccount<account>
 > = Prettify<
   SmartAccountClient<
-    version,
     transport,
     chain,
     account,
     actions,
-    [...SmartAccountClientRpcSchema<version>, ...AlchemyRpcSchema<version>]
+    [...SmartAccountClientRpcSchema, ...AlchemyRpcSchema<version>]
   >
 >;
 
 export type AlchemySmartAccountClient<
-  version extends EntryPointVersion,
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
-  account extends SmartContractAccount<version> | undefined =
-    | SmartContractAccount<version>
+  account extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined,
-  actions extends BaseAlchemyActions<
-    version,
+  actions extends BaseAlchemyActions<chain, account> = BaseAlchemyActions<
     chain,
     account
-  > = BaseAlchemyActions<version, chain, account>
+  >
 > = Prettify<
-  AlchemySmartAccountClient_Base<version, transport, chain, account, actions>
+  AlchemySmartAccountClient_Base<transport, chain, account, actions>
 >;
 
 export function createAlchemySmartAccountClient<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain = Chain,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >({
   account,
@@ -98,16 +91,20 @@ export function createAlchemySmartAccountClient<
   gasEstimator,
   ...config_
 }: AlchemySmartAccountClientConfig<
-  TEntryPointVersion,
   TTransport,
   TChain,
   TAccount
->): AlchemySmartAccountClient<
-  TEntryPointVersion,
-  TTransport,
-  TChain,
-  TAccount
-> {
+>): AlchemySmartAccountClient<TTransport, TChain, TAccount>;
+
+export function createAlchemySmartAccountClient({
+  account,
+  gasManagerConfig,
+  useSimulation,
+  feeEstimator,
+  customMiddleware,
+  gasEstimator,
+  ...config_
+}: AlchemySmartAccountClientConfig): AlchemySmartAccountClient {
   const config = AlchemyProviderConfigSchema.parse(config_);
   const { chain, opts, ...connectionConfig } = config;
 
@@ -131,10 +128,5 @@ export function createAlchemySmartAccountClient<
     feeEstimator,
     customMiddleware,
     gasEstimator,
-  }) as AlchemySmartAccountClient<
-    TEntryPointVersion,
-    TTransport,
-    TChain,
-    TAccount
-  >;
+  });
 }

--- a/packages/alchemy/src/client/types.ts
+++ b/packages/alchemy/src/client/types.ts
@@ -54,10 +54,8 @@ export type AlchemyRpcSchema<TEntryPointVersion extends EntryPointVersion> = [
   }
 ];
 
-export type ClientWithAlchemyMethods<
-  TEntryPointVersion extends EntryPointVersion
-> = BundlerClient<TEntryPointVersion, HttpTransport> & {
-  request: BundlerClient<TEntryPointVersion, HttpTransport>["request"] &
+export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
+  request: BundlerClient<HttpTransport>["request"] &
     {
       request(args: {
         method: "alchemy_requestPaymasterAndData";
@@ -65,7 +63,7 @@ export type ClientWithAlchemyMethods<
           {
             policyId: string;
             entryPoint: Address;
-            userOperation: UserOperationRequest<TEntryPointVersion>;
+            userOperation: UserOperationRequest<EntryPointVersion>;
           }
         ];
       }): Promise<{ paymasterAndData: Hex }>;
@@ -76,9 +74,9 @@ export type ClientWithAlchemyMethods<
           {
             policyId: string;
             entryPoint: Address;
-            userOperation: UserOperationRequest<TEntryPointVersion>;
+            userOperation: UserOperationRequest<EntryPointVersion>;
             dummySignature: Hex;
-            overrides?: RequestGasAndPaymasterAndDataOverrides<TEntryPointVersion>;
+            overrides?: RequestGasAndPaymasterAndDataOverrides<EntryPointVersion>;
           }
         ];
       }): Promise<{
@@ -92,7 +90,7 @@ export type ClientWithAlchemyMethods<
 
       request(args: {
         method: "alchemy_simulateUserOperationAssetChanges";
-        params: SimulateUserOperationAssetChangesRequest<TEntryPointVersion>;
+        params: SimulateUserOperationAssetChangesRequest<EntryPointVersion>;
       }): Promise<SimulateUserOperationAssetChangesResponse>;
 
       request(args: {

--- a/packages/alchemy/src/middleware/feeEstimator.ts
+++ b/packages/alchemy/src/middleware/feeEstimator.ts
@@ -1,11 +1,8 @@
-import type { ClientMiddlewareFn, EntryPointVersion } from "@alchemy/aa-core";
+import type { ClientMiddlewareFn } from "@alchemy/aa-core";
 import { applyUserOpOverrideOrFeeOption } from "@alchemy/aa-core";
 import type { ClientWithAlchemyMethods } from "../client/types";
 
-export const alchemyFeeEstimator: <
-  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
-  TEntryPointVersion extends EntryPointVersion
->(
+export const alchemyFeeEstimator: <C extends ClientWithAlchemyMethods>(
   client: C
 ) => ClientMiddlewareFn =
   (client) =>

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -55,10 +55,7 @@ export interface AlchemyGasEstimationOptions {
 }
 
 const dummyPaymasterAndData =
-  <
-    C extends ClientWithAlchemyMethods<TEntryPointVersion>,
-    TEntryPointVersion extends EntryPointVersion
-  >(
+  <C extends ClientWithAlchemyMethods>(
     client: C,
     config: AlchemyGasManagerConfig
   ) =>
@@ -72,10 +69,7 @@ const dummyPaymasterAndData =
     return `${paymasterAddress}${dummyData}` as Address;
   };
 
-export function alchemyGasManagerMiddleware<
-  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
-  TEntryPointVersion extends EntryPointVersion
->(
+export function alchemyGasManagerMiddleware<C extends ClientWithAlchemyMethods>(
   client: C,
   config: AlchemyGasManagerConfig
 ): Pick<
@@ -86,11 +80,10 @@ export function alchemyGasManagerMiddleware<
   const disableGasEstimation =
     gasEstimationOptions?.disableGasEstimation ?? false;
   const fallbackFeeDataGetter =
-    gasEstimationOptions?.fallbackFeeDataGetter ??
-    alchemyFeeEstimator<C, TEntryPointVersion>(client);
+    gasEstimationOptions?.fallbackFeeDataGetter ?? alchemyFeeEstimator(client);
   const fallbackGasEstimator =
     gasEstimationOptions?.fallbackGasEstimator ??
-    defaultGasEstimator<TEntryPointVersion, C>(client);
+    defaultGasEstimator<C>(client);
 
   return {
     gasEstimator: disableGasEstimation
@@ -165,17 +158,14 @@ export function alchemyGasManagerMiddleware<
   };
 }
 
-function requestGasAndPaymasterData<
-  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
-  TEntryPointVersion extends EntryPointVersion
->(
+function requestGasAndPaymasterData<C extends ClientWithAlchemyMethods>(
   client: C,
   config: AlchemyGasManagerConfig
 ): ClientMiddlewareConfig["paymasterAndData"] {
   return {
     dummyPaymasterAndData: dummyPaymasterAndData(client, config),
     paymasterAndData: async (struct, { overrides, feeOptions, account }) => {
-      const userOperation: UserOperationRequest<TEntryPointVersion> =
+      const userOperation: UserOperationRequest<EntryPointVersion> =
         deepHexlify(await resolveProperties(struct));
 
       const overrideField = (
@@ -208,7 +198,7 @@ function requestGasAndPaymasterData<
         return undefined;
       };
 
-      const _overrides: RequestGasAndPaymasterAndDataOverrides<TEntryPointVersion> =
+      const _overrides: RequestGasAndPaymasterAndDataOverrides<EntryPointVersion> =
         filterUndefined({
           maxFeePerGas: overrideField("maxFeePerGas"),
           maxPriorityFeePerGas: overrideField("maxPriorityFeePerGas"),
@@ -239,10 +229,7 @@ function requestGasAndPaymasterData<
   };
 }
 
-const requestPaymasterAndData: <
-  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
-  TEntryPointVersion extends EntryPointVersion
->(
+const requestPaymasterAndData: <C extends ClientWithAlchemyMethods>(
   client: C,
   config: AlchemyGasManagerConfig
 ) => ClientMiddlewareConfig["paymasterAndData"] = (client, config) => ({

--- a/packages/alchemy/src/middleware/userOperationSimulator.ts
+++ b/packages/alchemy/src/middleware/userOperationSimulator.ts
@@ -8,7 +8,7 @@ import {
 import type { ClientWithAlchemyMethods } from "../client/types";
 
 export function alchemyUserOperationSimulator<
-  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+  C extends ClientWithAlchemyMethods,
   TEntryPointVersion extends EntryPointVersion
 >(client: C): ClientMiddlewareFn {
   return async (struct, { account }) => {

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -25,7 +25,7 @@ describe("Utils Tests", () => {
         verificationGasLimit: "0x114c2",
       } as UserOperationRequest<"0.6.0">)
     ).toMatchInlineSnapshot(
-      `"0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"`
+      '"0xbb5560c1a3983429a6cdb244fa532fb4f2cf0de8ba9ccbf257bff93d069c76a3"'
     );
   });
 

--- a/packages/core/src/account/__tests__/simple.test.ts
+++ b/packages/core/src/account/__tests__/simple.test.ts
@@ -1,4 +1,3 @@
-import { sepolia } from "@alchemy/aa-core";
 import {
   createPublicClient,
   custom,
@@ -7,6 +6,7 @@ import {
   type Chain,
 } from "viem";
 import { describe, it } from "vitest";
+import { sepolia } from "../../chains/index.js";
 import { createBundlerClientFromExisting } from "../../client/bundlerClient.js";
 import { createSmartAccountClient } from "../../client/smartAccountClient.js";
 import { LocalAccountSigner } from "../../signer/local-account.js";

--- a/packages/core/src/account/base.ts
+++ b/packages/core/src/account/base.ts
@@ -17,7 +17,6 @@ import {
   type BundlerClient,
 } from "../client/bundlerClient.js";
 import { getEntryPoint } from "../entrypoint/index.js";
-import type { EntryPointVersion } from "../entrypoint/types.js";
 import {
   BatchExecutionNotSupportedError,
   FailedToGetStorageSlotError,
@@ -46,10 +45,9 @@ export enum DeploymentState {
  * @deprecated use `toSmartContractAccount` instead for creating SmartAccountInstances
  */
 export abstract class BaseSmartContractAccount<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
-> implements ISmartContractAccount<TEntryPointVersion, TTransport, TSigner>
+> implements ISmartContractAccount<TTransport, TSigner>
 {
   protected factoryAddress: Address;
   protected deploymentState: DeploymentState = DeploymentState.UNDEFINED;
@@ -62,12 +60,11 @@ export abstract class BaseSmartContractAccount<
   >;
   protected entryPointAddress: Address;
   readonly rpcProvider:
-    | BundlerClient<TEntryPointVersion, TTransport>
-    | BundlerClient<TEntryPointVersion, HttpTransport>;
+    | BundlerClient<TTransport>
+    | BundlerClient<HttpTransport>;
 
-  constructor(params_: BaseSmartAccountParams<TEntryPointVersion, TTransport>) {
+  constructor(params_: BaseSmartAccountParams<TTransport, TSigner>) {
     const params = createBaseSmartAccountParamsSchema<
-      TEntryPointVersion,
       TTransport,
       TSigner
     >().parse(params_);
@@ -114,7 +111,7 @@ export abstract class BaseSmartContractAccount<
             },
           }),
         })
-      : (params.rpcClient as BundlerClient<TEntryPointVersion, TTransport>);
+      : (params.rpcClient as BundlerClient<TTransport>);
 
     this.accountAddress = params.accountAddress;
     this.factoryAddress = params.factoryAddress;

--- a/packages/core/src/account/schema.ts
+++ b/packages/core/src/account/schema.ts
@@ -2,20 +2,18 @@ import { Address } from "abitype/zod";
 import { isHex, type Transport } from "viem";
 import z from "zod";
 import { createPublicErc4337ClientSchema } from "../client/schema.js";
-import type { EntryPointVersion } from "../entrypoint/types.js";
 import { isSigner } from "../signer/schema.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import { ChainSchema } from "../utils/index.js";
 
 export const createBaseSmartAccountParamsSchema = <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >() =>
   z.object({
     rpcClient: z.union([
       z.string(),
-      createPublicErc4337ClientSchema<TEntryPointVersion, TTransport>(),
+      createPublicErc4337ClientSchema<TTransport>(),
     ]),
     factoryAddress: Address,
     signer: z.custom<TSigner>(isSigner),
@@ -35,11 +33,10 @@ export const createBaseSmartAccountParamsSchema = <
   });
 
 export const SimpleSmartAccountParamsSchema = <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >() =>
-  createBaseSmartAccountParamsSchema<TEntryPointVersion, TTransport, TSigner>()
+  createBaseSmartAccountParamsSchema<TTransport, TSigner>()
     .omit({
       rpcClient: true,
     })

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -3,7 +3,6 @@ import type { Hash, Hex, HttpTransport, Transport } from "viem";
 import type { SignTypedDataParameters } from "viem/accounts";
 import type { z } from "zod";
 import type { BundlerClient } from "../client/bundlerClient";
-import type { EntryPointVersion } from "../entrypoint/types";
 import type { SmartAccountSigner } from "../signer/types";
 import type { BatchUserOperationCallData } from "../types";
 import type {
@@ -18,38 +17,23 @@ export type SignTypedDataParams = Omit<SignTypedDataParameters, "privateKey">;
  * @deprecated don't use base smart account anymore, migrate to using toSmartContractAccount instead
  */
 export type BaseSmartAccountParams<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = z.input<
-  ReturnType<
-    typeof createBaseSmartAccountParamsSchema<
-      TEntryPointVersion,
-      TTransport,
-      TSigner
-    >
-  >
+  ReturnType<typeof createBaseSmartAccountParamsSchema<TTransport, TSigner>>
 >;
 
 export type SimpleSmartAccountParams<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = z.input<
-  ReturnType<
-    typeof SimpleSmartAccountParamsSchema<
-      TEntryPointVersion,
-      TTransport,
-      TSigner
-    >
-  >
+  ReturnType<typeof SimpleSmartAccountParamsSchema<TTransport, TSigner>>
 >;
 
 /**
  * @deprecated use `toSmartContractAccount` instead for creating instances of smart accounts
  */
 export interface ISmartContractAccount<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > {
@@ -57,8 +41,8 @@ export interface ISmartContractAccount<
    * The RPC provider the account uses to make RPC calls
    */
   readonly rpcProvider:
-    | BundlerClient<TEntryPointVersion, TTransport>
-    | BundlerClient<TEntryPointVersion, HttpTransport>;
+    | BundlerClient<TTransport>
+    | BundlerClient<HttpTransport>;
 
   /**
    * @returns the init code for the account

--- a/packages/core/src/actions/bundler/estimateUserOperationGas.ts
+++ b/packages/core/src/actions/bundler/estimateUserOperationGas.ts
@@ -8,12 +8,7 @@ import type {
 
 export const estimateUserOperationGas = async <
   TEntryPointVersion extends EntryPointVersion,
-  TClient extends Client<
-    Transport,
-    Chain | undefined,
-    any,
-    BundlerRpcSchema<TEntryPointVersion>
-  >
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/bundler/getSupportedEntrypoints.ts
+++ b/packages/core/src/actions/bundler/getSupportedEntrypoints.ts
@@ -1,14 +1,8 @@
 import type { Address, Chain, Client, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
-import type { EntryPointVersion } from "../../entrypoint/types";
 
 export const getSupportedEntryPoints = async <
-  TClient extends Client<
-    Transport,
-    Chain | undefined,
-    any,
-    BundlerRpcSchema<EntryPointVersion>
-  >
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient
 ): Promise<Address[]> => {

--- a/packages/core/src/actions/bundler/getUserOperationByHash.ts
+++ b/packages/core/src/actions/bundler/getUserOperationByHash.ts
@@ -4,12 +4,7 @@ import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationResponse } from "../../types";
 
 export const getUserOperationByHash = async <
-  TClient extends Client<
-    Transport,
-    Chain | undefined,
-    any,
-    BundlerRpcSchema<EntryPointVersion>
-  >
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/bundler/getUserOperationReceipt.ts
+++ b/packages/core/src/actions/bundler/getUserOperationReceipt.ts
@@ -1,15 +1,9 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationReceipt } from "../../types";
 
 export const getUserOperationReceipt = async <
-  TClient extends Client<
-    Transport,
-    Chain | undefined,
-    any,
-    BundlerRpcSchema<EntryPointVersion>
-  >
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/bundler/sendRawUserOperation.ts
+++ b/packages/core/src/actions/bundler/sendRawUserOperation.ts
@@ -5,12 +5,7 @@ import type { UserOperationRequest } from "../../types";
 
 export const sendRawUserOperation = async <
   TEntryPointVersion extends EntryPointVersion,
-  TClient extends Client<
-    Transport,
-    Chain | undefined,
-    any,
-    BundlerRpcSchema<TEntryPointVersion>
-  >
+  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts
@@ -1,7 +1,9 @@
 import { fromHex, type Chain, type Client, type Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../../account/smartContractAccount";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { TransactionMissingToParamError } from "../../errors/transaction.js";
@@ -14,16 +16,17 @@ import type {
 } from "./types";
 
 export async function buildUserOperationFromTxs<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendTransactionsParameters<TEntryPointVersion, TAccount>
-): Promise<BuildUserOperationFromTransactionsResult<TEntryPointVersion>> {
+  args: SendTransactionsParameters<TAccount>
+): Promise<
+  BuildUserOperationFromTransactionsResult<GetEntryPointFromAccount<TAccount>>
+> {
   const { account = client.account, requests, overrides } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -74,13 +77,13 @@ export async function buildUserOperationFromTxs<
   const _overrides = {
     maxFeePerGas,
     maxPriorityFeePerGas,
-  } as UserOperationOverrides<TEntryPointVersion>;
+  } as UserOperationOverrides<GetEntryPointFromAccount<TAccount>>;
   filterUndefined(_overrides);
 
   const uoStruct = await buildUserOperation(client, {
     uo: batch,
     overrides: _overrides,
-    account: account as SmartContractAccount<TEntryPointVersion>,
+    account,
   });
 
   return {

--- a/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
+++ b/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
@@ -1,7 +1,6 @@
 import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
-import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import type { UserOperationStruct } from "../../types.js";
@@ -9,15 +8,14 @@ import { buildUserOperation } from "./buildUserOperation.js";
 import type { SendUserOperationParameters } from "./types";
 
 export const checkGasSponsorshipEligibility: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
+  args: SendUserOperationParameters<TAccount>
 ) => Promise<boolean> = async (client, args) => {
   const { account = client.account } = args;
 

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -1,8 +1,10 @@
 import type { Chain, Client, Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../../account/smartContractAccount";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import type { SendUserOperationResult } from "../../client/types";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { MismatchingEntryPointError } from "../../errors/entrypoint.js";
@@ -17,15 +19,15 @@ import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { DropAndReplaceUserOperationParameters } from "./types";
 
 export async function dropAndReplaceUserOperation<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: DropAndReplaceUserOperationParameters<TEntryPointVersion, TAccount>
+  args: DropAndReplaceUserOperationParameters<TAccount>
 ): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account, uoToDrop, overrides } = args;
   if (!account) {

--- a/packages/core/src/actions/smartAccount/getAddress.ts
+++ b/packages/core/src/actions/smartAccount/getAddress.ts
@@ -4,19 +4,17 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 
 export const getAddress: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: GetAccountParameter<TEntryPointVersion, TAccount>
+  args: GetAccountParameter<TAccount>
 ) => Address = (client, args) => {
   const { account } = args ?? { account: client.account };
   if (!account) {

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -1,11 +1,11 @@
 import type { Chain, Transport } from "viem";
 import type {
   GetAccountParameter,
+  GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../../../account/smartContractAccount";
 import type { BaseSmartAccountClient } from "../../../client/smartAccountClient";
 import type { SendUserOperationResult } from "../../../client/types";
-import type { EntryPointVersion } from "../../../entrypoint/types";
 import { AccountNotFoundError } from "../../../errors/account.js";
 import { ChainNotFoundError } from "../../../errors/client.js";
 import { MismatchingEntryPointError } from "../../../errors/entrypoint.js";
@@ -14,22 +14,17 @@ import type { UserOperationRequest, UserOperationStruct } from "../../../types";
 import { deepHexlify, isValidRequest } from "../../../utils/index.js";
 
 export async function _sendUserOperation<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
-  client: BaseSmartAccountClient<
-    TEntryPointVersion,
-    TTransport,
-    TChain,
-    TAccount
-  >,
+  client: BaseSmartAccountClient<TTransport, TChain, TAccount>,
   args: {
     uoStruct: UserOperationStruct<TEntryPointVersion>;
-  } & GetAccountParameter<TEntryPointVersion, TAccount>
+  } & GetAccountParameter<TAccount>
 ): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account } = args;
   if (!account) {

--- a/packages/core/src/actions/smartAccount/sendTransaction.ts
+++ b/packages/core/src/actions/smartAccount/sendTransaction.ts
@@ -5,9 +5,11 @@ import type {
   SendTransactionParameters,
   Transport,
 } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount.js";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
-import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { TransactionMissingToParamError } from "../../errors/transaction.js";
@@ -20,12 +22,12 @@ import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export async function sendTransaction<
-  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined,
-  TChainOverride extends Chain | undefined = Chain | undefined
+  TChainOverride extends Chain | undefined = Chain | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<Transport, TChain, TAccount>,
   args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
@@ -50,7 +52,7 @@ export async function sendTransaction<
 
   const uoStruct = await buildUserOperationFromTx(client, args, overrides);
   const { hash } = await _sendUserOperation(client, {
-    account: account as SmartContractAccount<TEntryPointVersion>,
+    account: account as SmartContractAccount,
     uoStruct: uoStruct as UserOperationStruct<TEntryPointVersion>,
   });
 

--- a/packages/core/src/actions/smartAccount/sendTransactions.ts
+++ b/packages/core/src/actions/smartAccount/sendTransactions.ts
@@ -1,7 +1,6 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
-import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { buildUserOperationFromTxs } from "./buildUserOperationFromTxs.js";
@@ -10,15 +9,14 @@ import type { SendTransactionsParameters } from "./types";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export async function sendTransactions<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendTransactionsParameters<TEntryPointVersion, TAccount>
+  args: SendTransactionsParameters<TAccount>
 ): Promise<Hex> {
   const { requests, overrides, account = client.account } = args;
   if (!account) {

--- a/packages/core/src/actions/smartAccount/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/sendUserOperation.ts
@@ -1,8 +1,10 @@
 import type { Chain, Client, Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount.js";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import type { SendUserOperationResult } from "../../client/types.js";
-import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { buildUserOperation } from "./buildUserOperation.js";
@@ -10,15 +12,15 @@ import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { SendUserOperationParameters } from "./types.js";
 
 export const sendUserOperation: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
+  args: SendUserOperationParameters<TAccount>
 ) => Promise<SendUserOperationResult<TEntryPointVersion>> = async (
   client,
   args
@@ -37,10 +39,8 @@ export const sendUserOperation: <
     );
   }
 
-  const entryPoint = account.getEntryPoint();
-
   const uoStruct = await buildUserOperation(client, args);
-  return _sendUserOperation<typeof entryPoint.version>(client, {
+  return _sendUserOperation(client, {
     account,
     uoStruct,
   });

--- a/packages/core/src/actions/smartAccount/signMessage.ts
+++ b/packages/core/src/actions/smartAccount/signMessage.ts
@@ -3,29 +3,23 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 
 export type SignMessageParameters<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
-> = { message: SignableMessage } & GetAccountParameter<
-  TEntryPointVersion,
-  TAccount
->;
+> = { message: SignableMessage } & GetAccountParameter<TAccount>;
 
 export const signMessage: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignMessageParameters<TEntryPointVersion, TAccount>
+  args: SignMessageParameters<TAccount>
 ) => Promise<Hex> = async (client, { account = client.account, message }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/signMessageWith6492.ts
+++ b/packages/core/src/actions/smartAccount/signMessageWith6492.ts
@@ -1,19 +1,17 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import type { SignMessageParameters } from "./signMessage";
 
 export const signMessageWith6492: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignMessageParameters<TEntryPointVersion, TAccount>
+  args: SignMessageParameters<TAccount>
 ) => Promise<Hex> = async (client, { account = client.account, message }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/signTypedData.ts
+++ b/packages/core/src/actions/smartAccount/signTypedData.ts
@@ -10,37 +10,29 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 
 export type SignTypedDataParameters<
-  TEntryPointVersion extends EntryPointVersion,
   TTypedData extends TypedData | { [key: string]: unknown },
   TPrimaryType extends string = string,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 > = {
   typedData: TypedDataDefinition<TTypedData, TPrimaryType>;
-} & GetAccountParameter<TEntryPointVersion, TAccount>;
+} & GetAccountParameter<TAccount>;
 
 export const signTypedData: <
-  TEntryPointVersion extends EntryPointVersion,
   const TTypedData extends TypedData | { [key: string]: unknown },
   TPrimaryType extends string = string,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignTypedDataParameters<
-    TEntryPointVersion,
-    TTypedData,
-    TPrimaryType,
-    TAccount
-  >
+  args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>
 ) => Promise<Hex> = async (client, { account = client.account, typedData }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/signTypedDataWith6492.ts
+++ b/packages/core/src/actions/smartAccount/signTypedDataWith6492.ts
@@ -1,26 +1,19 @@
 import type { Chain, Client, Hex, Transport, TypedData } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount";
-import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import type { SignTypedDataParameters } from "./signTypedData";
 
 export const signTypedDataWith6492: <
-  const TEntryPointVersion extends EntryPointVersion,
   const TTypedData extends TypedData | { [key: string]: unknown },
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined,
   TPrimaryType extends string = string
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignTypedDataParameters<
-    TEntryPointVersion,
-    TTypedData,
-    TPrimaryType,
-    TAccount
-  >
+  args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>
 ) => Promise<Hex> = async (client, { account = client.account, typedData }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/types.ts
+++ b/packages/core/src/actions/smartAccount/types.ts
@@ -1,10 +1,14 @@
 import type { Hex, RpcTransactionRequest } from "viem";
 import type {
   GetAccountParameter,
+  GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
 import type { UpgradeToData } from "../../client/types";
-import type { EntryPointVersion } from "../../entrypoint/types";
+import type {
+  DefaultEntryPointVersion,
+  EntryPointVersion,
+} from "../../entrypoint/types";
 import type {
   BatchUserOperationCallData,
   UserOperationCallData,
@@ -15,61 +19,61 @@ import type {
 
 //#region UpgradeAccountParams
 export type UpgradeAccountParams<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   upgradeTo: UpgradeToData;
   waitForTx?: boolean;
-} & GetAccountParameter<TEntryPointVersion, TAccount> &
+} & GetAccountParameter<TAccount> &
   UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion UpgradeAccountParams
 
 //#region SendUserOperationParameters
 export type SendUserOperationParameters<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   uo: UserOperationCallData | BatchUserOperationCallData;
-} & GetAccountParameter<TEntryPointVersion, TAccount> &
+} & GetAccountParameter<TAccount> &
   UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendUserOperationParameters
 
 //#region SignUserOperationParameters
 export type SignUserOperationParameters<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   uoStruct: UserOperationStruct<TEntryPointVersion>;
-} & GetAccountParameter<TEntryPointVersion, TAccount>;
+} & GetAccountParameter<TAccount>;
 //#endregion SignUserOperationParameters
 
 //#region SendTransactionsParameters
 export type SendTransactionsParameters<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   requests: RpcTransactionRequest[];
-} & GetAccountParameter<TEntryPointVersion, TAccount> &
+} & GetAccountParameter<TAccount> &
   UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendTransactionsParameters
 
 //#region DropAndReplaceUserOperationParameters
 export type DropAndReplaceUserOperationParameters<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   uoToDrop: UserOperationRequest<TEntryPointVersion>;
-} & GetAccountParameter<TEntryPointVersion, TAccount> &
+} & GetAccountParameter<TAccount> &
   UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion DropAndReplaceUserOperationParameters
 
@@ -81,7 +85,7 @@ export type WaitForUserOperationTxParameters = {
 
 //#region BuildUserOperationFromTransactionsResult
 export type BuildUserOperationFromTransactionsResult<
-  TEntryPointVersion extends EntryPointVersion
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
 > = {
   uoStruct: UserOperationStruct<TEntryPointVersion>;
   batch: BatchUserOperationCallData;

--- a/packages/core/src/actions/smartAccount/upgradeAccount.ts
+++ b/packages/core/src/actions/smartAccount/upgradeAccount.ts
@@ -1,7 +1,6 @@
 import type { Chain, Client, Hash, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
-import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { sendUserOperation } from "./sendUserOperation.js";
@@ -9,15 +8,14 @@ import type { UpgradeAccountParams } from "./types.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export const upgradeAccount: <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: UpgradeAccountParams<TEntryPointVersion, TAccount>
+  args: UpgradeAccountParams<TAccount>
 ) => Promise<Hash> = async (client, args) => {
   const { account = client.account, upgradeTo, overrides, waitForTx } = args;
 

--- a/packages/core/src/client/isSmartAccountClient.ts
+++ b/packages/core/src/client/isSmartAccountClient.ts
@@ -1,6 +1,5 @@
 import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../account/smartContractAccount";
-import type { EntryPointVersion } from "../entrypoint/types";
 import { smartAccountClientMethodKeys } from "./decorators/smartAccountClient.js";
 import type {
   BaseSmartAccountClient,
@@ -16,20 +15,14 @@ import type {
  * @returns
  */
 export function isSmartAccountClient<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-): client is SmartAccountClient<
-  TEntryPointVersion,
-  TTransport,
-  TChain,
-  TAccount
-> {
+): client is SmartAccountClient<TTransport, TChain, TAccount> {
   for (const key of smartAccountClientMethodKeys) {
     if (!(key in client)) {
       return false;
@@ -48,19 +41,13 @@ export function isSmartAccountClient<
  * @returns
  */
 export function isBaseSmartAccountClient<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-): client is BaseSmartAccountClient<
-  TEntryPointVersion,
-  TTransport,
-  TChain,
-  TAccount
-> {
+): client is BaseSmartAccountClient<TTransport, TChain, TAccount> {
   return client && "middleware" in client;
 }

--- a/packages/core/src/client/schema.ts
+++ b/packages/core/src/client/schema.ts
@@ -1,15 +1,13 @@
 import type { Transport } from "viem";
 import { z } from "zod";
 
-import type { EntryPointVersion } from "../entrypoint/types.js";
 import { BigNumberishRangeSchema, MultiplierSchema } from "../utils/index.js";
 import type { BundlerClient } from "./bundlerClient.js";
 
 export const createPublicErc4337ClientSchema = <
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport
 >() =>
-  z.custom<BundlerClient<TEntryPointVersion, TTransport>>((provider) => {
+  z.custom<BundlerClient<TTransport>>((provider) => {
     return (
       provider != null &&
       typeof provider === "object" &&

--- a/packages/core/src/entrypoint/index.ts
+++ b/packages/core/src/entrypoint/index.ts
@@ -69,9 +69,10 @@ export function getEntryPoint<
   chain: TChain,
   options: GetEntryPointOptions<TEntryPointVersion>
 ): EntryPointDefRegistry<TChain>[EntryPointVersion] {
-  const { version, addressOverride } = options ?? {
+  const { version = defaultEntryPointVersion, addressOverride } = options ?? {
     version: defaultEntryPointVersion,
   };
+
   const entryPoint = entryPointRegistry[version ?? defaultEntryPointVersion];
   const address = addressOverride || entryPoint.address[chain.id];
   if (!address) {

--- a/packages/core/src/entrypoint/types.ts
+++ b/packages/core/src/entrypoint/types.ts
@@ -124,7 +124,7 @@ export type EntryPointParameter<
   TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain = Chain
 > = {
-  entryPoint?: EntryPointDef<TEntryPointVersion, TChain>;
+  entryPoint: EntryPointDef<TEntryPointVersion, TChain>;
 };
 
 // EQ<TEntryPointVersion, DefaultEntryPointVersion> extends true

--- a/packages/core/src/middleware/actions.ts
+++ b/packages/core/src/middleware/actions.ts
@@ -11,7 +11,6 @@ import type {
   BundlerRpcSchema,
 } from "../client/decorators/bundlerClient.js";
 import type { ClientMiddlewareConfig } from "../client/types.js";
-import type { EntryPointVersion } from "../entrypoint/types.js";
 import { defaultFeeEstimator } from "./defaults/feeEstimator.js";
 import { defaultGasEstimator } from "./defaults/gasEstimator.js";
 import { defaultPaymasterAndData } from "./defaults/paymasterAndData.js";
@@ -19,31 +18,29 @@ import { noopMiddleware } from "./noopMiddleware.js";
 import type { ClientMiddleware } from "./types.js";
 
 export type MiddlewareClient<
-  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount | undefined =
+    | SmartContractAccount
     | undefined
 > = Client<
   TTransport,
   TChain,
   TAccount,
-  [...BundlerRpcSchema<TEntryPointVersion>, ...PublicRpcSchema],
-  PublicActions & BundlerActions<TEntryPointVersion>
+  [...BundlerRpcSchema, ...PublicRpcSchema],
+  PublicActions & BundlerActions
 >;
 
 export const middlewareActions =
   (overrides: ClientMiddlewareConfig) =>
   <
-    TEntryPointVersion extends EntryPointVersion,
     TTransport extends Transport = Transport,
     TChain extends Chain | undefined = Chain | undefined,
-    TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-      | SmartContractAccount<TEntryPointVersion>
+    TAccount extends SmartContractAccount | undefined =
+      | SmartContractAccount
       | undefined
   >(
-    client: MiddlewareClient<TEntryPointVersion, TTransport, TChain, TAccount>
+    client: MiddlewareClient<TTransport, TChain, TAccount>
   ): { middleware: ClientMiddleware } => ({
     middleware: {
       customMiddleware: overrides.customMiddleware ?? noopMiddleware,

--- a/packages/core/src/middleware/defaults/feeEstimator.ts
+++ b/packages/core/src/middleware/defaults/feeEstimator.ts
@@ -1,13 +1,9 @@
-import type { EntryPointVersion } from "../../entrypoint/types";
 import type { BigNumberish } from "../../types";
 import { applyUserOpOverrideOrFeeOption } from "../../utils/index.js";
 import type { MiddlewareClient } from "../actions";
 import type { ClientMiddlewareFn } from "../types";
 
-export const defaultFeeEstimator: <
-  TEntryPointVersion extends EntryPointVersion,
-  C extends MiddlewareClient<TEntryPointVersion>
->(
+export const defaultFeeEstimator: <C extends MiddlewareClient>(
   client: C
 ) => ClientMiddlewareFn =
   (client) =>

--- a/packages/core/src/middleware/defaults/gasEstimator.ts
+++ b/packages/core/src/middleware/defaults/gasEstimator.ts
@@ -1,13 +1,9 @@
-import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { deepHexlify, resolveProperties } from "../../utils/index.js";
 import { applyUserOpOverrideOrFeeOption } from "../../utils/userop.js";
 import type { MiddlewareClient } from "../actions.js";
 import type { ClientMiddlewareFn } from "../types.js";
 
-export const defaultGasEstimator: <
-  TEntryPointVersion extends EntryPointVersion,
-  C extends MiddlewareClient<TEntryPointVersion>
->(
+export const defaultGasEstimator: <C extends MiddlewareClient>(
   client: C
 ) => ClientMiddlewareFn =
   (client) =>

--- a/packages/core/src/middleware/types.ts
+++ b/packages/core/src/middleware/types.ts
@@ -1,5 +1,7 @@
-import type { SmartContractAccount } from "../account/smartContractAccount";
-import type { EntryPointVersion } from "../entrypoint/types";
+import type {
+  GetEntryPointFromAccount,
+  SmartContractAccount,
+} from "../account/smartContractAccount";
 import type {
   UserOperationFeeOptions,
   UserOperationOverrides,
@@ -8,17 +10,16 @@ import type {
 import type { Deferrable } from "../utils";
 
 //#region ClientMiddlewareFn
-export type ClientMiddlewareFn = <
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion>
->(
-  struct: Deferrable<UserOperationStruct<TEntryPointVersion>>,
+export type ClientMiddlewareFn = <TAccount extends SmartContractAccount>(
+  struct: Deferrable<UserOperationStruct<GetEntryPointFromAccount<TAccount>>>,
   args: {
-    overrides?: UserOperationOverrides<TEntryPointVersion>;
+    overrides?: UserOperationOverrides<GetEntryPointFromAccount<TAccount>>;
     feeOptions?: UserOperationFeeOptions;
     account: TAccount;
   }
-) => Promise<Deferrable<UserOperationStruct<TEntryPointVersion>>>;
+) => Promise<
+  Deferrable<UserOperationStruct<GetEntryPointFromAccount<TAccount>>>
+>;
 //#endregion ClientMiddlewareFn
 
 //#region ClientMiddleware

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -370,6 +370,10 @@ export type UserOperationStruct<TEntryPointVersion extends EntryPointVersion> =
     : never;
 //#endregion UserOperationStruct
 
+export type UserOperationStructUnion =
+  | UserOperationStruct_v6
+  | UserOperationStruct_v7;
+
 export type UserOperationLike<
   TEntryPointVersion extends EntryPointVersion = EntryPointVersion
 > = Interface<UserOperationOverrides<TEntryPointVersion>>;

--- a/packages/core/src/utils/testUtils.ts
+++ b/packages/core/src/utils/testUtils.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, custom, type Chain, type Transport } from "viem";
+import { createPublicClient, custom, type Chain } from "viem";
 import {
   toSmartContractAccount,
   type SmartContractAccount,
@@ -10,11 +10,9 @@ import {
 import { getEntryPoint } from "../entrypoint/index.js";
 import type { DefaultEntryPointVersion } from "../entrypoint/types.js";
 
-export const createDummySmartContractAccount = async <
-  C extends BundlerClient<DefaultEntryPointVersion, Transport>
->(
+export const createDummySmartContractAccount = async <C extends BundlerClient>(
   client: C
-): Promise<SmartContractAccount<DefaultEntryPointVersion>> => {
+): Promise<SmartContractAccount<"dummy", DefaultEntryPointVersion>> => {
   return toSmartContractAccount({
     source: "dummy",
     accountAddress: "0x1234567890123456789012345678901234567890",

--- a/packages/ethers/src/account-signer.ts
+++ b/packages/ethers/src/account-signer.ts
@@ -3,7 +3,7 @@ import {
   resolveProperties,
   type BatchUserOperationCallData,
   type BundlerClient,
-  type EntryPointVersion,
+  type GetEntryPointFromAccount,
   type SmartContractAccount,
   type UserOperationCallData,
   type UserOperationOverrides,
@@ -27,8 +27,8 @@ const hexlifyOptional = (value: any): `0x${string}` | undefined => {
 };
 
 export class AccountSigner<
-  TEntryPointVersion extends EntryPointVersion,
-  TAccount extends SmartContractAccount<TEntryPointVersion> = SmartContractAccount<TEntryPointVersion>
+  TAccount extends SmartContractAccount = SmartContractAccount,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > extends Signer {
   readonly account: TAccount;
 
@@ -102,13 +102,11 @@ export class AccountSigner<
     );
   }
 
-  getPublicErc4337Client(): BundlerClient<TEntryPointVersion, Transport> {
+  getPublicErc4337Client(): BundlerClient<Transport> {
     return this.provider.getBundlerClient();
   }
 
-  connect(
-    provider: EthersProviderAdapter
-  ): AccountSigner<TEntryPointVersion, TAccount> {
+  connect(provider: EthersProviderAdapter): AccountSigner<TAccount> {
     this.provider = provider;
 
     return this;

--- a/packages/ethers/src/provider-adapter.ts
+++ b/packages/ethers/src/provider-adapter.ts
@@ -3,7 +3,6 @@ import {
   createSmartAccountClient,
   getChain,
   type BundlerClient,
-  type EntryPointVersion,
   type SmartAccountClient,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -15,7 +14,7 @@ import type { EthersProviderAdapterOpts } from "./types.js";
 /** Lightweight Adapter for SmartAccountProvider to enable Signer Creation */
 // TODO: Add support for strong entry point version type
 export class EthersProviderAdapter extends JsonRpcProvider {
-  readonly accountProvider: SmartAccountClient<EntryPointVersion>;
+  readonly accountProvider: SmartAccountClient;
 
   constructor(opts: EthersProviderAdapterOpts) {
     super();
@@ -24,13 +23,13 @@ export class EthersProviderAdapter extends JsonRpcProvider {
     } else {
       const chain = getChain(opts.chainId);
       if (typeof opts.rpcProvider === "string") {
-        this.accountProvider = createSmartAccountClient<EntryPointVersion>({
+        this.accountProvider = createSmartAccountClient({
           transport: http(opts.rpcProvider),
           chain,
           account: opts.account,
         });
       } else {
-        this.accountProvider = createSmartAccountClient<EntryPointVersion>({
+        this.accountProvider = createSmartAccountClient({
           transport: custom(opts.rpcProvider.transport),
           chain,
           account: opts.account,
@@ -58,14 +57,13 @@ export class EthersProviderAdapter extends JsonRpcProvider {
    * @param fn - a function that takes the account provider's rpcClient and returns an ISmartContractAccount
    * @returns an {@link AccountSigner} that can be used to sign and send user operations
    */
-  connectToAccount<
-    TEntryPointVersion extends EntryPointVersion,
-    TAccount extends SmartContractAccount<TEntryPointVersion>
-  >(account: TAccount): AccountSigner<TEntryPointVersion, TAccount> {
-    return new AccountSigner<TEntryPointVersion, TAccount>(this, account);
+  connectToAccount<TAccount extends SmartContractAccount>(
+    account: TAccount
+  ): AccountSigner<TAccount> {
+    return new AccountSigner<TAccount>(this, account);
   }
 
-  getBundlerClient(): BundlerClient<EntryPointVersion, Transport> {
+  getBundlerClient(): BundlerClient<Transport> {
     return createBundlerClientFromExisting(
       createPublicClient({
         transport: custom(this.accountProvider.transport),

--- a/packages/ethers/src/types.ts
+++ b/packages/ethers/src/types.ts
@@ -16,15 +16,10 @@ export type EthersProviderAdapterOpts<
   account?: TAccount;
 } & (
   | {
-      rpcProvider: string | BundlerClient<EntryPointVersion, TTransport>;
+      rpcProvider: string | BundlerClient<TTransport>;
       chainId: number;
     }
   | {
-      accountProvider: SmartAccountClient<
-        EntryPointVersion,
-        TTransport,
-        TChain,
-        TAccount
-      >;
+      accountProvider: SmartAccountClient<TTransport, TChain, TAccount>;
     }
 );


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for `@alchemy/aa-core` in various files across different packages.

### Detailed summary
- Added `@alchemy/aa-core` dependency in multiple files
- Updated types and functions to accommodate the new dependency
- Adjusted client interfaces and middleware functions

> The following files were skipped due to too many changes: `packages/core/src/actions/smartAccount/signMessageWith6492.ts`, `packages/alchemy/src/client/decorators/alchemyEnhancedApis.ts`, `packages/accounts/plugingen/phases/plugin-actions/management-actions.ts`, `packages/accounts/src/nani-account/account.ts`, `packages/accounts/src/msca/plugins/session-key/utils.ts`, `packages/ethers/src/account-signer.ts`, `packages/core/src/middleware/types.ts`, `packages/core/src/actions/smartAccount/signTypedDataWith6492.ts`, `packages/alchemy/src/client/isAlchemySmartAccountClient.ts`, `packages/core/src/account/schema.ts`, `packages/alchemy/src/actions/simulateUserOperationChanges.ts`, `packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts`, `packages/core/src/actions/smartAccount/upgradeAccount.ts`, `packages/core/src/actions/smartAccount/sendTransactions.ts`, `packages/core/src/actions/smartAccount/signMessage.ts`, `packages/accounts/plugingen/phases/plugin-actions/read-actions.ts`, `packages/alchemy/src/client/types.ts`, `packages/alchemy/src/client/decorators/smartAccount.ts`, `packages/accounts/src/light-account/decorator.ts`, `packages/core/src/actions/smartAccount/signTypedData.ts`, `packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts`, `packages/core/src/account/base.ts`, `packages/core/src/actions/smartAccount/internal/sendUserOperation.ts`, `packages/core/src/client/isSmartAccountClient.ts`, `packages/accounts/src/msca/plugin-manager/decorator.ts`, `packages/core/src/actions/smartAccount/sendUserOperation.ts`, `packages/core/src/middleware/actions.ts`, `packages/core/src/actions/smartAccount/sendTransaction.ts`, `packages/core/src/actions/smartAccount/signUserOperation.ts`, `packages/accounts/src/light-account/actions/transferOwnership.ts`, `packages/core/src/account/types.ts`, `packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts`, `packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts`, `packages/ethers/src/provider-adapter.ts`, `packages/alchemy/src/client/lightAccountClient.ts`, `packages/core/src/actions/smartAccount/buildUserOperation.ts`, `packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts`, `packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts`, `packages/accounts/src/msca/utils.ts`, `packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts`, `packages/accounts/src/msca/plugin-manager/installPlugin.ts`, `packages/alchemy/src/client/modularAccountClient.ts`, `packages/alchemy/src/middleware/gasManager.ts`, `packages/accounts/src/msca/client.ts`, `packages/core/src/client/bundlerClient.ts`, `packages/accounts/src/msca/account-loupe/decorator.ts`, `packages/accounts/src/light-account/client.ts`, `packages/core/src/client/decorators/bundlerClient.ts`, `packages/accounts/plugingen/phases/plugin-actions/index.ts`, `packages/core/src/actions/smartAccount/types.ts`, `packages/alchemy/src/client/smartAccountClient.ts`, `packages/accounts/src/msca/plugins/multi-owner/extension.ts`, `packages/accounts/src/msca/account/multiOwnerAccount.ts`, `packages/accounts/src/msca/plugins/multi-owner/plugin.ts`, `packages/accounts/src/msca/plugins/session-key/plugin.ts`, `packages/accounts/src/msca/plugins/session-key/extension.ts`, `packages/core/src/client/decorators/smartAccountClient.ts`, `packages/core/src/client/smartAccountClient.ts`, `packages/core/src/account/simple.ts`, `packages/core/src/account/smartContractAccount.ts`, `packages/accounts/src/light-account/account.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->