### PR TITLE
feat: [Entrypoint 0.7 SDK] support non-typed interfaces with function overloading for smart accounts interfaces

### DIFF
--- a/packages/accounts/plugingen/phases/plugin-actions/index.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/index.ts
@@ -17,6 +17,10 @@ export const PluginActionsGenPhase: Phase = async (input) => {
   addImport("viem", { name: "Chain", isType: true });
   addImport("viem", { name: "Client", isType: true });
   addImport("@alchemy/aa-core", {
+    name: "EntryPointVersion",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
     name: "SmartContractAccount",
     isType: true,
   });
@@ -42,14 +46,14 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     .map((n) => {
       const argsParamString =
         n.inputs.length > 0
-          ? dedent`{ 
-                  args, 
-                  overrides, 
-                  account = client.account 
+          ? dedent`{
+                  args,
+                  overrides,
+                  account = client.account
               }`
-          : dedent`{ 
-                  overrides, 
-                  account = client.account 
+          : dedent`{
+                  overrides,
+                  account = client.account
               }`;
       const argsEncodeString = n.inputs.length > 0 ? "args," : "";
 
@@ -58,31 +62,35 @@ export const PluginActionsGenPhase: Phase = async (input) => {
             n.name
           )}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${
         n.name
-      }">, "args"> & { overrides?: UserOperationOverrides; } & GetAccountParameter<TAccount>) => Promise<SendUserOperationResult>
-        `);
+      }">, "args"> & { overrides?: UserOperationOverrides<TEntryPointVersion>; } & GetAccountParameter<TEntryPointVersion, TAccount>) =>
+        Promise<SendUserOperationResult<TEntryPointVersion>>`);
       const methodName = camelCase(n.name);
       return dedent`
               ${methodName}(${argsParamString}) {
                 if (!account) {
                   throw new AccountNotFoundError();
-                } 
+                }
                 if (!isSmartAccountClient(client)) {
                   throw new IncompatibleClientError("SmartAccountClient", "${methodName}", client);
                 }
-  
+
                 const uo = encodeFunctionData({
                   abi: ${executionAbiConst},
                   functionName: "${n.name}",
                   ${argsEncodeString}
                 });
-  
+
                 return client.sendUserOperation({ uo, overrides, account });
               }
             `;
     });
 
   addType(
-    "ExecutionActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>",
+    `ExecutionActions<
+      TEntryPointVersion extends EntryPointVersion,
+      TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+        SmartContractAccount<TEntryPointVersion> | undefined
+    >`,
     dedent`{
         ${providerFunctionDefs.join(";\n\n")}
       }`
@@ -97,12 +105,15 @@ export const PluginActionsGenPhase: Phase = async (input) => {
   });
 
   addType(
-    `${contract.name}Actions<TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
-    | undefined>`,
+    `${contract.name}Actions<
+      TEntryPointVersion extends EntryPointVersion,
+      TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+          | SmartContractAccount<TEntryPointVersion>
+          | undefined,
+    >`,
     dedent`
-  ExecutionActions<TAccount> & ManagementActions<TAccount> & ReadAndEncodeActions${
-    hasReadMethods ? "<TAccount>" : ""
+  ExecutionActions<TEntryPointVersion, TAccount> & ManagementActions<TEntryPointVersion, TAccount> & ReadAndEncodeActions${
+    hasReadMethods ? "<TEntryPointVersion, TAccount>" : ""
   }
   `,
     true
@@ -110,16 +121,19 @@ export const PluginActionsGenPhase: Phase = async (input) => {
 
   input.content.push(dedent`
     export const ${camelCase(contract.name)}Actions: <
+        TEntryPointVersion extends EntryPointVersion,
         TTransport extends Transport = Transport,
         TChain extends Chain | undefined = Chain | undefined,
-        TAccount extends SmartContractAccount | undefined =
-            | SmartContractAccount
-            | undefined
+        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+            | SmartContractAccount<TEntryPointVersion>
+            | undefined,
     >(
         client: Client<TTransport, TChain, TAccount>
     ) => ${
       contract.name
-    }Actions<TAccount> = (client) => ({ ${providerFunctions.join(",\n")} });
+    }Actions<TEntryPointVersion, TAccount> = (client) => ({ ${providerFunctions.join(
+    ",\n"
+  )} });
   `);
 
   return input;

--- a/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
@@ -24,9 +24,16 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
       true
     );
     addType(
-      "ManagementActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>",
+      `ManagementActions<
+        TEntryPointVersion extends EntryPointVersion,
+        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+          SmartContractAccount<TEntryPointVersion> | undefined,
+      >`,
       dedent`{
-      install${contract.name}: (args: {overrides?: UserOperationOverrides} & Install${contract.name}Params & GetAccountParameter<TAccount>) => Promise<SendUserOperationResult>
+      install${contract.name}: (
+        args: { overrides?: UserOperationOverrides<TEntryPointVersion> } &
+          Install${contract.name}Params & GetAccountParameter<TEntryPointVersion, TAccount>
+      ) => Promise<SendUserOperationResult<TEntryPointVersion>>
     }`
     );
 
@@ -119,6 +126,10 @@ const addImports = (
   });
   addImport("@alchemy/aa-core", {
     name: "GetAccountParameter",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
+    name: "EntryPointVersion",
     isType: true,
   });
   // TODO: after plugingen becomes its own cli tool package, this should be changed to

--- a/packages/accounts/plugingen/phases/plugin-actions/read-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/read-actions.ts
@@ -45,8 +45,8 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
       const readMethodName = `read${pascalCase(n.name)}`;
       accountFunctionActionDefs.push(
         n.inputs.length > 0
-          ? dedent`${readMethodName}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> & GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
-          : dedent`${readMethodName}: (args: GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          ? dedent`${readMethodName}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> & GetAccountParameter<TEntryPointVersion, TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          : dedent`${readMethodName}: (args: GetAccountParameter<TEntryPointVersion, TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
       );
 
       methodContent.push(dedent`
@@ -73,7 +73,11 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
   });
 
   const typeName = input.hasReadMethods
-    ? "ReadAndEncodeActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>"
+    ? `ReadAndEncodeActions<
+        TEntryPointVersion extends EntryPointVersion,
+        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+          SmartContractAccount<TEntryPointVersion> | undefined
+      >`
     : "ReadAndEncodeActions";
 
   addType(

--- a/packages/accounts/src/light-account/account.ts
+++ b/packages/accounts/src/light-account/account.ts
@@ -1,11 +1,15 @@
+import type { EntryPointParameter } from "@alchemy/aa-core";
 import {
   FailedToGetStorageSlotError,
+  InvalidEntryPointError,
   createBundlerClient,
   getAccountAddress,
-  getVersion060EntryPoint,
+  getEntryPoint,
   toSmartContractAccount,
   type Address,
-  type Hex,
+  type EntryPointDef,
+  type EntryPointDefRegistry,
+  type EntryPointVersion,
   type SmartAccountSigner,
   type SmartContractAccountWithSigner,
   type ToSmartContractAccountParams,
@@ -18,6 +22,7 @@ import {
   hashMessage,
   hashTypedData,
   trim,
+  type Hex,
   type SignTypedDataParameters,
   type Transport,
 } from "viem";
@@ -32,45 +37,72 @@ import {
 } from "./utils.js";
 
 export type LightAccount<
+  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner
-> = SmartContractAccountWithSigner<"LightAccount", TSigner> & {
+> = SmartContractAccountWithSigner<
+  TEntryPointVersion,
+  "LightAccount",
+  TSigner
+> & {
   getLightAccountVersion: () => Promise<LightAccountVersion>;
   encodeTransferOwnership: (newOwner: Address) => Hex;
   getOwnerAddress: () => Promise<Address>;
 };
 
 export type CreateLightAccountParams<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = Pick<
-  ToSmartContractAccountParams<"LightAccount", TTransport>,
-  "transport" | "chain" | "entryPoint" | "accountAddress"
+  ToSmartContractAccountParams<TEntryPointVersion, "LightAccount", TTransport>,
+  "transport" | "chain"
 > & {
   signer: TSigner;
   salt?: bigint;
+  accountAddress?: Address;
   factoryAddress?: Address;
   initCode?: Hex;
   version?: LightAccountVersion;
-};
+} & EntryPointParameter<TEntryPointVersion>;
 
 export async function createLightAccount<
+  TEntryPointDef extends EntryPointDefRegistry[EntryPointVersion],
+  TEntryPointVersion extends EntryPointVersion = TEntryPointDef extends EntryPointDef<
+    infer U
+  >
+    ? U
+    : never,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  config: CreateLightAccountParams<TTransport, TSigner>
-): Promise<LightAccount<TSigner>>;
+  config: CreateLightAccountParams<TEntryPointVersion, TTransport, TSigner>
+): Promise<LightAccount<TEntryPointVersion, TSigner>>;
 
-export async function createLightAccount({
+export async function createLightAccount<
+  TEntryPointDef extends EntryPointDefRegistry[EntryPointVersion],
+  TEntryPointVersion extends EntryPointVersion = TEntryPointDef extends EntryPointDef<
+    infer U
+  >
+    ? U
+    : never,
+  TTransport extends Transport = Transport,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+>({
   transport,
   chain,
   signer,
   initCode,
   version = "v1.1.0",
-  entryPoint = getVersion060EntryPoint(chain),
+  entryPoint,
   accountAddress,
   factoryAddress = getDefaultLightAccountFactoryAddress(chain, version),
   salt: salt_ = 0n,
-}: CreateLightAccountParams): Promise<LightAccount> {
+}: CreateLightAccountParams<TEntryPointVersion, TTransport, TSigner>): Promise<
+  LightAccount<TEntryPointVersion>
+> {
+  const _entryPoint: EntryPointDef<EntryPointVersion> =
+    entryPoint ?? getEntryPoint(chain);
+
   const client = createBundlerClient({
     transport,
     chain,
@@ -97,7 +129,7 @@ export async function createLightAccount({
 
   const address = await getAccountAddress({
     client,
-    entryPointAddress: entryPoint.address,
+    entryPoint: _entryPoint,
     accountAddress,
     getAccountInitCode,
   });
@@ -160,74 +192,148 @@ export async function createLightAccount({
     });
   };
 
-  const account = await toSmartContractAccount({
-    transport,
-    chain,
-    entryPoint,
-    accountAddress: address,
-    source: "LightAccount",
-    getAccountInitCode,
-    encodeExecute: async ({ target, data, value }) => {
-      return encodeFunctionData({
-        abi: LightAccountAbi,
-        functionName: "execute",
-        args: [target, value ?? 0n, data],
-      });
-    },
-    encodeBatchExecute: async (txs) => {
-      const [targets, values, datas] = txs.reduce(
-        (accum, curr) => {
-          accum[0].push(curr.target);
-          accum[1].push(curr.value ?? 0n);
-          accum[2].push(curr.data);
+  const account =
+    _entryPoint.version === "0.6.0"
+      ? await toSmartContractAccount({
+          transport,
+          chain,
+          entryPoint: _entryPoint as EntryPointDef<"0.6.0">,
+          accountAddress: address,
+          source: "LightAccount",
+          getAccountInitCode,
+          encodeExecute: async ({ target, data, value }) => {
+            return encodeFunctionData({
+              abi: LightAccountAbi,
+              functionName: "execute",
+              args: [target, value ?? 0n, data],
+            });
+          },
+          encodeBatchExecute: async (txs) => {
+            const [targets, values, datas] = txs.reduce(
+              (accum, curr) => {
+                accum[0].push(curr.target);
+                accum[1].push(curr.value ?? 0n);
+                accum[2].push(curr.data);
 
-          return accum;
-        },
-        [[], [], []] as [Address[], bigint[], Hex[]]
-      );
-      return encodeFunctionData({
-        abi: LightAccountAbi,
-        functionName: "executeBatch",
-        args: [targets, values, datas],
-      });
-    },
-    signUserOperationHash: async (uoHash: Hex) => {
-      return signer.signMessage({ raw: uoHash });
-    },
-    async signMessage({ message }) {
-      const version = await getLightAccountVersion(account);
-      switch (version) {
-        case "v1.0.1":
-          return signer.signMessage(message);
-        case "v1.0.2":
-          throw new Error(
-            `Version ${version} of LightAccount doesn't support 1271`
-          );
-        default:
-          return signWith1271Wrapper(hashMessage(message));
-      }
-    },
-    async signTypedData(params) {
-      const version = await getLightAccountVersion(account);
-      switch (version) {
-        case "v1.0.1": {
-          return signer.signTypedData(
-            params as unknown as SignTypedDataParameters
-          );
-        }
-        case "v1.0.2":
-          throw new Error(
-            `Version ${version} of LightAccount doesn't support 1271`
-          );
-        default:
-          return signWith1271Wrapper(hashTypedData(params));
-      }
-    },
-    getDummySignature: () => {
-      return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
-    },
-    encodeUpgradeToAndCall,
-  });
+                return accum;
+              },
+              [[], [], []] as [Address[], bigint[], Hex[]]
+            );
+            return encodeFunctionData({
+              abi: LightAccountAbi,
+              functionName: "executeBatch",
+              args: [targets, values, datas],
+            });
+          },
+          signUserOperationHash: async (uoHash: Hex) => {
+            return signer.signMessage({ raw: uoHash });
+          },
+          async signMessage({ message }) {
+            const version = await getLightAccountVersion(account!);
+            switch (version) {
+              case "v1.0.1":
+                return signer.signMessage(message);
+              case "v1.0.2":
+                throw new Error(
+                  `Version ${version} of LightAccount doesn't support 1271`
+                );
+              default:
+                return signWith1271Wrapper(hashMessage(message));
+            }
+          },
+          async signTypedData(params) {
+            const version = await getLightAccountVersion(account!);
+            switch (version) {
+              case "v1.0.1": {
+                return signer.signTypedData(
+                  params as unknown as SignTypedDataParameters
+                );
+              }
+              case "v1.0.2":
+                throw new Error(
+                  `Version ${version} of LightAccount doesn't support 1271`
+                );
+              default:
+                return signWith1271Wrapper(hashTypedData(params));
+            }
+          },
+          getDummySignature: () => {
+            return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+          },
+          encodeUpgradeToAndCall,
+        })
+      : _entryPoint.version === "0.7.0"
+      ? await toSmartContractAccount({
+          transport,
+          chain,
+          entryPoint: _entryPoint as EntryPointDef<"0.7.0">,
+          accountAddress: address,
+          source: "LightAccount",
+          getAccountInitCode,
+          encodeExecute: async ({ target, data, value }) => {
+            return encodeFunctionData({
+              abi: LightAccountAbi,
+              functionName: "execute",
+              args: [target, value ?? 0n, data],
+            });
+          },
+          encodeBatchExecute: async (txs) => {
+            const [targets, values, datas] = txs.reduce(
+              (accum, curr) => {
+                accum[0].push(curr.target);
+                accum[1].push(curr.value ?? 0n);
+                accum[2].push(curr.data);
+
+                return accum;
+              },
+              [[], [], []] as [Address[], bigint[], Hex[]]
+            );
+            return encodeFunctionData({
+              abi: LightAccountAbi,
+              functionName: "executeBatch",
+              args: [targets, values, datas],
+            });
+          },
+          signUserOperationHash: async (uoHash: Hex) => {
+            return signer.signMessage({ raw: uoHash });
+          },
+          async signMessage({ message }) {
+            const version = await getLightAccountVersion(account!);
+            switch (version) {
+              case "v1.0.1":
+                return signer.signMessage(message);
+              case "v1.0.2":
+                throw new Error(
+                  `Version ${version} of LightAccount doesn't support 1271`
+                );
+              default:
+                return signWith1271Wrapper(hashMessage(message));
+            }
+          },
+          async signTypedData(params) {
+            const version = await getLightAccountVersion(account!);
+            switch (version) {
+              case "v1.0.1": {
+                return signer.signTypedData(
+                  params as unknown as SignTypedDataParameters
+                );
+              }
+              case "v1.0.2":
+                throw new Error(
+                  `Version ${version} of LightAccount doesn't support 1271`
+                );
+              default:
+                return signWith1271Wrapper(hashTypedData(params));
+            }
+          },
+          getDummySignature: () => {
+            return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+          },
+          encodeUpgradeToAndCall,
+        })
+      : undefined;
+
+  if (!account) throw new InvalidEntryPointError(chain, _entryPoint.version);
 
   return {
     ...account,
@@ -258,5 +364,5 @@ export async function createLightAccount({
       return callResult;
     },
     getSigner: () => signer,
-  };
+  } as LightAccount<TEntryPointVersion, TSigner>;
 }

--- a/packages/accounts/src/light-account/client.ts
+++ b/packages/accounts/src/light-account/client.ts
@@ -1,5 +1,6 @@
 import {
   createSmartAccountClient,
+  type EntryPointDef,
   type EntryPointVersion,
   type SmartAccountClient,
   type SmartAccountClientActions,
@@ -43,30 +44,42 @@ export type CreateLightAccountClientParams<
 >;
 
 export function createLightAccountClient<
+  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends LightAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateLightAccountClientParams<EntryPointVersion, TChain, TSigner>
+  args: CreateLightAccountClientParams<TEntryPointVersion, TChain, TSigner>
 ): Promise<
   SmartAccountClient<
-    EntryPointVersion,
+    TEntryPointVersion,
     Transport,
     TChain,
-    LightAccount<EntryPointVersion, TSigner>,
+    LightAccount<TEntryPointVersion, TSigner>,
     SmartAccountClientActions<
-      EntryPointVersion,
+      TEntryPointVersion,
       TChain,
-      SmartContractAccount<EntryPointVersion>
+      SmartContractAccount<TEntryPointVersion>
     > &
       LightAccountClientActions<
-        EntryPointVersion,
+        TEntryPointVersion,
         TSigner,
-        LightAccount<EntryPointVersion, TSigner>
+        LightAccount<TEntryPointVersion, TSigner>
       >
   >
 >;
 
 export async function createLightAccountClient<
+  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends LightAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >({
@@ -74,25 +87,34 @@ export async function createLightAccountClient<
   transport,
   chain,
   ...clientConfig
-}: CreateLightAccountClientParams<EntryPointVersion, TChain, TSigner>): Promise<
+}: CreateLightAccountClientParams<
+  TEntryPointVersion,
+  TChain,
+  TSigner
+>): Promise<
   SmartAccountClient<
-    EntryPointVersion,
+    TEntryPointVersion,
     Transport,
     TChain,
-    LightAccount<EntryPointVersion>
+    LightAccount<TEntryPointVersion>
   >
 > {
-  const lightAccount = await createLightAccount({
+  const lightAccount = (await createLightAccount<
+    EntryPointDef<TEntryPointVersion>,
+    TEntryPointVersion,
+    Transport,
+    TSigner
+  >({
     ...account,
     transport,
     chain,
-  });
+  })) as LightAccount<TEntryPointVersion, TSigner>;
 
   return createSmartAccountClient<
-    EntryPointVersion,
+    LightAccount<TEntryPointVersion, TSigner>,
+    TEntryPointVersion,
     Transport,
-    TChain,
-    LightAccount<EntryPointVersion>
+    TChain
   >({
     ...clientConfig,
     transport,

--- a/packages/accounts/src/light-account/client.ts
+++ b/packages/accounts/src/light-account/client.ts
@@ -1,12 +1,13 @@
 import {
   createSmartAccountClient,
+  type EntryPointVersion,
   type SmartAccountClient,
   type SmartAccountClientActions,
   type SmartAccountClientConfig,
   type SmartAccountSigner,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
-import { type Chain, type CustomTransport, type Transport } from "viem";
+import { type Chain, type Transport } from "viem";
 import {
   createLightAccount,
   type CreateLightAccountParams,
@@ -18,18 +19,26 @@ import {
 } from "./decorator.js";
 
 export type CreateLightAccountClientParams<
-  TTransport extends Transport = Transport,
+  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = {
-  transport: CreateLightAccountParams<TTransport, TSigner>["transport"];
-  chain: CreateLightAccountParams<TTransport, TSigner>["chain"];
+  transport: CreateLightAccountParams<
+    TEntryPointVersion,
+    Transport,
+    TSigner
+  >["transport"];
+  chain: CreateLightAccountParams<
+    TEntryPointVersion,
+    Transport,
+    TSigner
+  >["chain"];
   account: Omit<
-    CreateLightAccountParams<TTransport, TSigner>,
+    CreateLightAccountParams<TEntryPointVersion, Transport, TSigner>,
     "transport" | "chain"
   >;
 } & Omit<
-  SmartAccountClientConfig<TTransport, TChain>,
+  SmartAccountClientConfig<TEntryPointVersion, Transport, TChain>,
   "transport" | "account" | "chain"
 >;
 
@@ -37,30 +46,54 @@ export function createLightAccountClient<
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateLightAccountClientParams<Transport, TChain, TSigner>
+  args: CreateLightAccountClientParams<EntryPointVersion, TChain, TSigner>
 ): Promise<
   SmartAccountClient<
-    CustomTransport,
-    Chain,
-    LightAccount<TSigner>,
-    SmartAccountClientActions<Chain, SmartContractAccount> &
-      LightAccountClientActions<TSigner, LightAccount<TSigner>>
+    EntryPointVersion,
+    Transport,
+    TChain,
+    LightAccount<EntryPointVersion, TSigner>,
+    SmartAccountClientActions<
+      EntryPointVersion,
+      TChain,
+      SmartContractAccount<EntryPointVersion>
+    > &
+      LightAccountClientActions<
+        EntryPointVersion,
+        TSigner,
+        LightAccount<EntryPointVersion, TSigner>
+      >
   >
 >;
 
-export async function createLightAccountClient({
+export async function createLightAccountClient<
+  TChain extends Chain | undefined = Chain | undefined,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+>({
   account,
   transport,
   chain,
   ...clientConfig
-}: CreateLightAccountClientParams): Promise<SmartAccountClient> {
+}: CreateLightAccountClientParams<EntryPointVersion, TChain, TSigner>): Promise<
+  SmartAccountClient<
+    EntryPointVersion,
+    Transport,
+    TChain,
+    LightAccount<EntryPointVersion>
+  >
+> {
   const lightAccount = await createLightAccount({
     ...account,
     transport,
     chain,
   });
 
-  return createSmartAccountClient({
+  return createSmartAccountClient<
+    EntryPointVersion,
+    Transport,
+    TChain,
+    LightAccount<EntryPointVersion>
+  >({
     ...clientConfig,
     transport,
     chain: chain,

--- a/packages/accounts/src/light-account/decorator.ts
+++ b/packages/accounts/src/light-account/decorator.ts
@@ -1,35 +1,39 @@
-import type {
-  GetAccountParameter,
-  Hex,
-  SmartAccountSigner,
-} from "@alchemy/aa-core";
-import type { Chain, Client, Transport } from "viem";
+import type { EntryPointVersion, SmartAccountSigner } from "@alchemy/aa-core";
+import type { Chain, Client, Hex, Transport } from "viem";
 import type { LightAccount } from "./account";
-import { transferOwnership } from "./actions/transferOwnership.js";
+import {
+  transferOwnership,
+  type TransferLightAccountOwnershipParams,
+} from "./actions/transferOwnership.js";
 
 export type LightAccountClientActions<
+  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TSigner> | undefined =
-    | LightAccount<TSigner>
+  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined =
+    | LightAccount<TEntryPointVersion, TSigner>
     | undefined
 > = {
   transferOwnership: (
-    args: {
-      newOwner: TSigner;
-      waitForTxn?: boolean;
-    } & GetAccountParameter<TAccount, LightAccount>
+    args: TransferLightAccountOwnershipParams<
+      TEntryPointVersion,
+      TSigner,
+      TAccount
+    >
   ) => Promise<Hex>;
 };
 
 export const lightAccountClientActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
-  TAccount extends LightAccount<TSigner> | undefined =
-    | LightAccount<TSigner>
+  TAccount extends LightAccount<TEntryPointVersion, TSigner> | undefined =
+    | LightAccount<TEntryPointVersion, TSigner>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => LightAccountClientActions<TSigner, TAccount> = (client) => ({
+) => LightAccountClientActions<TEntryPointVersion, TSigner, TAccount> = (
+  client
+) => ({
   transferOwnership: async (args) => transferOwnership(client, args),
 });

--- a/packages/accounts/src/light-account/utils.ts
+++ b/packages/accounts/src/light-account/utils.ts
@@ -15,6 +15,7 @@ import {
   polygonAmoy,
   polygonMumbai,
   sepolia,
+  type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import { fromHex, type Address, type Chain } from "viem";
@@ -95,7 +96,10 @@ export const LightAccountUnsupported1271Factories = new Set(
   LightAccountUnsupported1271Impls.map((x) => x.factoryAddress)
 );
 
-export const getLightAccountVersion = async <A extends SmartContractAccount>(
+export const getLightAccountVersion = async <
+  TEntryPointVersion extends EntryPointVersion,
+  A extends SmartContractAccount<TEntryPointVersion>
+>(
   account: A
 ) => {
   const implAddress = await account.getImplementationAddress();

--- a/packages/accounts/src/msca/account-loupe/decorator.ts
+++ b/packages/accounts/src/msca/account-loupe/decorator.ts
@@ -2,6 +2,7 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
+  type EntryPointVersion,
   type GetAccountParameter,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -15,8 +16,9 @@ import type {
 } from "./types.js";
 
 export type AccountLoupeActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   /// @notice Gets the validation functions and plugin address for a selector
@@ -24,7 +26,10 @@ export type AccountLoupeActions<
   /// @param selector The selector to get the configuration for
   /// @return The configuration for this selector
   getExecutionFunctionConfig(
-    args: { selector: FunctionReference } & GetAccountParameter<TAccount>
+    args: { selector: FunctionReference } & GetAccountParameter<
+      TEntryPointVersion,
+      TAccount
+    >
   ): Promise<ExecutionFunctionConfig>;
 
   /// @notice Gets the pre and post execution hooks for a selector
@@ -33,7 +38,7 @@ export type AccountLoupeActions<
   getExecutionHooks(
     args: {
       selector: FunctionReference;
-    } & GetAccountParameter<TAccount>
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
   ): Promise<ReadonlyArray<ExecutionHooks>>;
 
   /// @notice Gets the pre user op and runtime validation hooks associated with a selector
@@ -41,25 +46,26 @@ export type AccountLoupeActions<
   /// @return preUserOpValidationHooks The pre user op validation hooks for this selector
   /// @return preRuntimeValidationHooks The pre runtime validation hooks for this selector
   getPreValidationHooks(
-    args: { selector: Hash } & GetAccountParameter<TAccount>
+    args: { selector: Hash } & GetAccountParameter<TEntryPointVersion, TAccount>
   ): Promise<Readonly<PreValidationHooks>>;
 
   /// @notice Gets an array of all installed plugins
   /// @return The addresses of all installed plugins
   getInstalledPlugins(
-    args: GetAccountParameter<TAccount>
+    args: GetAccountParameter<TEntryPointVersion, TAccount>
   ): Promise<ReadonlyArray<Address>>;
 };
 
 export const accountLoupeActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => AccountLoupeActions<TAccount> = (client) => ({
+) => AccountLoupeActions<TEntryPointVersion, TAccount> = (client) => ({
   getExecutionFunctionConfig: async ({
     selector,
     account = client.account,

--- a/packages/accounts/src/msca/account/standardExecutor.ts
+++ b/packages/accounts/src/msca/account/standardExecutor.ts
@@ -1,9 +1,9 @@
-import type { SmartContractAccount } from "@alchemy/aa-core";
+import type { EntryPointVersion, SmartContractAccount } from "@alchemy/aa-core";
 import { encodeFunctionData } from "viem";
 import { IStandardExecutorAbi } from "../abis/IStandardExecutor.js";
 
 export const standardExecutor: Pick<
-  SmartContractAccount,
+  SmartContractAccount<EntryPointVersion>,
   "encodeExecute" | "encodeBatchExecute"
 > = {
   encodeExecute: async ({ target, data, value }) => {

--- a/packages/accounts/src/msca/client.ts
+++ b/packages/accounts/src/msca/client.ts
@@ -1,5 +1,6 @@
 import {
   createSmartAccountClient,
+  type EntryPointVersion,
   type SmartAccountClient,
   type SmartAccountClientActions,
   type SmartAccountSigner,
@@ -25,42 +26,81 @@ import {
 } from "./plugins/multi-owner/index.js";
 
 export type CreateMultiOwnerModularAccountClientParams<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = {
   account: Omit<
-    CreateMultiOwnerModularAccountParams<TTransport, TSigner>,
+    CreateMultiOwnerModularAccountParams<
+      TEntryPointVersion,
+      TTransport,
+      TSigner
+    >,
     "transport" | "chain"
   >;
 } & Omit<
-  CreateLightAccountClientParams<TTransport, TChain, TSigner>,
+  CreateLightAccountClientParams<TEntryPointVersion, TChain, TSigner>,
   "account"
 >;
 
 export function createMultiOwnerModularAccountClient<
+  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateMultiOwnerModularAccountClientParams<Transport, TChain, TSigner>
+  args: CreateMultiOwnerModularAccountClientParams<
+    TEntryPointVersion,
+    Transport,
+    TChain,
+    TSigner
+  >
 ): Promise<
   SmartAccountClient<
+    TEntryPointVersion,
     CustomTransport,
     Chain,
-    MultiOwnerModularAccount<TSigner>,
-    SmartAccountClientActions<Chain, MultiOwnerModularAccount<TSigner>> &
-      MultiOwnerPluginActions<MultiOwnerModularAccount<TSigner>> &
-      PluginManagerActions<MultiOwnerModularAccount<TSigner>> &
-      AccountLoupeActions<MultiOwnerModularAccount<TSigner>>
+    MultiOwnerModularAccount<TEntryPointVersion, TSigner>,
+    SmartAccountClientActions<
+      TEntryPointVersion,
+      Chain,
+      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+    > &
+      MultiOwnerPluginActions<
+        TEntryPointVersion,
+        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+      > &
+      PluginManagerActions<
+        TEntryPointVersion,
+        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+      > &
+      AccountLoupeActions<
+        TEntryPointVersion,
+        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+      >
   >
 >;
 
-export async function createMultiOwnerModularAccountClient({
+export async function createMultiOwnerModularAccountClient<
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+>({
   account,
   transport,
   chain,
   ...clientConfig
-}: CreateMultiOwnerModularAccountClientParams): Promise<SmartAccountClient> {
+}: CreateMultiOwnerModularAccountClientParams<
+  EntryPointVersion,
+  Transport,
+  Chain,
+  TSigner
+>): Promise<
+  SmartAccountClient<
+    EntryPointVersion,
+    Transport,
+    Chain,
+    MultiOwnerModularAccount<EntryPointVersion, TSigner>
+  >
+> {
   const modularAccount = await createMultiOwnerModularAccount({
     ...account,
     transport,

--- a/packages/accounts/src/msca/client.ts
+++ b/packages/accounts/src/msca/client.ts
@@ -1,5 +1,6 @@
 import {
   createSmartAccountClient,
+  type EntryPointDef,
   type EntryPointVersion,
   type SmartAccountClient,
   type SmartAccountClientActions,
@@ -45,7 +46,14 @@ export type CreateMultiOwnerModularAccountClientParams<
 >;
 
 export function createMultiOwnerModularAccountClient<
-  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends
+    | MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+    | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends MultiOwnerModularAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
@@ -82,6 +90,14 @@ export function createMultiOwnerModularAccountClient<
 >;
 
 export async function createMultiOwnerModularAccountClient<
+  TAccount extends
+    | MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+    | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends MultiOwnerModularAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >({
   account,
@@ -89,25 +105,35 @@ export async function createMultiOwnerModularAccountClient<
   chain,
   ...clientConfig
 }: CreateMultiOwnerModularAccountClientParams<
-  EntryPointVersion,
+  TEntryPointVersion,
   Transport,
   Chain,
   TSigner
 >): Promise<
   SmartAccountClient<
-    EntryPointVersion,
+    TEntryPointVersion,
     Transport,
     Chain,
-    MultiOwnerModularAccount<EntryPointVersion, TSigner>
+    MultiOwnerModularAccount<TEntryPointVersion, TSigner>
   >
 > {
-  const modularAccount = await createMultiOwnerModularAccount({
+  const modularAccount = (await createMultiOwnerModularAccount<
+    EntryPointDef<TEntryPointVersion>,
+    TEntryPointVersion,
+    Transport,
+    TSigner
+  >({
     ...account,
     transport,
     chain,
-  });
+  })) as MultiOwnerModularAccount<TEntryPointVersion, TSigner>;
 
-  return createSmartAccountClient({
+  return createSmartAccountClient<
+    MultiOwnerModularAccount<TEntryPointVersion, TSigner>,
+    TEntryPointVersion,
+    Transport,
+    Chain
+  >({
     ...clientConfig,
     transport,
     chain,

--- a/packages/accounts/src/msca/plugin-manager/decorator.ts
+++ b/packages/accounts/src/msca/plugin-manager/decorator.ts
@@ -1,4 +1,5 @@
 import type {
+  EntryPointVersion,
   SendUserOperationResult,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -13,27 +14,29 @@ export { type InstallPluginParams } from "./installPlugin.js";
 export { type UninstallPluginParams } from "./uninstallPlugin.js";
 
 export type PluginManagerActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   installPlugin: (
-    params: InstallPluginParams<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    params: InstallPluginParams<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   uninstallPlugin: (
-    params: UninstallPluginParams<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    params: UninstallPluginParams<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 export const pluginManagerActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => PluginManagerActions<TAccount> = (client) => ({
+) => PluginManagerActions<TEntryPointVersion, TAccount> = (client) => ({
   installPlugin: async (params) => installPlugin(client, params),
   uninstallPlugin: async (params) => uninstallPlugin(client, params),
 });

--- a/packages/accounts/src/msca/plugins/multi-owner/extension.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/extension.ts
@@ -1,3 +1,4 @@
+import type { EntryPointVersion } from "@alchemy/aa-core";
 import {
   AccountNotFoundError,
   type GetAccountParameter,
@@ -13,68 +14,79 @@ import {
 } from "./plugin.js";
 
 export type MultiOwnerPluginActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
-> = MultiOwnerPluginActions_<TAccount> & {
+> = MultiOwnerPluginActions_<TEntryPointVersion, TAccount> & {
   readOwners: (
-    params: GetPluginAddressParameter & GetAccountParameter<TAccount>
+    params: GetPluginAddressParameter &
+      GetAccountParameter<TEntryPointVersion, TAccount>
   ) => Promise<ReadonlyArray<Address>>;
 
   isOwnerOf: (
     params: { address: Address } & GetPluginAddressParameter &
-      GetAccountParameter<TAccount>
+      GetAccountParameter<TEntryPointVersion, TAccount>
   ) => Promise<boolean>;
 } & (IsUndefined<TAccount> extends false
     ? {
         readOwners: (
-          params?: GetPluginAddressParameter & GetAccountParameter<TAccount>
+          params?: GetPluginAddressParameter &
+            GetAccountParameter<TEntryPointVersion, TAccount>
         ) => Promise<ReadonlyArray<Address>>;
       }
     : {});
 
 export const multiOwnerPluginActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => MultiOwnerPluginActions<TAccount> = <
+) => MultiOwnerPluginActions<TEntryPointVersion, TAccount> = <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => ({
-  ...multiOwnerPluginActions_(client),
-  async readOwners(
-    args: GetPluginAddressParameter & GetAccountParameter<TAccount>
-  ) {
-    const account = args?.account ?? client.account;
-    if (!account) {
-      throw new AccountNotFoundError();
-    }
-    // TODO: check if the account actually has the plugin installed
-    // either via account loupe or checking if the supports interface call passes on the account
-    const contract = MultiOwnerPlugin.getContract(client, args?.pluginAddress);
-    return contract.read.ownersOf([account.address]);
-  },
+) =>
+  ({
+    // @ts-ignore
+    ...multiOwnerPluginActions_(client),
+    async readOwners(
+      args: GetPluginAddressParameter &
+        GetAccountParameter<TEntryPointVersion, TAccount>
+    ) {
+      const account = args?.account ?? client.account;
+      if (!account) {
+        throw new AccountNotFoundError();
+      }
+      // TODO: check if the account actually has the plugin installed
+      // either via account loupe or checking if the supports interface call passes on the account
+      const contract = MultiOwnerPlugin.getContract(
+        client,
+        args?.pluginAddress
+      );
+      return contract.read.ownersOf([account.address]);
+    },
 
-  async isOwnerOf(
-    args: { address: Address } & GetPluginAddressParameter &
-      GetAccountParameter<TAccount>
-  ) {
-    const account = args.account ?? client.account;
-    if (!account) {
-      throw new AccountNotFoundError();
-    }
-    // TODO: check if the account actually has the plugin installed
-    // either via account loupe or checking if the supports interface call passes on the account
-    const contract = MultiOwnerPlugin.getContract(client, args.pluginAddress);
-    return contract.read.isOwnerOf([account.address, args.address]);
-  },
-});
+    async isOwnerOf(
+      args: { address: Address } & GetPluginAddressParameter &
+        GetAccountParameter<TEntryPointVersion, TAccount>
+    ) {
+      const account = args.account ?? client.account;
+      if (!account) {
+        throw new AccountNotFoundError();
+      }
+      // TODO: check if the account actually has the plugin installed
+      // either via account loupe or checking if the supports interface call passes on the account
+      const contract = MultiOwnerPlugin.getContract(client, args.pluginAddress);
+      return contract.read.isOwnerOf([account.address, args.address]);
+    },
+  } as MultiOwnerPluginActions<TEntryPointVersion, TAccount>);

--- a/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
@@ -17,6 +17,7 @@ import {
   AccountNotFoundError,
   isSmartAccountClient,
   IncompatibleClientError,
+  type EntryPointVersion,
   type SmartContractAccount,
   type UserOperationOverrides,
   type GetAccountParameter,
@@ -31,8 +32,9 @@ import { type FunctionReference } from "../../account-loupe/types.js";
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 type ExecutionActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   updateOwners: (
@@ -42,8 +44,10 @@ type ExecutionActions<
         "updateOwners"
       >,
       "args"
-    > & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    > & {
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type InstallArgs = [{ type: "address[]" }];
@@ -55,21 +59,23 @@ export type InstallMultiOwnerPluginParams = {
 };
 
 type ManagementActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   installMultiOwnerPlugin: (
     args: {
-      overrides?: UserOperationOverrides;
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
     } & InstallMultiOwnerPluginParams &
-      GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+      GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type ReadAndEncodeActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   encodeUpdateOwners: (
@@ -93,7 +99,7 @@ type ReadAndEncodeActions<
   ) => Hex;
 
   readEip712Domain: (
-    args: GetAccountParameter<TAccount>
+    args: GetAccountParameter<TEntryPointVersion, TAccount>
   ) => Promise<
     ReadContractReturnType<
       typeof MultiOwnerPluginExecutionFunctionAbi,
@@ -119,7 +125,7 @@ type ReadAndEncodeActions<
       >,
       "args"
     > &
-      GetAccountParameter<TAccount>
+      GetAccountParameter<TEntryPointVersion, TAccount>
   ) => Promise<
     ReadContractReturnType<
       typeof MultiOwnerPluginExecutionFunctionAbi,
@@ -129,12 +135,13 @@ type ReadAndEncodeActions<
 };
 
 export type MultiOwnerPluginActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
-> = ExecutionActions<TAccount> &
-  ManagementActions<TAccount> &
-  ReadAndEncodeActions<TAccount>;
+> = ExecutionActions<TEntryPointVersion, TAccount> &
+  ManagementActions<TEntryPointVersion, TAccount> &
+  ReadAndEncodeActions<TEntryPointVersion, TAccount>;
 
 const addresses = {
   10: "0xcE0000007B008F50d762D155002600004cD6c647" as Address,
@@ -174,14 +181,15 @@ export const MultiOwnerPlugin: Plugin<typeof MultiOwnerPluginAbi> = {
 };
 
 export const multiOwnerPluginActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => MultiOwnerPluginActions<TAccount> = (client) => ({
+) => MultiOwnerPluginActions<TEntryPointVersion, TAccount> = (client) => ({
   updateOwners({ args, overrides, account = client.account }) {
     if (!account) {
       throw new AccountNotFoundError();

--- a/packages/accounts/src/msca/plugins/multi-owner/signer.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/signer.ts
@@ -1,6 +1,7 @@
 import type {
   Address,
   BundlerClient,
+  EntryPointVersion,
   SmartAccountSigner,
 } from "@alchemy/aa-core";
 import {
@@ -16,10 +17,11 @@ import {
 import { MultiOwnerPlugin, MultiOwnerPluginAbi } from "./plugin.js";
 
 export const multiOwnerMessageSigner = <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport,
   TSigner extends SmartAccountSigner
 >(
-  client: BundlerClient<TTransport>,
+  client: BundlerClient<TEntryPointVersion, TTransport>,
   accountAddress: Address,
   signer: () => TSigner,
   pluginAddress: Address = MultiOwnerPlugin.meta.addresses[client.chain.id]

--- a/packages/accounts/src/msca/plugins/session-key/plugin.ts
+++ b/packages/accounts/src/msca/plugins/session-key/plugin.ts
@@ -17,6 +17,7 @@ import {
   AccountNotFoundError,
   isSmartAccountClient,
   IncompatibleClientError,
+  type EntryPointVersion,
   type SmartContractAccount,
   type UserOperationOverrides,
   type GetAccountParameter,
@@ -32,8 +33,9 @@ import { type FunctionReference } from "../../account-loupe/types.js";
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 type ExecutionActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   executeWithSessionKey: (
@@ -43,8 +45,10 @@ type ExecutionActions<
         "executeWithSessionKey"
       >,
       "args"
-    > & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    > & {
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   addSessionKey: (
     args: Pick<
@@ -53,8 +57,10 @@ type ExecutionActions<
         "addSessionKey"
       >,
       "args"
-    > & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    > & {
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   removeSessionKey: (
     args: Pick<
@@ -63,8 +69,10 @@ type ExecutionActions<
         "removeSessionKey"
       >,
       "args"
-    > & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    > & {
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   rotateSessionKey: (
     args: Pick<
@@ -73,8 +81,10 @@ type ExecutionActions<
         "rotateSessionKey"
       >,
       "args"
-    > & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    > & {
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 
   updateKeyPermissions: (
     args: Pick<
@@ -83,8 +93,10 @@ type ExecutionActions<
         "updateKeyPermissions"
       >,
       "args"
-    > & { overrides?: UserOperationOverrides } & GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+    > & {
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
+    } & GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type InstallArgs = [
@@ -100,16 +112,17 @@ export type InstallSessionKeyPluginParams = {
 };
 
 type ManagementActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   installSessionKeyPlugin: (
     args: {
-      overrides?: UserOperationOverrides;
+      overrides?: UserOperationOverrides<TEntryPointVersion>;
     } & InstallSessionKeyPluginParams &
-      GetAccountParameter<TAccount>
-  ) => Promise<SendUserOperationResult>;
+      GetAccountParameter<TEntryPointVersion, TAccount>
+  ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
 type ReadAndEncodeActions = {
@@ -165,11 +178,12 @@ type ReadAndEncodeActions = {
 };
 
 export type SessionKeyPluginActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
-> = ExecutionActions<TAccount> &
-  ManagementActions<TAccount> &
+> = ExecutionActions<TEntryPointVersion, TAccount> &
+  ManagementActions<TEntryPointVersion, TAccount> &
   ReadAndEncodeActions;
 
 const addresses = {
@@ -210,14 +224,15 @@ export const SessionKeyPlugin: Plugin<typeof SessionKeyPluginAbi> = {
 };
 
 export const sessionKeyPluginActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => SessionKeyPluginActions<TAccount> = (client) => ({
+) => SessionKeyPluginActions<TEntryPointVersion, TAccount> = (client) => ({
   executeWithSessionKey({ args, overrides, account = client.account }) {
     if (!account) {
       throw new AccountNotFoundError();

--- a/packages/accounts/src/msca/plugins/session-key/utils.ts
+++ b/packages/accounts/src/msca/plugins/session-key/utils.ts
@@ -1,4 +1,5 @@
 import type {
+  EntryPointVersion,
   GetAccountParameter,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -9,17 +10,18 @@ import { SessionKeyPlugin } from "./plugin.js";
 // find predecessors for each keys and returned the struct `ISessionKeyPlugin.SessionKeyToRemove[]`
 // where SessionKeyToRemove = { sessionKey: Address, predecessor: Hex }
 export const buildSessionKeysToRemoveStruct: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: {
     keys: ReadonlyArray<Address>;
     pluginAddress?: Address;
-  } & GetAccountParameter<TAccount>
+  } & GetAccountParameter<TEntryPointVersion, TAccount>
 ) => Promise<{ sessionKey: Address; predecessor: Address }[]> = async (
   client,
   { keys, pluginAddress, account = client.account }

--- a/packages/accounts/src/msca/utils.ts
+++ b/packages/accounts/src/msca/utils.ts
@@ -74,15 +74,17 @@ export const getDefaultMultiOwnerModularAccountFactoryAddress = (
 };
 
 export async function getMSCAUpgradeToData<
-  TEntryPointVersion extends EntryPointVersion,
-  TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain | undefined,
-  TSigner extends SmartAccountSigner = SmartAccountSigner,
   TAccount extends
     | SmartContractAccountWithSigner<TEntryPointVersion, string, TSigner>
-    | undefined =
-    | SmartContractAccountWithSigner<TEntryPointVersion, string, TSigner>
-    | undefined
+    | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends MultiOwnerModularAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
+  TTransport extends Transport = Transport,
+  TChain extends Chain | undefined = Chain | undefined,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
   client: SmartAccountClient<TEntryPointVersion, TTransport, TChain, TAccount>,
   args: {
@@ -117,6 +119,7 @@ export async function getMSCAUpgradeToData<
     signerAddress: await account.getSigner().getAddress(),
   });
 
+  const entryPoint = account.getEntryPoint();
   return {
     ...initData,
     createMAAccount: async () =>
@@ -125,7 +128,12 @@ export async function getMSCAUpgradeToData<
         chain: chain as Chain,
         signer: account.getSigner(),
         accountAddress: account.address,
+        entryPoint,
       }),
+  } as UpgradeToData & {
+    createMAAccount: () => Promise<
+      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+    >;
   };
 }
 

--- a/packages/accounts/src/msca/utils.ts
+++ b/packages/accounts/src/msca/utils.ts
@@ -17,6 +17,7 @@ import {
   polygonAmoy,
   polygonMumbai,
   sepolia,
+  type EntryPointVersion,
   type GetAccountParameter,
   type SmartAccountClient,
   type SmartAccountSigner,
@@ -73,29 +74,37 @@ export const getDefaultMultiOwnerModularAccountFactoryAddress = (
 };
 
 export async function getMSCAUpgradeToData<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner,
   TAccount extends
-    | SmartContractAccountWithSigner<string, TSigner>
-    | undefined = SmartContractAccountWithSigner<string, TSigner> | undefined
+    | SmartContractAccountWithSigner<TEntryPointVersion, string, TSigner>
+    | undefined =
+    | SmartContractAccountWithSigner<TEntryPointVersion, string, TSigner>
+    | undefined
 >(
-  client: SmartAccountClient<TTransport, TChain, TAccount>,
-  {
-    multiOwnerPluginAddress,
-    account: account_ = client.account,
-  }: {
+  client: SmartAccountClient<TEntryPointVersion, TTransport, TChain, TAccount>,
+  args: {
     multiOwnerPluginAddress?: Address;
-  } & GetAccountParameter<TAccount>
+  } & GetAccountParameter<TEntryPointVersion, TAccount>
 ): Promise<
   UpgradeToData & {
-    createMAAccount: () => Promise<MultiOwnerModularAccount<TSigner>>;
+    createMAAccount: () => Promise<
+      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+    >;
   }
 > {
+  const { account: account_ = client.account, multiOwnerPluginAddress } = args;
+
   if (!account_) {
     throw new AccountNotFoundError();
   }
-  const account = account_ as SmartContractAccountWithSigner<string, TSigner>;
+  const account = account_ as SmartContractAccountWithSigner<
+    TEntryPointVersion,
+    string,
+    TSigner
+  >;
 
   const chain = client.chain;
   if (!chain) {
@@ -121,6 +130,7 @@ export async function getMSCAUpgradeToData<
 }
 
 export async function getMAInitializationData<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined
 >({
@@ -129,7 +139,7 @@ export async function getMAInitializationData<
   signerAddress,
 }: {
   multiOwnerPluginAddress?: Address;
-  client: SmartAccountClient<TTransport, TChain>;
+  client: SmartAccountClient<TEntryPointVersion, TTransport, TChain>;
   signerAddress: Address | Address[];
 }): Promise<UpgradeToData> {
   if (!client.chain) {

--- a/packages/accounts/src/nani-account/__tests__/account.test.ts
+++ b/packages/accounts/src/nani-account/__tests__/account.test.ts
@@ -2,10 +2,9 @@ import {
   LocalAccountSigner,
   polygonMumbai,
   type Address,
-  type Hex,
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
-import { http } from "viem";
+import { http, type Hex } from "viem";
 import { createNaniAccount } from "../account.js";
 import { getDefaultNaniAccountFactoryAddress } from "../utils.js";
 

--- a/packages/accounts/src/nani-account/account.ts
+++ b/packages/accounts/src/nani-account/account.ts
@@ -245,9 +245,7 @@ export const createNaniAccount = async <TTransport extends Transport>(
     transport: params.transport,
     chain: params.chain,
     accountAddress: params.accountAddress as Address | undefined,
-    entryPoint: getEntryPoint(params.chain, {
-      addressOverride: naniAccount.getEntryPointAddress(),
-    }),
+    entryPoint: getEntryPoint(params.chain),
     encodeBatchExecute: naniAccount.encodeBatchExecute.bind(naniAccount),
     encodeExecute: (tx) =>
       naniAccount.encodeExecute(tx.target, tx.value ?? 0n, tx.data),

--- a/packages/accounts/src/nani-account/transferNaniAccountOwnership.ts
+++ b/packages/accounts/src/nani-account/transferNaniAccountOwnership.ts
@@ -2,6 +2,7 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   isSmartAccountClient,
+  type DefaultEntryPointVersion,
   type GetAccountParameter,
   type SmartAccountSigner,
 } from "@alchemy/aa-core";
@@ -27,7 +28,7 @@ export const transferOwnership: <
   args: {
     newOwner: TSigner;
     waitForTxn?: boolean;
-  } & GetAccountParameter<TAccount>
+  } & GetAccountParameter<DefaultEntryPointVersion, TAccount>
 ) => Promise<Hex> = async (
   client,
   { newOwner, waitForTxn = false, account: account_ = client.account }

--- a/packages/alchemy/src/actions/simulateUserOperationChanges.ts
+++ b/packages/alchemy/src/actions/simulateUserOperationChanges.ts
@@ -2,6 +2,7 @@ import {
   AccountNotFoundError,
   IncompatibleClientError,
   deepHexlify,
+  type EntryPointVersion,
   type SendUserOperationParameters,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -11,16 +12,22 @@ import type { AlchemyRpcSchema } from "../client/types";
 import type { SimulateUserOperationAssetChangesResponse } from "./types";
 
 export const simulateUserOperationChanges: <
+  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
-  client: Client<Transport, TChain, TAccount, AlchemyRpcSchema>,
-  args: SendUserOperationParameters<TAccount>
+  client: Client<
+    Transport,
+    TChain,
+    TAccount,
+    AlchemyRpcSchema<TEntryPointVersion>
+  >,
+  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
 ) => Promise<SimulateUserOperationAssetChangesResponse> = async (
   client,
-  { account = client.account, ...params }
+  { account = client.account, overrides, ...params }
 ) => {
   if (!account) {
     throw new AccountNotFoundError();
@@ -38,6 +45,7 @@ export const simulateUserOperationChanges: <
     await client.buildUserOperation({
       ...params,
       account,
+      overrides,
     })
   );
 

--- a/packages/alchemy/src/actions/types.ts
+++ b/packages/alchemy/src/actions/types.ts
@@ -1,4 +1,4 @@
-import type { UserOperationStruct } from "@alchemy/aa-core";
+import type { EntryPointVersion, UserOperationStruct } from "@alchemy/aa-core";
 import type { Address, Hash } from "viem";
 
 export enum SimulateAssetType {
@@ -18,8 +18,10 @@ export enum SimulateChangeType {
   TRANSFER = "TRANSFER",
 }
 
-export type SimulateUserOperationAssetChangesRequest = [
-  UserOperationStruct,
+export type SimulateUserOperationAssetChangesRequest<
+  TEntryPointVersion extends EntryPointVersion
+> = [
+  UserOperationStruct<TEntryPointVersion>,
   entryPoint: Address,
   blockNumber?: Hash
 ];

--- a/packages/alchemy/src/client/decorators/alchemyEnhancedApis.ts
+++ b/packages/alchemy/src/client/decorators/alchemyEnhancedApis.ts
@@ -1,4 +1,4 @@
-import type { SmartContractAccount } from "@alchemy/aa-core";
+import type { EntryPointVersion, SmartContractAccount } from "@alchemy/aa-core";
 import type { Alchemy } from "alchemy-sdk";
 import type { Chain, HttpTransport, Transport } from "viem";
 import { AlchemySdkClientSchema } from "../../schema.js";
@@ -17,13 +17,19 @@ export type AlchemyEnhancedApis = {
 export const alchemyEnhancedApiActions: (
   alchemy: Alchemy
 ) => <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
-  client: AlchemySmartAccountClient<TTransport, TChain, TAccount>
+  client: AlchemySmartAccountClient<
+    TEntryPointVersion,
+    TTransport,
+    TChain,
+    TAccount
+  >
 ) => AlchemyEnhancedApis = (alchemy) => (client) => {
   const alchemySdk = AlchemySdkClientSchema.parse(alchemy);
 

--- a/packages/alchemy/src/client/decorators/smartAccount.ts
+++ b/packages/alchemy/src/client/decorators/smartAccount.ts
@@ -1,4 +1,5 @@
 import type {
+  EntryPointVersion,
   SendUserOperationParameters,
   SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -7,24 +8,28 @@ import { simulateUserOperationChanges } from "../../actions/simulateUserOperatio
 import type { SimulateUserOperationAssetChangesResponse } from "../../actions/types.js";
 
 export type AlchemySmartAccountClientActions<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   simulateUserOperation: (
-    args: SendUserOperationParameters<TAccount>
+    args: SendUserOperationParameters<TEntryPointVersion, TAccount>
   ) => Promise<SimulateUserOperationAssetChangesResponse>;
 };
 
 export const alchemyActions: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-) => AlchemySmartAccountClientActions<TAccount> = (client) => ({
+) => AlchemySmartAccountClientActions<TEntryPointVersion, TAccount> = (
+  client
+) => ({
   simulateUserOperation: async (args) =>
     simulateUserOperationChanges(client, args),
 });

--- a/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
+++ b/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
@@ -4,7 +4,7 @@ import {
   type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
-import type { Chain, CustomTransport, Transport } from "viem";
+import type { Chain, CustomTransport, HttpTransport, Transport } from "viem";
 import { alchemyFeeEstimator } from "../../middleware/feeEstimator.js";
 import { alchemyGasManagerMiddleware } from "../../middleware/gasManager.js";
 import { alchemyUserOperationSimulator } from "../../middleware/userOperationSimulator.js";
@@ -35,11 +35,13 @@ export type CreateAlchemySmartAccountClientFromRpcClient<
  * from an existing Alchemy Rpc Client
  */
 export function createAlchemySmartAccountClientFromRpcClient<
-  TEntryPointVersion extends EntryPointVersion,
-  TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends SmartContractAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
+  TChain extends Chain | undefined = Chain | undefined
 >({
   opts,
   account,
@@ -61,7 +63,13 @@ export function createAlchemySmartAccountClientFromRpcClient<
   const feeOptions =
     opts?.feeOptions ?? getDefaultUserOperationFeeOptions(client.chain);
 
-  return createSmartAccountClientFromExisting({
+  return createSmartAccountClientFromExisting<
+    TAccount,
+    TEntryPointVersion,
+    HttpTransport,
+    TChain,
+    ClientWithAlchemyMethods<TEntryPointVersion>
+  >({
     account,
     client,
     type: "AlchemySmartAccountClient",

--- a/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
+++ b/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
@@ -1,6 +1,7 @@
 import {
   createSmartAccountClientFromExisting,
   getDefaultUserOperationFeeOptions,
+  type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import type { Chain, CustomTransport, Transport } from "viem";
@@ -15,28 +16,31 @@ import type {
 import type { ClientWithAlchemyMethods } from "../types";
 
 export type CreateAlchemySmartAccountClientFromRpcClient<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = Omit<
-  AlchemySmartAccountClientConfig<Transport, Chain, TAccount>,
+  AlchemySmartAccountClientConfig<
+    TEntryPointVersion,
+    Transport,
+    Chain,
+    TAccount
+  >,
   "rpcUrl" | "chain" | "apiKey" | "jwt"
-> & { client: ClientWithAlchemyMethods };
+> & { client: ClientWithAlchemyMethods<TEntryPointVersion> };
 
 /**
  * Helper method meant to be used internally to create an alchemy smart account client
  * from an existing Alchemy Rpc Client
  */
 export function createAlchemySmartAccountClientFromRpcClient<
+  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
->(
-  args: CreateAlchemySmartAccountClientFromRpcClient<TAccount>
-): AlchemySmartAccountClient<CustomTransport, TChain, TAccount>;
-
-export function createAlchemySmartAccountClientFromRpcClient({
+>({
   opts,
   account,
   useSimulation,
@@ -45,7 +49,15 @@ export function createAlchemySmartAccountClientFromRpcClient({
   gasEstimator,
   customMiddleware,
   client,
-}: CreateAlchemySmartAccountClientFromRpcClient): AlchemySmartAccountClient {
+}: CreateAlchemySmartAccountClientFromRpcClient<
+  TEntryPointVersion,
+  TAccount
+>): AlchemySmartAccountClient<
+  TEntryPointVersion,
+  CustomTransport,
+  TChain,
+  TAccount
+> {
   const feeOptions =
     opts?.feeOptions ?? getDefaultUserOperationFeeOptions(client.chain);
 
@@ -79,5 +91,10 @@ export function createAlchemySmartAccountClientFromRpcClient({
             gasEstimator,
         },
       })),
-  }).extend(alchemyActions);
+  }).extend(alchemyActions) as AlchemySmartAccountClient<
+    TEntryPointVersion,
+    CustomTransport,
+    TChain,
+    TAccount
+  >;
 }

--- a/packages/alchemy/src/client/isAlchemySmartAccountClient.ts
+++ b/packages/alchemy/src/client/isAlchemySmartAccountClient.ts
@@ -1,19 +1,26 @@
 import {
   isSmartAccountClient,
+  type EntryPointVersion,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
 import type { Chain, Client, Transport } from "viem";
 import type { AlchemySmartAccountClient } from "./smartAccountClient";
 
 export const isAlchemySmartAccountClient = <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-): client is AlchemySmartAccountClient<TTransport, TChain, TAccount> => {
+): client is AlchemySmartAccountClient<
+  TEntryPointVersion,
+  TTransport,
+  TChain,
+  TAccount
+> => {
   // TODO: the goal of this check is to make sure that the client supports certain RPC methods
   // we should probably do this by checking the client's transport and configured URL, since alchemy
   // clients have to be RPC clients. this is difficult to do though because the transport might

--- a/packages/alchemy/src/client/modularAccountClient.ts
+++ b/packages/alchemy/src/client/modularAccountClient.ts
@@ -10,7 +10,7 @@ import {
   type MultiOwnerPluginActions,
   type PluginManagerActions,
 } from "@alchemy/aa-accounts";
-import type { SmartAccountSigner } from "@alchemy/aa-core";
+import type { EntryPointVersion, SmartAccountSigner } from "@alchemy/aa-core";
 import {
   custom,
   type Chain,
@@ -28,39 +28,66 @@ import type {
 } from "./smartAccountClient";
 
 export type AlchemyModularAccountClientConfig<
+  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = Omit<
-  CreateMultiOwnerModularAccountParams<HttpTransport, TSigner>,
+  CreateMultiOwnerModularAccountParams<
+    TEntryPointVersion,
+    HttpTransport,
+    TSigner
+  >,
   "transport" | "chain"
 > &
   Omit<
-    AlchemySmartAccountClientConfig<Transport, Chain, LightAccount<TSigner>>,
+    AlchemySmartAccountClientConfig<
+      TEntryPointVersion,
+      Transport,
+      Chain,
+      LightAccount<TEntryPointVersion, TSigner>
+    >,
     "account"
   >;
 
 export function createModularAccountAlchemyClient<
+  TEntryPointVersion extends EntryPointVersion,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  params: AlchemyModularAccountClientConfig<TSigner>
+  params: AlchemyModularAccountClientConfig<TEntryPointVersion, TSigner>
 ): Promise<
   AlchemySmartAccountClient<
+    TEntryPointVersion,
     CustomTransport,
     Chain | undefined,
-    MultiOwnerModularAccount<TSigner>,
-    BaseAlchemyActions<Chain | undefined, MultiOwnerModularAccount<TSigner>> &
-      MultiOwnerPluginActions<MultiOwnerModularAccount<TSigner>> &
-      PluginManagerActions<MultiOwnerModularAccount<TSigner>> &
-      AccountLoupeActions<MultiOwnerModularAccount<TSigner>>
+    MultiOwnerModularAccount<TEntryPointVersion, TSigner>,
+    BaseAlchemyActions<
+      TEntryPointVersion,
+      Chain | undefined,
+      MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+    > &
+      MultiOwnerPluginActions<
+        TEntryPointVersion,
+        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+      > &
+      PluginManagerActions<
+        TEntryPointVersion,
+        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+      > &
+      AccountLoupeActions<
+        TEntryPointVersion,
+        MultiOwnerModularAccount<TEntryPointVersion, TSigner>
+      >
   >
 >;
 
-export async function createModularAccountAlchemyClient(
-  config: AlchemyModularAccountClientConfig
-): Promise<AlchemySmartAccountClient> {
+export async function createModularAccountAlchemyClient<
+  TEntryPointVersion extends EntryPointVersion
+>(
+  config: AlchemyModularAccountClientConfig<TEntryPointVersion>
+): Promise<AlchemySmartAccountClient<TEntryPointVersion>> {
   const { chain, opts, ...connectionConfig } =
     AlchemyProviderConfigSchema.parse(config);
 
-  const client = createAlchemyPublicRpcClient({
+  const client = createAlchemyPublicRpcClient<TEntryPointVersion>({
     chain,
     connectionConfig,
   });

--- a/packages/alchemy/src/client/rpcClient.ts
+++ b/packages/alchemy/src/client/rpcClient.ts
@@ -1,15 +1,21 @@
-import { createBundlerClient, type ConnectionConfig } from "@alchemy/aa-core";
+import {
+  createBundlerClient,
+  type ConnectionConfig,
+  type EntryPointVersion,
+} from "@alchemy/aa-core";
 import { http, type Chain } from "viem";
 import { AlchemyChainSchema } from "../schema.js";
 import type { ClientWithAlchemyMethods } from "./types.js";
 
-export const createAlchemyPublicRpcClient = ({
+export const createAlchemyPublicRpcClient = <
+  TEntryPointVersion extends EntryPointVersion
+>({
   chain: chain_,
   connectionConfig,
 }: {
   connectionConfig: ConnectionConfig;
   chain: Chain;
-}): ClientWithAlchemyMethods => {
+}): ClientWithAlchemyMethods<TEntryPointVersion> => {
   const chain = AlchemyChainSchema.parse(chain_);
 
   const rpcUrl =

--- a/packages/alchemy/src/client/types.ts
+++ b/packages/alchemy/src/client/types.ts
@@ -1,5 +1,6 @@
 import {
   type BundlerClient,
+  type EntryPointVersion,
   type UserOperationRequest,
 } from "@alchemy/aa-core";
 import type { Address, Hex, HttpTransport } from "viem";
@@ -9,14 +10,14 @@ import type {
 } from "../actions/types";
 import type { RequestGasAndPaymasterAndDataOverrides } from "../middleware/gasManager";
 
-export type AlchemyRpcSchema = [
+export type AlchemyRpcSchema<TEntryPointVersion extends EntryPointVersion> = [
   {
     Method: "alchemy_requestPaymasterAndData";
     Parameters: [
       {
         policyId: string;
         entryPoint: Address;
-        userOperation: UserOperationRequest;
+        userOperation: UserOperationRequest<TEntryPointVersion>;
       }
     ];
     ReturnType: { paymasterAndData: Hex };
@@ -27,9 +28,9 @@ export type AlchemyRpcSchema = [
       {
         policyId: string;
         entryPoint: Address;
-        userOperation: UserOperationRequest;
+        userOperation: UserOperationRequest<TEntryPointVersion>;
         dummySignature: Hex;
-        overrides?: RequestGasAndPaymasterAndDataOverrides;
+        overrides?: RequestGasAndPaymasterAndDataOverrides<TEntryPointVersion>;
       }
     ];
     ReturnType: {
@@ -43,7 +44,7 @@ export type AlchemyRpcSchema = [
   },
   {
     Method: "alchemy_simulateUserOperationAssetChanges";
-    Parameters: SimulateUserOperationAssetChangesRequest;
+    Parameters: SimulateUserOperationAssetChangesRequest<TEntryPointVersion>;
     ReturnType: SimulateUserOperationAssetChangesResponse;
   },
   {
@@ -53,8 +54,10 @@ export type AlchemyRpcSchema = [
   }
 ];
 
-export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
-  request: BundlerClient["request"] &
+export type ClientWithAlchemyMethods<
+  TEntryPointVersion extends EntryPointVersion
+> = BundlerClient<TEntryPointVersion, HttpTransport> & {
+  request: BundlerClient<TEntryPointVersion, HttpTransport>["request"] &
     {
       request(args: {
         method: "alchemy_requestPaymasterAndData";
@@ -62,7 +65,7 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
           {
             policyId: string;
             entryPoint: Address;
-            userOperation: UserOperationRequest;
+            userOperation: UserOperationRequest<TEntryPointVersion>;
           }
         ];
       }): Promise<{ paymasterAndData: Hex }>;
@@ -73,9 +76,9 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
           {
             policyId: string;
             entryPoint: Address;
-            userOperation: UserOperationRequest;
+            userOperation: UserOperationRequest<TEntryPointVersion>;
             dummySignature: Hex;
-            overrides?: RequestGasAndPaymasterAndDataOverrides;
+            overrides?: RequestGasAndPaymasterAndDataOverrides<TEntryPointVersion>;
           }
         ];
       }): Promise<{
@@ -89,7 +92,7 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
 
       request(args: {
         method: "alchemy_simulateUserOperationAssetChanges";
-        params: SimulateUserOperationAssetChangesRequest;
+        params: SimulateUserOperationAssetChangesRequest<TEntryPointVersion>;
       }): Promise<SimulateUserOperationAssetChangesResponse>;
 
       request(args: {

--- a/packages/alchemy/src/middleware/feeEstimator.ts
+++ b/packages/alchemy/src/middleware/feeEstimator.ts
@@ -1,8 +1,11 @@
-import type { ClientMiddlewareFn } from "@alchemy/aa-core";
+import type { ClientMiddlewareFn, EntryPointVersion } from "@alchemy/aa-core";
 import { applyUserOpOverrideOrFeeOption } from "@alchemy/aa-core";
 import type { ClientWithAlchemyMethods } from "../client/types";
 
-export const alchemyFeeEstimator: <C extends ClientWithAlchemyMethods>(
+export const alchemyFeeEstimator: <
+  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+  TEntryPointVersion extends EntryPointVersion
+>(
   client: C
 ) => ClientMiddlewareFn =
   (client) =>

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -2,6 +2,8 @@ import type {
   Address,
   ClientMiddlewareConfig,
   ClientMiddlewareFn,
+  EntryPointVersion,
+  UserOperationOverrides,
 } from "@alchemy/aa-core";
 import {
   deepHexlify,
@@ -10,22 +12,33 @@ import {
   isBigNumberish,
   isMultiplier,
   resolveProperties,
-  type Hex,
   type Multiplier,
   type UserOperationFeeOptions,
   type UserOperationRequest,
 } from "@alchemy/aa-core";
-import { fromHex } from "viem";
+import { fromHex, type Hex } from "viem";
 import type { ClientWithAlchemyMethods } from "../client/types";
 import { getAlchemyPaymasterAddress } from "../gas-manager.js";
 import { alchemyFeeEstimator } from "./feeEstimator.js";
 
-export type RequestGasAndPaymasterAndDataOverrides = Partial<{
-  maxFeePerGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  maxPriorityFeePerGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  callGasLimit: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  preVerificationGas: UserOperationRequest["maxFeePerGas"] | Multiplier;
-  verificationGasLimit: UserOperationRequest["maxFeePerGas"] | Multiplier;
+export type RequestGasAndPaymasterAndDataOverrides<
+  TEntryPointVersion extends EntryPointVersion
+> = Partial<{
+  maxFeePerGas:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  maxPriorityFeePerGas:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  callGasLimit:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  preVerificationGas:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
+  verificationGasLimit:
+    | UserOperationRequest<TEntryPointVersion>["maxFeePerGas"]
+    | Multiplier;
 }>;
 
 export interface AlchemyGasManagerConfig {
@@ -42,7 +55,10 @@ export interface AlchemyGasEstimationOptions {
 }
 
 const dummyPaymasterAndData =
-  <C extends ClientWithAlchemyMethods>(
+  <
+    C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+    TEntryPointVersion extends EntryPointVersion
+  >(
     client: C,
     config: AlchemyGasManagerConfig
   ) =>
@@ -56,20 +72,25 @@ const dummyPaymasterAndData =
     return `${paymasterAddress}${dummyData}` as Address;
   };
 
-export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
+export function alchemyGasManagerMiddleware<
+  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+  TEntryPointVersion extends EntryPointVersion
+>(
   client: C,
   config: AlchemyGasManagerConfig
 ): Pick<
   ClientMiddlewareConfig,
   "paymasterAndData" | "feeEstimator" | "gasEstimator"
-> => {
+> {
   const gasEstimationOptions = config.gasEstimationOptions;
   const disableGasEstimation =
     gasEstimationOptions?.disableGasEstimation ?? false;
   const fallbackFeeDataGetter =
-    gasEstimationOptions?.fallbackFeeDataGetter ?? alchemyFeeEstimator(client);
+    gasEstimationOptions?.fallbackFeeDataGetter ??
+    alchemyFeeEstimator<C, TEntryPointVersion>(client);
   const fallbackGasEstimator =
-    gasEstimationOptions?.fallbackGasEstimator ?? defaultGasEstimator(client);
+    gasEstimationOptions?.fallbackGasEstimator ??
+    defaultGasEstimator<TEntryPointVersion, C>(client);
 
   return {
     gasEstimator: disableGasEstimation
@@ -81,7 +102,13 @@ export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
             verificationGasLimit: 0n,
           };
 
-          if (overrides?.paymasterAndData) {
+          const entryPoint = account.getEntryPoint();
+
+          if (
+            entryPoint.version === "0.6.0"
+              ? (overrides as UserOperationOverrides<"0.6.0">)?.paymasterAndData
+              : (overrides as UserOperationOverrides<"0.7.0">)?.paymasterData
+          ) {
             return {
               ...struct,
               ...zeroEstimates,
@@ -106,9 +133,16 @@ export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
           let maxFeePerGas = (await struct.maxFeePerGas) ?? 0n;
           let maxPriorityFeePerGas = (await struct.maxPriorityFeePerGas) ?? 0n;
 
+          const entryPoint = account.getEntryPoint();
           // but if user is bypassing paymaster to fallback to having the account to pay the gas (one-off override),
           // we cannot delegate gas estimation to the bundler because paymaster middleware will not be called
-          if (overrides?.paymasterAndData === "0x") {
+          if (
+            entryPoint.version === "0.6.0"
+              ? (overrides as UserOperationOverrides<"0.6.0">)
+                  ?.paymasterAndData === "0x"
+              : (overrides as UserOperationOverrides<"0.7.0">)
+                  ?.paymasterData === "0x"
+          ) {
             const result = await fallbackFeeDataGetter(struct, {
               overrides,
               feeOptions,
@@ -129,78 +163,86 @@ export const alchemyGasManagerMiddleware = <C extends ClientWithAlchemyMethods>(
       ? requestPaymasterAndData(client, config)
       : requestGasAndPaymasterData(client, config),
   };
-};
+}
 
-const requestGasAndPaymasterData: <C extends ClientWithAlchemyMethods>(
+function requestGasAndPaymasterData<
+  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+  TEntryPointVersion extends EntryPointVersion
+>(
   client: C,
   config: AlchemyGasManagerConfig
-) => ClientMiddlewareConfig["paymasterAndData"] = (client, config) => ({
-  dummyPaymasterAndData: dummyPaymasterAndData(client, config),
-  paymasterAndData: async (struct, { overrides, feeOptions, account }) => {
-    const userOperation: UserOperationRequest = deepHexlify(
-      await resolveProperties(struct)
-    );
+): ClientMiddlewareConfig["paymasterAndData"] {
+  return {
+    dummyPaymasterAndData: dummyPaymasterAndData(client, config),
+    paymasterAndData: async (struct, { overrides, feeOptions, account }) => {
+      const userOperation: UserOperationRequest<TEntryPointVersion> =
+        deepHexlify(await resolveProperties(struct));
 
-    const overrideField = (
-      field: keyof UserOperationFeeOptions
-    ): Hex | Multiplier | undefined => {
-      if (overrides?.[field] != null) {
-        // one-off absolute override
-        if (isBigNumberish(overrides[field])) {
-          return deepHexlify(overrides[field]);
+      const overrideField = (
+        field: keyof UserOperationFeeOptions
+      ): Hex | Multiplier | undefined => {
+        if (overrides?.[field] != null) {
+          // one-off absolute override
+          if (isBigNumberish(overrides[field])) {
+            return deepHexlify(overrides[field]);
+          }
+          // one-off multiplier overrides
+          else {
+            return {
+              multiplier: Number((overrides[field] as Multiplier).multiplier),
+            };
+          }
         }
-        // one-off multiplier overrides
-        else {
+
+        // provider level fee options with multiplier
+        if (isMultiplier(feeOptions?.[field])) {
           return {
-            multiplier: Number((overrides[field] as Multiplier).multiplier),
+            multiplier: Number((feeOptions![field] as Multiplier).multiplier),
           };
         }
-      }
 
-      // provider level fee options with multiplier
-      if (isMultiplier(feeOptions?.[field])) {
-        return {
-          multiplier: Number((feeOptions![field] as Multiplier).multiplier),
-        };
-      }
+        if (fromHex(userOperation[field], "bigint") > 0n) {
+          return userOperation[field];
+        }
 
-      if (fromHex(userOperation[field], "bigint") > 0n) {
-        return userOperation[field];
-      }
+        return undefined;
+      };
 
-      return undefined;
-    };
+      const _overrides: RequestGasAndPaymasterAndDataOverrides<TEntryPointVersion> =
+        filterUndefined({
+          maxFeePerGas: overrideField("maxFeePerGas"),
+          maxPriorityFeePerGas: overrideField("maxPriorityFeePerGas"),
+          callGasLimit: overrideField("callGasLimit"),
+          verificationGasLimit: overrideField("verificationGasLimit"),
+          preVerificationGas: overrideField("preVerificationGas"),
+        });
 
-    const _overrides: RequestGasAndPaymasterAndDataOverrides = filterUndefined({
-      maxFeePerGas: overrideField("maxFeePerGas"),
-      maxPriorityFeePerGas: overrideField("maxPriorityFeePerGas"),
-      callGasLimit: overrideField("callGasLimit"),
-      verificationGasLimit: overrideField("verificationGasLimit"),
-      preVerificationGas: overrideField("preVerificationGas"),
-    });
+      const result = await client.request({
+        method: "alchemy_requestGasAndPaymasterAndData",
+        params: [
+          {
+            policyId: config.policyId,
+            entryPoint: account.getEntryPoint().address,
+            userOperation: userOperation,
+            dummySignature: userOperation.signature,
+            overrides:
+              Object.keys(_overrides).length > 0 ? _overrides : undefined,
+          },
+        ],
+      });
 
-    const result = await client.request({
-      method: "alchemy_requestGasAndPaymasterAndData",
-      params: [
-        {
-          policyId: config.policyId,
-          entryPoint: account.getEntryPoint().address,
-          userOperation: userOperation,
-          dummySignature: userOperation.signature,
-          overrides:
-            Object.keys(_overrides).length > 0 ? _overrides : undefined,
-        },
-      ],
-    });
+      return {
+        ...struct,
+        ...result,
+      };
+    },
+  };
+}
 
-    return {
-      ...struct,
-      ...result,
-    };
-  },
-});
-
-const requestPaymasterAndData: <C extends ClientWithAlchemyMethods>(
+const requestPaymasterAndData: <
+  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+  TEntryPointVersion extends EntryPointVersion
+>(
   client: C,
   config: AlchemyGasManagerConfig
 ) => ClientMiddlewareConfig["paymasterAndData"] = (client, config) => ({

--- a/packages/alchemy/src/middleware/userOperationSimulator.ts
+++ b/packages/alchemy/src/middleware/userOperationSimulator.ts
@@ -2,21 +2,22 @@ import {
   deepHexlify,
   resolveProperties,
   type ClientMiddlewareFn,
+  type EntryPointVersion,
   type UserOperationStruct,
 } from "@alchemy/aa-core";
 import type { ClientWithAlchemyMethods } from "../client/types";
 
-export const alchemyUserOperationSimulator: <
-  C extends ClientWithAlchemyMethods
->(
-  client: C
-) => ClientMiddlewareFn =
-  (client) =>
-  async (struct, { account }) => {
+export function alchemyUserOperationSimulator<
+  C extends ClientWithAlchemyMethods<TEntryPointVersion>,
+  TEntryPointVersion extends EntryPointVersion
+>(client: C): ClientMiddlewareFn {
+  return async (struct, { account }) => {
     const uoSimResult = await client.request({
       method: "alchemy_simulateUserOperationAssetChanges",
       params: [
-        deepHexlify(await resolveProperties(struct)) as UserOperationStruct,
+        deepHexlify(
+          await resolveProperties(struct)
+        ) as UserOperationStruct<TEntryPointVersion>,
         account.getEntryPoint().address,
       ],
     });
@@ -27,3 +28,4 @@ export const alchemyUserOperationSimulator: <
 
     return struct;
   };
+}

--- a/packages/alchemy/src/signer/client/types.ts
+++ b/packages/alchemy/src/signer/client/types.ts
@@ -1,5 +1,6 @@
-import type { Address, Hex } from "@alchemy/aa-core";
+import type { Address } from "@alchemy/aa-core";
 import type { TSignedRequest, getWebAuthnAttestation } from "@turnkey/http";
+import type { Hex } from "viem";
 
 export type CredentialCreationOptionOverrides = {
   publicKey?: Partial<CredentialCreationOptions["publicKey"]>;

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -25,7 +25,7 @@ describe("Utils Tests", () => {
         verificationGasLimit: "0x114c2",
       } as UserOperationRequest<"0.6.0">)
     ).toMatchInlineSnapshot(
-      `"0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"`
+      `"0xbb5560c1a3983429a6cdb244fa532fb4f2cf0de8ba9ccbf257bff93d069c76a3"`
     );
   });
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,36 +1,29 @@
 import { sepolia } from "@alchemy/aa-core";
+import { getEntryPoint } from "../entrypoint/index.js";
 import type { UserOperationRequest } from "../types";
-import {
-  getDefaultEntryPointAddress,
-  getUserOperationHash,
-  stringToIndex,
-} from "../utils/index.js";
+import { stringToIndex } from "../utils/index.js";
 
 describe("Utils Tests", () => {
   const chain = sepolia;
-  const entryPointAddress = getDefaultEntryPointAddress(chain);
+  const entryPoint = getEntryPoint(chain);
 
   it("getUserOperationHash should correctly hash a request", () => {
     expect(
-      getUserOperationHash(
-        {
-          callData:
-            "0xb61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
-          callGasLimit: "0x2f6c",
-          initCode: "0x",
-          maxFeePerGas: "0x59682f1e",
-          maxPriorityFeePerGas: "0x59682f00",
-          nonce: "0x1f",
-          paymasterAndData: "0x",
-          preVerificationGas: "0xa890",
-          sender: "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4",
-          signature:
-            "0xd16f93b584fbfdc03a5ee85914a1f29aa35c44fea5144c387ee1040a3c1678252bf323b7e9c3e9b4dfd91cca841fc522f4d3160a1e803f2bf14eb5fa037aae4a1b",
-          verificationGasLimit: "0x114c2",
-        } as UserOperationRequest,
-        entryPointAddress,
-        80001n
-      )
+      entryPoint.getUserOperationHash({
+        callData:
+          "0xb61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
+        callGasLimit: "0x2f6c",
+        initCode: "0x",
+        maxFeePerGas: "0x59682f1e",
+        maxPriorityFeePerGas: "0x59682f00",
+        nonce: "0x1f",
+        paymasterAndData: "0x",
+        preVerificationGas: "0xa890",
+        sender: "0xb856DBD4fA1A79a46D426f537455e7d3E79ab7c4",
+        signature:
+          "0xd16f93b584fbfdc03a5ee85914a1f29aa35c44fea5144c387ee1040a3c1678252bf323b7e9c3e9b4dfd91cca841fc522f4d3160a1e803f2bf14eb5fa037aae4a1b",
+        verificationGasLimit: "0x114c2",
+      } as UserOperationRequest<"0.6.0">)
     ).toMatchInlineSnapshot(
       `"0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b"`
     );

--- a/packages/core/src/abis/EntryPointAbi_v6.ts
+++ b/packages/core/src/abis/EntryPointAbi_v6.ts
@@ -1,4 +1,4 @@
-export const EntryPointAbi = [
+export const EntryPointAbi_v6 = [
   {
     inputs: [
       {

--- a/packages/core/src/abis/EntryPointAbi_v7.ts
+++ b/packages/core/src/abis/EntryPointAbi_v7.ts
@@ -1,0 +1,658 @@
+// https://etherscan.io/address/0x0000000071727de22e5e9d8baf0edac6f37da032
+export const EntryPointAbi_v7 = [
+  {
+    inputs: [
+      { internalType: "bool", name: "success", type: "bool" },
+      { internalType: "bytes", name: "ret", type: "bytes" },
+    ],
+    name: "DelegateAndRevert",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "opIndex", type: "uint256" },
+      { internalType: "string", name: "reason", type: "string" },
+    ],
+    name: "FailedOp",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "opIndex", type: "uint256" },
+      { internalType: "string", name: "reason", type: "string" },
+      { internalType: "bytes", name: "inner", type: "bytes" },
+    ],
+    name: "FailedOpWithRevert",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "returnData", type: "bytes" }],
+    name: "PostOpReverted",
+    type: "error",
+  },
+  { inputs: [], name: "ReentrancyGuardReentrantCall", type: "error" },
+  {
+    inputs: [{ internalType: "address", name: "sender", type: "address" }],
+    name: "SenderAddressResult",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "address", name: "aggregator", type: "address" }],
+    name: "SignatureValidationFailed",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "factory",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "paymaster",
+        type: "address",
+      },
+    ],
+    name: "AccountDeployed",
+    type: "event",
+  },
+  { anonymous: false, inputs: [], name: "BeforeExecution", type: "event" },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "totalDeposit",
+        type: "uint256",
+      },
+    ],
+    name: "Deposited",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "revertReason",
+        type: "bytes",
+      },
+    ],
+    name: "PostOpRevertReason",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "aggregator",
+        type: "address",
+      },
+    ],
+    name: "SignatureAggregatorChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "totalStaked",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "unstakeDelaySec",
+        type: "uint256",
+      },
+    ],
+    name: "StakeLocked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "withdrawTime",
+        type: "uint256",
+      },
+    ],
+    name: "StakeUnlocked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "StakeWithdrawn",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "paymaster",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+      { indexed: false, internalType: "bool", name: "success", type: "bool" },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "actualGasCost",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "actualGasUsed",
+        type: "uint256",
+      },
+    ],
+    name: "UserOperationEvent",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+    ],
+    name: "UserOperationPrefundTooLow",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "userOpHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "nonce",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "revertReason",
+        type: "bytes",
+      },
+    ],
+    name: "UserOperationRevertReason",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Withdrawn",
+    type: "event",
+  },
+  {
+    inputs: [
+      { internalType: "uint32", name: "unstakeDelaySec", type: "uint32" },
+    ],
+    name: "addStake",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "target", type: "address" },
+      { internalType: "bytes", name: "data", type: "bytes" },
+    ],
+    name: "delegateAndRevert",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "depositTo",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "deposits",
+    outputs: [
+      { internalType: "uint256", name: "deposit", type: "uint256" },
+      { internalType: "bool", name: "staked", type: "bool" },
+      { internalType: "uint112", name: "stake", type: "uint112" },
+      { internalType: "uint32", name: "unstakeDelaySec", type: "uint32" },
+      { internalType: "uint48", name: "withdrawTime", type: "uint48" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "getDepositInfo",
+    outputs: [
+      {
+        components: [
+          { internalType: "uint256", name: "deposit", type: "uint256" },
+          { internalType: "bool", name: "staked", type: "bool" },
+          { internalType: "uint112", name: "stake", type: "uint112" },
+          { internalType: "uint32", name: "unstakeDelaySec", type: "uint32" },
+          { internalType: "uint48", name: "withdrawTime", type: "uint48" },
+        ],
+        internalType: "struct IStakeManager.DepositInfo",
+        name: "info",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "sender", type: "address" },
+      { internalType: "uint192", name: "key", type: "uint192" },
+    ],
+    name: "getNonce",
+    outputs: [{ internalType: "uint256", name: "nonce", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "initCode", type: "bytes" }],
+    name: "getSenderAddress",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "sender", type: "address" },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "bytes", name: "initCode", type: "bytes" },
+          { internalType: "bytes", name: "callData", type: "bytes" },
+          {
+            internalType: "bytes32",
+            name: "accountGasLimits",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "preVerificationGas",
+            type: "uint256",
+          },
+          { internalType: "bytes32", name: "gasFees", type: "bytes32" },
+          { internalType: "bytes", name: "paymasterAndData", type: "bytes" },
+          { internalType: "bytes", name: "signature", type: "bytes" },
+        ],
+        internalType: "struct PackedUserOperation",
+        name: "userOp",
+        type: "tuple",
+      },
+    ],
+    name: "getUserOpHash",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "sender", type: "address" },
+              { internalType: "uint256", name: "nonce", type: "uint256" },
+              { internalType: "bytes", name: "initCode", type: "bytes" },
+              { internalType: "bytes", name: "callData", type: "bytes" },
+              {
+                internalType: "bytes32",
+                name: "accountGasLimits",
+                type: "bytes32",
+              },
+              {
+                internalType: "uint256",
+                name: "preVerificationGas",
+                type: "uint256",
+              },
+              { internalType: "bytes32", name: "gasFees", type: "bytes32" },
+              {
+                internalType: "bytes",
+                name: "paymasterAndData",
+                type: "bytes",
+              },
+              { internalType: "bytes", name: "signature", type: "bytes" },
+            ],
+            internalType: "struct PackedUserOperation[]",
+            name: "userOps",
+            type: "tuple[]",
+          },
+          {
+            internalType: "contract IAggregator",
+            name: "aggregator",
+            type: "address",
+          },
+          { internalType: "bytes", name: "signature", type: "bytes" },
+        ],
+        internalType: "struct IEntryPoint.UserOpsPerAggregator[]",
+        name: "opsPerAggregator",
+        type: "tuple[]",
+      },
+      { internalType: "address payable", name: "beneficiary", type: "address" },
+    ],
+    name: "handleAggregatedOps",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "sender", type: "address" },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "bytes", name: "initCode", type: "bytes" },
+          { internalType: "bytes", name: "callData", type: "bytes" },
+          {
+            internalType: "bytes32",
+            name: "accountGasLimits",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "preVerificationGas",
+            type: "uint256",
+          },
+          { internalType: "bytes32", name: "gasFees", type: "bytes32" },
+          { internalType: "bytes", name: "paymasterAndData", type: "bytes" },
+          { internalType: "bytes", name: "signature", type: "bytes" },
+        ],
+        internalType: "struct PackedUserOperation[]",
+        name: "ops",
+        type: "tuple[]",
+      },
+      { internalType: "address payable", name: "beneficiary", type: "address" },
+    ],
+    name: "handleOps",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint192", name: "key", type: "uint192" }],
+    name: "incrementNonce",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes", name: "callData", type: "bytes" },
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "sender", type: "address" },
+              { internalType: "uint256", name: "nonce", type: "uint256" },
+              {
+                internalType: "uint256",
+                name: "verificationGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "callGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "paymasterVerificationGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "paymasterPostOpGasLimit",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "preVerificationGas",
+                type: "uint256",
+              },
+              { internalType: "address", name: "paymaster", type: "address" },
+              {
+                internalType: "uint256",
+                name: "maxFeePerGas",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "maxPriorityFeePerGas",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct EntryPoint.MemoryUserOp",
+            name: "mUserOp",
+            type: "tuple",
+          },
+          { internalType: "bytes32", name: "userOpHash", type: "bytes32" },
+          { internalType: "uint256", name: "prefund", type: "uint256" },
+          { internalType: "uint256", name: "contextOffset", type: "uint256" },
+          { internalType: "uint256", name: "preOpGas", type: "uint256" },
+        ],
+        internalType: "struct EntryPoint.UserOpInfo",
+        name: "opInfo",
+        type: "tuple",
+      },
+      { internalType: "bytes", name: "context", type: "bytes" },
+    ],
+    name: "innerHandleOp",
+    outputs: [
+      { internalType: "uint256", name: "actualGasCost", type: "uint256" },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "uint192", name: "", type: "uint192" },
+    ],
+    name: "nonceSequenceNumber",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes4", name: "interfaceId", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "unlockStake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address payable",
+        name: "withdrawAddress",
+        type: "address",
+      },
+    ],
+    name: "withdrawStake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address payable",
+        name: "withdrawAddress",
+        type: "address",
+      },
+      { internalType: "uint256", name: "withdrawAmount", type: "uint256" },
+    ],
+    name: "withdrawTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  { stateMutability: "payable", type: "receive" },
+] as const;

--- a/packages/core/src/account/schema.ts
+++ b/packages/core/src/account/schema.ts
@@ -2,18 +2,20 @@ import { Address } from "abitype/zod";
 import { isHex, type Transport } from "viem";
 import z from "zod";
 import { createPublicErc4337ClientSchema } from "../client/schema.js";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import { isSigner } from "../signer/schema.js";
 import type { SmartAccountSigner } from "../signer/types.js";
 import { ChainSchema } from "../utils/index.js";
 
 export const createBaseSmartAccountParamsSchema = <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >() =>
   z.object({
     rpcClient: z.union([
       z.string(),
-      createPublicErc4337ClientSchema<TTransport>(),
+      createPublicErc4337ClientSchema<TEntryPointVersion, TTransport>(),
     ]),
     factoryAddress: Address,
     signer: z.custom<TSigner>(isSigner),
@@ -24,16 +26,20 @@ export const createBaseSmartAccountParamsSchema = <
     ),
     initCode: z
       .string()
-      .refine(isHex, "initCode must be a valid hex.")
+      .refine(
+        (x) => isHex(x, { strict: true }),
+        "initCode must be a valid hex."
+      )
       .optional()
       .describe("Optional override for the account init code."),
   });
 
 export const SimpleSmartAccountParamsSchema = <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >() =>
-  createBaseSmartAccountParamsSchema<TTransport, TSigner>()
+  createBaseSmartAccountParamsSchema<TEntryPointVersion, TTransport, TSigner>()
     .omit({
       rpcClient: true,
     })

--- a/packages/core/src/account/types.ts
+++ b/packages/core/src/account/types.ts
@@ -3,6 +3,7 @@ import type { Hash, Hex, HttpTransport, Transport } from "viem";
 import type { SignTypedDataParameters } from "viem/accounts";
 import type { z } from "zod";
 import type { BundlerClient } from "../client/bundlerClient";
+import type { EntryPointVersion } from "../entrypoint/types";
 import type { SmartAccountSigner } from "../signer/types";
 import type { BatchUserOperationCallData } from "../types";
 import type {
@@ -17,23 +18,38 @@ export type SignTypedDataParams = Omit<SignTypedDataParameters, "privateKey">;
  * @deprecated don't use base smart account anymore, migrate to using toSmartContractAccount instead
  */
 export type BaseSmartAccountParams<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = z.input<
-  ReturnType<typeof createBaseSmartAccountParamsSchema<TTransport, TSigner>>
+  ReturnType<
+    typeof createBaseSmartAccountParamsSchema<
+      TEntryPointVersion,
+      TTransport,
+      TSigner
+    >
+  >
 >;
 
 export type SimpleSmartAccountParams<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > = z.input<
-  ReturnType<typeof SimpleSmartAccountParamsSchema<TTransport, TSigner>>
+  ReturnType<
+    typeof SimpleSmartAccountParamsSchema<
+      TEntryPointVersion,
+      TTransport,
+      TSigner
+    >
+  >
 >;
 
 /**
  * @deprecated use `toSmartContractAccount` instead for creating instances of smart accounts
  */
 export interface ISmartContractAccount<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 > {
@@ -41,8 +57,8 @@ export interface ISmartContractAccount<
    * The RPC provider the account uses to make RPC calls
    */
   readonly rpcProvider:
-    | BundlerClient<TTransport>
-    | BundlerClient<HttpTransport>;
+    | BundlerClient<TEntryPointVersion, TTransport>
+    | BundlerClient<TEntryPointVersion, HttpTransport>;
 
   /**
    * @returns the init code for the account
@@ -135,6 +151,7 @@ export interface ISmartContractAccount<
   getSigner(): TSigner;
 
   /**
+   *
    * @returns the address of the factory contract for the smart account
    */
   getFactoryAddress(): Address;

--- a/packages/core/src/actions/bundler/estimateUserOperationGas.ts
+++ b/packages/core/src/actions/bundler/estimateUserOperationGas.ts
@@ -1,16 +1,23 @@
 import type { Address, Chain, Client, StateOverride, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type {
   UserOperationEstimateGasResponse,
   UserOperationRequest,
 } from "../../types";
 
 export const estimateUserOperationGas = async <
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TEntryPointVersion extends EntryPointVersion,
+  TClient extends Client<
+    Transport,
+    Chain | undefined,
+    any,
+    BundlerRpcSchema<TEntryPointVersion>
+  >
 >(
   client: TClient,
   args: {
-    request: UserOperationRequest;
+    request: UserOperationRequest<TEntryPointVersion>;
     entryPoint: Address;
     stateOverride?: StateOverride;
   }

--- a/packages/core/src/actions/bundler/getSupportedEntrypoints.ts
+++ b/packages/core/src/actions/bundler/getSupportedEntrypoints.ts
@@ -1,8 +1,14 @@
 import type { Address, Chain, Client, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 
 export const getSupportedEntryPoints = async <
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TClient extends Client<
+    Transport,
+    Chain | undefined,
+    any,
+    BundlerRpcSchema<EntryPointVersion>
+  >
 >(
   client: TClient
 ): Promise<Address[]> => {

--- a/packages/core/src/actions/bundler/getUserOperationByHash.ts
+++ b/packages/core/src/actions/bundler/getUserOperationByHash.ts
@@ -1,15 +1,21 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationResponse } from "../../types";
 
 export const getUserOperationByHash = async <
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TClient extends Client<
+    Transport,
+    Chain | undefined,
+    any,
+    BundlerRpcSchema<EntryPointVersion>
+  >
 >(
   client: TClient,
   args: {
     hash: Hex;
   }
-): Promise<UserOperationResponse | null> => {
+): Promise<UserOperationResponse<EntryPointVersion> | null> => {
   return client.request({
     method: "eth_getUserOperationByHash",
     params: [args.hash],

--- a/packages/core/src/actions/bundler/getUserOperationReceipt.ts
+++ b/packages/core/src/actions/bundler/getUserOperationReceipt.ts
@@ -1,9 +1,15 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationReceipt } from "../../types";
 
 export const getUserOperationReceipt = async <
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TClient extends Client<
+    Transport,
+    Chain | undefined,
+    any,
+    BundlerRpcSchema<EntryPointVersion>
+  >
 >(
   client: TClient,
   args: {

--- a/packages/core/src/actions/bundler/sendRawUserOperation.ts
+++ b/packages/core/src/actions/bundler/sendRawUserOperation.ts
@@ -1,13 +1,20 @@
 import type { Address, Chain, Client, Hex, Transport } from "viem";
 import type { BundlerRpcSchema } from "../../client/decorators/bundlerClient";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type { UserOperationRequest } from "../../types";
 
 export const sendRawUserOperation = async <
-  TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>
+  TEntryPointVersion extends EntryPointVersion,
+  TClient extends Client<
+    Transport,
+    Chain | undefined,
+    any,
+    BundlerRpcSchema<TEntryPointVersion>
+  >
 >(
   client: TClient,
   args: {
-    request: UserOperationRequest;
+    request: UserOperationRequest<TEntryPointVersion>;
     entryPoint: Address;
   }
 ): Promise<Hex> => {

--- a/packages/core/src/actions/smartAccount/buildUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperation.ts
@@ -1,23 +1,29 @@
-import type { Chain, Client, Transport } from "viem";
-import type { SmartContractAccount } from "../../account/smartContractAccount.js";
+import type { Address, Chain, Client, Hex, Transport } from "viem";
+import {
+  parseFactoryAddressFromAccountInitCode,
+  type SmartContractAccount,
+} from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
+import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
+import { MismatchingEntryPointError } from "../../errors/entrypoint.js";
 import type { UserOperationStruct } from "../../types.js";
 import type { Deferrable } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import type { SendUserOperationParameters } from "./types";
 
-export const buildUserOperation: <
+export async function buildUserOperation<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendUserOperationParameters<TAccount>
-) => Promise<UserOperationStruct> = async (client, args) => {
+  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
+): Promise<UserOperationStruct<TEntryPointVersion>> {
   const { account = client.account, overrides, uo } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -31,19 +37,49 @@ export const buildUserOperation: <
     );
   }
 
+  const entryPoint = account.getEntryPoint();
+  if (overrides && !entryPoint.isUserOpVersion(overrides)) {
+    throw new MismatchingEntryPointError(entryPoint.version, overrides);
+  }
+
+  const getInitCode = account.getInitCode();
+  const getFactoryAndData = getInitCode.then((initCode) =>
+    initCode === "0x"
+      ? ["0x0" as Address, "0x" as Hex]
+      : parseFactoryAddressFromAccountInitCode(initCode)
+  );
+
+  const callData = Array.isArray(uo)
+    ? account.encodeBatchExecute(uo)
+    : typeof uo === "string"
+    ? uo
+    : account.encodeExecute(uo);
+
+  const signature = account.getDummySignature();
+
+  const nonce = account.getNonce(overrides?.nonceKey);
+
+  const _uo =
+    entryPoint.version === "0.6.0"
+      ? ({
+          initCode: getInitCode,
+          sender: account.address,
+          nonce,
+          callData,
+          signature,
+        } as Deferrable<UserOperationStruct<"0.6.0">>)
+      : ({
+          factory: getFactoryAndData.then(([factory]) => factory),
+          factoryData: getFactoryAndData.then(([, data]) => data),
+          sender: account.address,
+          nonce,
+          callData,
+          signature,
+        } as Deferrable<UserOperationStruct<"0.7.0">>);
+
   return _runMiddlewareStack(client, {
-    uo: {
-      initCode: account.getInitCode(),
-      sender: account.address,
-      nonce: account.getNonce(overrides?.nonceKey),
-      callData: Array.isArray(uo)
-        ? account.encodeBatchExecute(uo)
-        : typeof uo === "string"
-        ? uo
-        : account.encodeExecute(uo),
-      signature: account.getDummySignature(),
-    } as Deferrable<UserOperationStruct>,
+    uo: _uo as Deferrable<UserOperationStruct<TEntryPointVersion>>,
     overrides,
     account,
   });
-};
+}

--- a/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
+++ b/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
@@ -1,21 +1,30 @@
 import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
+import type { EntryPointVersion } from "../../entrypoint/types.js";
+import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import type { UserOperationStruct } from "../../types.js";
 import { buildUserOperation } from "./buildUserOperation.js";
 import type { SendUserOperationParameters } from "./types";
 
 export const checkGasSponsorshipEligibility: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendUserOperationParameters<TAccount>
+  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
 ) => Promise<boolean> = async (client, args) => {
+  const { account = client.account } = args;
+
+  if (!account) {
+    throw new AccountNotFoundError();
+  }
+
   if (!isBaseSmartAccountClient(client)) {
     throw new IncompatibleClientError(
       "BaseSmartAccountClient",
@@ -25,10 +34,16 @@ export const checkGasSponsorshipEligibility: <
   }
 
   return buildUserOperation(client, args)
-    .then(
-      (userOperationStruct: UserOperationStruct) =>
-        userOperationStruct.paymasterAndData !== "0x" &&
-        userOperationStruct.paymasterAndData !== null
+    .then((userOperationStruct) =>
+      account.getEntryPoint().version === "0.6.0"
+        ? (userOperationStruct as UserOperationStruct<"0.6.0">)
+            .paymasterAndData !== "0x" &&
+          (userOperationStruct as UserOperationStruct<"0.6.0">)
+            .paymasterAndData !== null
+        : (userOperationStruct as UserOperationStruct<"0.7.0">)
+            .paymasterData !== "0x" &&
+          (userOperationStruct as UserOperationStruct<"0.7.0">)
+            .paymasterData !== null
     )
     .catch(() => false);
 };

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -2,24 +2,31 @@ import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import type { SendUserOperationResult } from "../../client/types";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
-import type { UserOperationOverrides, UserOperationStruct } from "../../types";
+import { MismatchingEntryPointError } from "../../errors/entrypoint.js";
+import type {
+  UserOperationOverrides,
+  UserOperationRequest,
+  UserOperationStruct,
+} from "../../types";
 import { bigIntMax, bigIntMultiply } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { DropAndReplaceUserOperationParameters } from "./types";
 
-export const dropAndReplaceUserOperation: <
+export async function dropAndReplaceUserOperation<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: DropAndReplaceUserOperationParameters<TAccount>
-) => Promise<SendUserOperationResult> = async (client, args) => {
+  args: DropAndReplaceUserOperationParameters<TEntryPointVersion, TAccount>
+): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account, uoToDrop, overrides } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -32,13 +39,29 @@ export const dropAndReplaceUserOperation: <
     );
   }
 
-  const uoToSubmit = {
-    initCode: uoToDrop.initCode,
-    sender: uoToDrop.sender,
-    nonce: uoToDrop.nonce,
-    callData: uoToDrop.callData,
-    signature: uoToDrop.signature,
-  } as UserOperationStruct;
+  const entryPoint = account.getEntryPoint();
+  if (entryPoint.isUserOpVersion(uoToDrop)) {
+    throw new MismatchingEntryPointError(entryPoint.version, uoToDrop);
+  }
+
+  const uoToSubmit = (
+    entryPoint.version === "0.6.0"
+      ? {
+          initCode: (uoToDrop as UserOperationRequest<"0.6.0">).initCode,
+          sender: (uoToDrop as UserOperationRequest<"0.6.0">).sender,
+          nonce: (uoToDrop as UserOperationRequest<"0.6.0">).nonce,
+          callData: (uoToDrop as UserOperationRequest<"0.6.0">).callData,
+          signature: (uoToDrop as UserOperationRequest<"0.6.0">).signature,
+        }
+      : {
+          factory: (uoToDrop as UserOperationRequest<"0.7.0">).factory,
+          factoryData: (uoToDrop as UserOperationRequest<"0.7.0">).factoryData,
+          sender: (uoToDrop as UserOperationRequest<"0.7.0">).sender,
+          nonce: (uoToDrop as UserOperationRequest<"0.7.0">).nonce,
+          callData: (uoToDrop as UserOperationRequest<"0.7.0">).callData,
+          signature: (uoToDrop as UserOperationRequest<"0.7.0">).signature,
+        }
+  ) as UserOperationStruct<TEntryPointVersion>;
 
   // Run once to get the fee estimates
   // This can happen at any part of the middleware stack, so we want to run it all
@@ -51,17 +74,24 @@ export const dropAndReplaceUserOperation: <
     }
   );
 
-  const _overrides: UserOperationOverrides = {
+  const _overrides = {
     ...overrides,
     maxFeePerGas: bigIntMax(
       BigInt(maxFeePerGas ?? 0n),
-      bigIntMultiply(uoToDrop.maxFeePerGas, 1.1)
+      bigIntMultiply(
+        (uoToDrop as UserOperationRequest<TEntryPointVersion>).maxFeePerGas,
+        1.1
+      )
     ),
     maxPriorityFeePerGas: bigIntMax(
       BigInt(maxPriorityFeePerGas ?? 0n),
-      bigIntMultiply(uoToDrop.maxPriorityFeePerGas, 1.1)
+      bigIntMultiply(
+        (uoToDrop as UserOperationRequest<TEntryPointVersion>)
+          .maxPriorityFeePerGas,
+        1.1
+      )
     ),
-  };
+  } as UserOperationOverrides<TEntryPointVersion>;
 
   const uoToSend = await _runMiddlewareStack(client, {
     uo: uoToSubmit,
@@ -69,5 +99,8 @@ export const dropAndReplaceUserOperation: <
     account,
   });
 
-  return _sendUserOperation(client, { uoStruct: uoToSend, account });
-};
+  return _sendUserOperation(client, {
+    uoStruct: uoToSend,
+    account,
+  });
+}

--- a/packages/core/src/actions/smartAccount/getAddress.ts
+++ b/packages/core/src/actions/smartAccount/getAddress.ts
@@ -4,17 +4,19 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 
 export const getAddress: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: GetAccountParameter<TAccount>
+  args: GetAccountParameter<TEntryPointVersion, TAccount>
 ) => Address = (client, args) => {
   const { account } = args ?? { account: client.account };
   if (!account) {

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -53,13 +53,9 @@ export async function _sendUserOperation<
   }
 
   request.signature = await account.signUserOperationHash(
-    entryPoint.version === "0.6.0"
-      ? entryPoint.getUserOperationHash(
-          request as UserOperationRequest<"0.6.0">
-        )
-      : entryPoint.getUserOperationHash(
-          request as UserOperationRequest<"0.7.0">
-        )
+    entryPoint.getUserOperationHash(
+      request as UserOperationRequest<TEntryPointVersion>
+    )
   );
 
   return {

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -5,22 +5,32 @@ import type {
 } from "../../../account/smartContractAccount";
 import type { BaseSmartAccountClient } from "../../../client/smartAccountClient";
 import type { SendUserOperationResult } from "../../../client/types";
+import type { EntryPointVersion } from "../../../entrypoint/types";
 import { AccountNotFoundError } from "../../../errors/account.js";
 import { ChainNotFoundError } from "../../../errors/client.js";
+import { MismatchingEntryPointError } from "../../../errors/entrypoint.js";
 import { InvalidUserOperationError } from "../../../errors/useroperation.js";
-import type { UserOperationStruct } from "../../../types";
+import type { UserOperationRequest, UserOperationStruct } from "../../../types";
 import { deepHexlify, isValidRequest } from "../../../utils/index.js";
 
-export const _sendUserOperation: <
+export async function _sendUserOperation<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
-  client: BaseSmartAccountClient<TTransport, TChain, TAccount>,
-  args: { uoStruct: UserOperationStruct } & GetAccountParameter<TAccount>
-) => Promise<SendUserOperationResult> = async (client, args) => {
+  client: BaseSmartAccountClient<
+    TEntryPointVersion,
+    TTransport,
+    TChain,
+    TAccount
+  >,
+  args: {
+    uoStruct: UserOperationStruct<TEntryPointVersion>;
+  } & GetAccountParameter<TEntryPointVersion, TAccount>
+): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account } = args;
   if (!account) {
     throw new AccountNotFoundError();
@@ -30,20 +40,30 @@ export const _sendUserOperation: <
     throw new ChainNotFoundError();
   }
 
-  const request = deepHexlify(args.uoStruct);
+  const entryPoint = account.getEntryPoint();
+  if (entryPoint.isUserOpVersion(args.uoStruct)) {
+    throw new MismatchingEntryPointError(entryPoint.version, args.uoStruct);
+  }
+
+  const request = deepHexlify(
+    args.uoStruct
+  ) as UserOperationRequest<TEntryPointVersion>;
   if (!isValidRequest(request)) {
     throw new InvalidUserOperationError(args.uoStruct);
   }
 
   request.signature = await account.signUserOperationHash(
-    account.getEntryPoint().getUserOperationHash(request)
+    entryPoint.version === "0.6.0"
+      ? entryPoint.getUserOperationHash(
+          request as UserOperationRequest<"0.6.0">
+        )
+      : entryPoint.getUserOperationHash(
+          request as UserOperationRequest<"0.7.0">
+        )
   );
 
   return {
-    hash: await client.sendRawUserOperation(
-      request,
-      account.getEntryPoint().address
-    ),
+    hash: await client.sendRawUserOperation(request, entryPoint.address),
     request,
   };
-};
+}

--- a/packages/core/src/actions/smartAccount/sendTransaction.ts
+++ b/packages/core/src/actions/smartAccount/sendTransaction.ts
@@ -7,25 +7,30 @@ import type {
 } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
+import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { TransactionMissingToParamError } from "../../errors/transaction.js";
-import type { UserOperationOverrides } from "../../types.js";
+import type {
+  UserOperationOverrides,
+  UserOperationStruct,
+} from "../../types.js";
 import { buildUserOperationFromTx } from "./buildUserOperationFromTx.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
-export const sendTransaction: <
+export async function sendTransaction<
+  TEntryPointVersion extends EntryPointVersion,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined
 >(
   client: Client<Transport, TChain, TAccount>,
   args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
-  overrides?: UserOperationOverrides
-) => Promise<Hex> = async (client, args, overrides) => {
+  overrides?: UserOperationOverrides<TEntryPointVersion>
+): Promise<Hex> {
   const { account = client.account } = args;
   if (!account || typeof account === "string") {
     throw new AccountNotFoundError();
@@ -45,9 +50,9 @@ export const sendTransaction: <
 
   const uoStruct = await buildUserOperationFromTx(client, args, overrides);
   const { hash } = await _sendUserOperation(client, {
-    account: account as SmartContractAccount,
-    uoStruct,
+    account: account as SmartContractAccount<TEntryPointVersion>,
+    uoStruct: uoStruct as UserOperationStruct<TEntryPointVersion>,
   });
 
   return waitForUserOperationTransaction(client, { hash });
-};
+}

--- a/packages/core/src/actions/smartAccount/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/sendUserOperation.ts
@@ -2,6 +2,7 @@ import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import type { SendUserOperationResult } from "../../client/types.js";
+import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { buildUserOperation } from "./buildUserOperation.js";
@@ -9,15 +10,19 @@ import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { SendUserOperationParameters } from "./types.js";
 
 export const sendUserOperation: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendUserOperationParameters<TAccount>
-) => Promise<SendUserOperationResult> = async (client, args) => {
+  args: SendUserOperationParameters<TEntryPointVersion, TAccount>
+) => Promise<SendUserOperationResult<TEntryPointVersion>> = async (
+  client,
+  args
+) => {
   const { account = client.account } = args;
 
   if (!account) {
@@ -32,6 +37,11 @@ export const sendUserOperation: <
     );
   }
 
+  const entryPoint = account.getEntryPoint();
+
   const uoStruct = await buildUserOperation(client, args);
-  return _sendUserOperation(client, { account, uoStruct });
+  return _sendUserOperation<typeof entryPoint.version>(client, {
+    account,
+    uoStruct,
+  });
 };

--- a/packages/core/src/actions/smartAccount/signMessage.ts
+++ b/packages/core/src/actions/smartAccount/signMessage.ts
@@ -3,27 +3,32 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 
 export type SignMessageParameters<
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
-> = { message: SignableMessage } & GetAccountParameter<TAccount>;
+> = { message: SignableMessage } & GetAccountParameter<
+  TEntryPointVersion,
+  TAccount
+>;
 
 export const signMessage: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignMessageParameters<TAccount>
+  args: SignMessageParameters<TEntryPointVersion, TAccount>
 ) => Promise<Hex> = async (client, { account = client.account, message }) => {
   if (!account) {
     throw new AccountNotFoundError();
   }
-
   return account.signMessage({ message });
 };

--- a/packages/core/src/actions/smartAccount/signMessageWith6492.ts
+++ b/packages/core/src/actions/smartAccount/signMessageWith6492.ts
@@ -1,17 +1,19 @@
 import type { Chain, Client, Hex, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import type { SignMessageParameters } from "./signMessage";
 
 export const signMessageWith6492: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignMessageParameters<TAccount>
+  args: SignMessageParameters<TEntryPointVersion, TAccount>
 ) => Promise<Hex> = async (client, { account = client.account, message }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/signTypedData.ts
+++ b/packages/core/src/actions/smartAccount/signTypedData.ts
@@ -10,29 +10,37 @@ import type {
   GetAccountParameter,
   SmartContractAccount,
 } from "../../account/smartContractAccount";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 
 export type SignTypedDataParameters<
+  TEntryPointVersion extends EntryPointVersion,
   TTypedData extends TypedData | { [key: string]: unknown },
   TPrimaryType extends string = string,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = {
   typedData: TypedDataDefinition<TTypedData, TPrimaryType>;
-} & GetAccountParameter<TAccount>;
+} & GetAccountParameter<TEntryPointVersion, TAccount>;
 
 export const signTypedData: <
+  TEntryPointVersion extends EntryPointVersion,
   const TTypedData extends TypedData | { [key: string]: unknown },
   TPrimaryType extends string = string,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>
+  args: SignTypedDataParameters<
+    TEntryPointVersion,
+    TTypedData,
+    TPrimaryType,
+    TAccount
+  >
 ) => Promise<Hex> = async (client, { account = client.account, typedData }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/signTypedDataWith6492.ts
+++ b/packages/core/src/actions/smartAccount/signTypedDataWith6492.ts
@@ -1,19 +1,26 @@
 import type { Chain, Client, Hex, Transport, TypedData } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import { AccountNotFoundError } from "../../errors/account.js";
 import type { SignTypedDataParameters } from "./signTypedData";
 
 export const signTypedDataWith6492: <
+  const TEntryPointVersion extends EntryPointVersion,
   const TTypedData extends TypedData | { [key: string]: unknown },
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined,
   TPrimaryType extends string = string
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>
+  args: SignTypedDataParameters<
+    TEntryPointVersion,
+    TTypedData,
+    TPrimaryType,
+    TAccount
+  >
 ) => Promise<Hex> = async (client, { account = client.account, typedData }) => {
   if (!account) {
     throw new AccountNotFoundError();

--- a/packages/core/src/actions/smartAccount/signUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/signUserOperation.ts
@@ -48,13 +48,9 @@ export async function signUserOperation<
 
   const entryPoint = account.getEntryPoint();
   request.signature = await account.signUserOperationHash(
-    entryPoint.version === "0.6.0"
-      ? entryPoint.getUserOperationHash(
-          request as UserOperationRequest<"0.6.0">
-        )
-      : entryPoint.getUserOperationHash(
-          request as UserOperationRequest<"0.7.0">
-        )
+    entryPoint.getUserOperationHash(
+      request as UserOperationRequest<TEntryPointVersion>
+    )
   );
 
   return request as UserOperationRequest<TEntryPointVersion>;

--- a/packages/core/src/actions/smartAccount/types.ts
+++ b/packages/core/src/actions/smartAccount/types.ts
@@ -4,57 +4,73 @@ import type {
   SmartContractAccount,
 } from "../../account/smartContractAccount";
 import type { UpgradeToData } from "../../client/types";
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type {
   BatchUserOperationCallData,
   UserOperationCallData,
-  UserOperationOverrides,
+  UserOperationOverridesParameter,
   UserOperationRequest,
   UserOperationStruct,
 } from "../../types";
 
 //#region UpgradeAccountParams
 export type UpgradeAccountParams<
-  TAccount extends SmartContractAccount | undefined
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
+    | undefined
 > = {
   upgradeTo: UpgradeToData;
-  overrides?: UserOperationOverrides;
   waitForTx?: boolean;
-} & GetAccountParameter<TAccount>;
+} & GetAccountParameter<TEntryPointVersion, TAccount> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion UpgradeAccountParams
 
 //#region SendUserOperationParameters
 export type SendUserOperationParameters<
-  TAccount extends SmartContractAccount | undefined
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
+    | undefined
 > = {
   uo: UserOperationCallData | BatchUserOperationCallData;
-  overrides?: UserOperationOverrides;
-} & GetAccountParameter<TAccount>;
+} & GetAccountParameter<TEntryPointVersion, TAccount> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendUserOperationParameters
 
 //#region SignUserOperationParameters
 export type SignUserOperationParameters<
-  TAccount extends SmartContractAccount | undefined
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
+    | undefined
 > = {
-  uoStruct: UserOperationStruct;
-} & GetAccountParameter<TAccount>;
+  uoStruct: UserOperationStruct<TEntryPointVersion>;
+} & GetAccountParameter<TEntryPointVersion, TAccount>;
 //#endregion SignUserOperationParameters
 
 //#region SendTransactionsParameters
 export type SendTransactionsParameters<
-  TAccount extends SmartContractAccount | undefined
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
+    | undefined
 > = {
   requests: RpcTransactionRequest[];
-  overrides?: UserOperationOverrides;
-} & GetAccountParameter<TAccount>;
+} & GetAccountParameter<TEntryPointVersion, TAccount> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendTransactionsParameters
 
 //#region DropAndReplaceUserOperationParameters
 export type DropAndReplaceUserOperationParameters<
-  TAccount extends SmartContractAccount | undefined
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
+    | undefined
 > = {
-  uoToDrop: UserOperationRequest;
-  overrides?: UserOperationOverrides;
-} & GetAccountParameter<TAccount>;
+  uoToDrop: UserOperationRequest<TEntryPointVersion>;
+} & GetAccountParameter<TEntryPointVersion, TAccount> &
+  UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion DropAndReplaceUserOperationParameters
 
 //#region WaitForUserOperationTxParameters
@@ -64,9 +80,10 @@ export type WaitForUserOperationTxParameters = {
 //#endregion WaitForUserOperationTxParameters
 
 //#region BuildUserOperationFromTransactionsResult
-export type BuildUserOperationFromTransactionsResult = {
-  uoStruct: UserOperationStruct;
+export type BuildUserOperationFromTransactionsResult<
+  TEntryPointVersion extends EntryPointVersion
+> = {
+  uoStruct: UserOperationStruct<TEntryPointVersion>;
   batch: BatchUserOperationCallData;
-  overrides: UserOperationOverrides;
-};
+} & UserOperationOverridesParameter<TEntryPointVersion, true>;
 //#endregion BuildUserOperationFromTransactionsResult

--- a/packages/core/src/actions/smartAccount/upgradeAccount.ts
+++ b/packages/core/src/actions/smartAccount/upgradeAccount.ts
@@ -1,6 +1,7 @@
 import type { Chain, Client, Hash, Transport } from "viem";
 import type { SmartContractAccount } from "../../account/smartContractAccount.js";
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
+import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { sendUserOperation } from "./sendUserOperation.js";
@@ -8,14 +9,15 @@ import type { UpgradeAccountParams } from "./types.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export const upgradeAccount: <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: UpgradeAccountParams<TAccount>
+  args: UpgradeAccountParams<TEntryPointVersion, TAccount>
 ) => Promise<Hash> = async (client, args) => {
   const { account = client.account, upgradeTo, overrides, waitForTx } = args;
 

--- a/packages/core/src/client/isSmartAccountClient.ts
+++ b/packages/core/src/client/isSmartAccountClient.ts
@@ -1,5 +1,6 @@
 import type { Chain, Client, Transport } from "viem";
 import type { SmartContractAccount } from "../account/smartContractAccount";
+import type { EntryPointVersion } from "../entrypoint/types";
 import { smartAccountClientMethodKeys } from "./decorators/smartAccountClient.js";
 import type {
   BaseSmartAccountClient,
@@ -15,14 +16,20 @@ import type {
  * @returns
  */
 export function isSmartAccountClient<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-): client is SmartAccountClient<TTransport, TChain, TAccount> {
+): client is SmartAccountClient<
+  TEntryPointVersion,
+  TTransport,
+  TChain,
+  TAccount
+> {
   for (const key of smartAccountClientMethodKeys) {
     if (!(key in client)) {
       return false;
@@ -41,13 +48,19 @@ export function isSmartAccountClient<
  * @returns
  */
 export function isBaseSmartAccountClient<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>
-): client is BaseSmartAccountClient<TTransport, TChain, TAccount> {
+): client is BaseSmartAccountClient<
+  TEntryPointVersion,
+  TTransport,
+  TChain,
+  TAccount
+> {
   return client && "middleware" in client;
 }

--- a/packages/core/src/client/schema.ts
+++ b/packages/core/src/client/schema.ts
@@ -1,13 +1,15 @@
 import type { Transport } from "viem";
 import { z } from "zod";
 
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import { BigNumberishRangeSchema, MultiplierSchema } from "../utils/index.js";
 import type { BundlerClient } from "./bundlerClient.js";
 
 export const createPublicErc4337ClientSchema = <
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport
 >() =>
-  z.custom<BundlerClient<TTransport>>((provider) => {
+  z.custom<BundlerClient<TEntryPointVersion, TTransport>>((provider) => {
     return (
       provider != null &&
       typeof provider === "object" &&

--- a/packages/core/src/client/smartAccountClient.ts
+++ b/packages/core/src/client/smartAccountClient.ts
@@ -108,12 +108,14 @@ export type BaseSmartAccountClient<
 >;
 
 export function createSmartAccountClient<
-  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends SmartContractAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined
+  TChain extends Chain | undefined = Chain | undefined
 >(
   config: SmartAccountClientConfig<
     TEntryPointVersion,
@@ -127,11 +129,10 @@ export function createSmartAccountClient<
     name = "account provider",
     transport,
     type = "SmartAccountClient",
-    account,
     ...params
   } = config;
 
-  const entryPoint = account?.getEntryPoint();
+  const entryPoint = params.account?.getEntryPoint();
   const _createBundlerClient =
     entryPoint?.version === "0.6.0"
       ? createBundlerClient<"0.6.0", Transport>
@@ -232,12 +233,14 @@ export function createSmartAccountClient<
 }
 
 export function createSmartAccountClientFromExisting<
-  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends SmartContractAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
-    | SmartContractAccount<TEntryPointVersion>
-    | undefined,
   TClient extends BundlerClient<TEntryPointVersion, TTransport> = BundlerClient<
     TEntryPointVersion,
     TTransport
@@ -262,10 +265,10 @@ export function createSmartAccountClientFromExisting<
   TRpcSchema
 > {
   return createSmartAccountClient<
+    TAccount,
     TEntryPointVersion,
     CustomTransport,
-    TChain,
-    TAccount
+    TChain
   >({
     ...config,
     chain: config.client.chain,

--- a/packages/core/src/client/types.ts
+++ b/packages/core/src/client/types.ts
@@ -1,6 +1,7 @@
 import type { Address } from "abitype";
 import type { Hash, Hex } from "viem";
 import type { z } from "zod";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import type {
   ClientMiddleware,
   ClientMiddlewareFn,
@@ -15,9 +16,11 @@ export type ConnectorData = {
 export type ConnectionConfig = z.input<typeof ConnectionConfigSchema>;
 
 //#region SendUserOperationResult
-export type SendUserOperationResult = {
+export type SendUserOperationResult<
+  TEntryPointVersion extends EntryPointVersion
+> = {
   hash: Hash;
-  request: UserOperationRequest;
+  request: UserOperationRequest<TEntryPointVersion>;
 };
 //#endregion SendUserOperationResult
 

--- a/packages/core/src/entrypoint/0.6.ts
+++ b/packages/core/src/entrypoint/0.6.ts
@@ -1,28 +1,115 @@
-import type { Address, Chain } from "viem";
-import type { UserOperationRequest } from "../types";
 import {
-  getDefaultEntryPointAddress,
-  getUserOperationHash,
-  packUo,
-} from "../utils/index.js";
-import type { EntryPointDef } from "./types";
+  encodeAbiParameters,
+  hexToBigInt,
+  keccak256,
+  type Address,
+  type Chain,
+  type Hash,
+  type Hex,
+} from "viem";
+import {
+  arbitrum,
+  arbitrumGoerli,
+  arbitrumSepolia,
+  base,
+  baseGoerli,
+  baseSepolia,
+  goerli,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  polygonMumbai,
+  sepolia,
+} from "viem/chains";
+import { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6.js";
+import type {
+  UserOperationLike,
+  UserOperationRequest,
+  UserOperationStruct,
+} from "../types.js";
+import type { SupportedEntryPoint } from "./types.js";
 
-export const getVersion060EntryPoint: (
-  chain: Chain,
-  address?: Address
-) => EntryPointDef<UserOperationRequest> = (
-  chain: Chain,
-  address = getDefaultEntryPointAddress(chain)
-) => {
-  return {
-    version: "0.6.0",
-    address,
-    chain,
-    packUserOperation: (userOperation: UserOperationRequest) => {
-      return packUo(userOperation);
-    },
-    getUserOperationHash: (userOperation: UserOperationRequest) => {
-      return getUserOperationHash(userOperation, address, chain.id);
-    },
-  } satisfies EntryPointDef<UserOperationRequest>;
+const packUserOperation = (request: UserOperationRequest<"0.6.0">): Hex => {
+  const hashedInitCode = keccak256(request.initCode);
+  const hashedCallData = keccak256(request.callData);
+  const hashedPaymasterAndData = keccak256(request.paymasterAndData);
+
+  return encodeAbiParameters(
+    [
+      { type: "address" },
+      { type: "uint256" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "bytes32" },
+    ],
+    [
+      request.sender as Address,
+      hexToBigInt(request.nonce),
+      hashedInitCode,
+      hashedCallData,
+      hexToBigInt(request.callGasLimit),
+      hexToBigInt(request.verificationGasLimit),
+      hexToBigInt(request.preVerificationGas),
+      hexToBigInt(request.maxFeePerGas),
+      hexToBigInt(request.maxPriorityFeePerGas),
+      hashedPaymasterAndData,
+    ]
+  );
 };
+
+export default {
+  version: "0.6.0",
+
+  address: {
+    [mainnet.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [sepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [goerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [polygon.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [polygonMumbai.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [polygonAmoy.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [optimism.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [optimismGoerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [optimismSepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [arbitrum.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [arbitrumGoerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [arbitrumSepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [base.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [baseGoerli.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    [baseSepolia.id]: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+  },
+
+  abi: EntryPointAbi_v6,
+
+  getUserOperationHash: (
+    request: UserOperationRequest<"0.6.0">,
+    entryPointAddress: Address,
+    chainId: number
+  ): Hash => {
+    const encoded = encodeAbiParameters(
+      [{ type: "bytes32" }, { type: "address" }, { type: "uint256" }],
+      [
+        keccak256(packUserOperation(request)),
+        entryPointAddress,
+        BigInt(chainId),
+      ]
+    );
+
+    return keccak256(encoded);
+  },
+
+  packUserOperation,
+
+  isUserOpVersion: (
+    userOperation: UserOperationLike
+  ): userOperation is UserOperationStruct<"0.6.0"> &
+    UserOperationRequest<"0.6.0"> =>
+    "paymasterAndData" in userOperation && "initCode" in userOperation,
+} as SupportedEntryPoint<"0.6.0", Chain, typeof EntryPointAbi_v6>;

--- a/packages/core/src/entrypoint/0.7.ts
+++ b/packages/core/src/entrypoint/0.7.ts
@@ -1,0 +1,180 @@
+import {
+  concat,
+  encodeAbiParameters,
+  hexToBigInt,
+  isAddress,
+  keccak256,
+  pad,
+  type Address,
+  type Chain,
+  type Hash,
+  type Hex,
+} from "viem";
+import {
+  arbitrum,
+  arbitrumGoerli,
+  arbitrumSepolia,
+  base,
+  baseGoerli,
+  baseSepolia,
+  goerli,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  polygonMumbai,
+  sepolia,
+} from "viem/chains";
+import { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7.js";
+import type {
+  UserOperationLike,
+  UserOperationRequest,
+  UserOperationRequest_v7,
+  UserOperationStruct,
+} from "../types.js";
+import type { SupportedEntryPoint } from "./types.js";
+
+const packUserOperation = (request: UserOperationRequest<"0.7.0">): Hex => {
+  const initCode = concat([request.factory, request.factoryData]);
+  const accountGasLimits = packAccountGasLimits(
+    (({ verificationGasLimit, callGasLimit }) => ({
+      verificationGasLimit,
+      callGasLimit,
+    }))(request)
+  );
+
+  const gasFees = packAccountGasLimits(
+    (({ maxPriorityFeePerGas, maxFeePerGas }) => ({
+      maxPriorityFeePerGas,
+      maxFeePerGas,
+    }))(request)
+  );
+
+  const paymasterAndData = isAddress(request.paymaster)
+    ? packPaymasterData(
+        (({
+          paymaster,
+          paymasterVerificationGasLimit,
+          paymasterPostOpGasLimit,
+          paymasterData,
+        }) => ({
+          paymaster,
+          paymasterVerificationGasLimit,
+          paymasterPostOpGasLimit,
+          paymasterData,
+        }))(request)
+      )
+    : "0x";
+
+  return encodeAbiParameters(
+    [
+      { type: "address" },
+      { type: "uint256" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+      { type: "uint256" },
+      { type: "bytes32" },
+      { type: "bytes32" },
+    ],
+    [
+      request.sender as Address,
+      hexToBigInt(request.nonce),
+      keccak256(initCode),
+      keccak256(request.callData),
+      accountGasLimits,
+      hexToBigInt(request.preVerificationGas),
+      gasFees,
+      paymasterAndData,
+    ]
+  );
+};
+
+export default {
+  version: "0.7.0",
+
+  address: {
+    [mainnet.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [sepolia.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [goerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [polygon.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [polygonMumbai.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [polygonAmoy.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [optimism.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [optimismGoerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [optimismSepolia.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [arbitrum.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [arbitrumGoerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [arbitrumSepolia.id]: "0x000000071727De22E5E9d8BAf0edAc6f37da032",
+    [base.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [baseGoerli.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+    [baseSepolia.id]: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+  },
+
+  abi: EntryPointAbi_v7,
+
+  getUserOperationHash: (
+    request: UserOperationRequest<"0.7.0">,
+    entryPointAddress: Address,
+    chainId: number
+  ): Hash => {
+    const encoded = encodeAbiParameters(
+      [{ type: "bytes32" }, { type: "address" }, { type: "uint256" }],
+      [
+        keccak256(packUserOperation(request)),
+        entryPointAddress,
+        BigInt(chainId),
+      ]
+    );
+
+    return keccak256(encoded);
+  },
+
+  packUserOperation,
+
+  isUserOpVersion: (
+    userOperation: UserOperationLike
+  ): userOperation is UserOperationStruct<"0.7.0"> &
+    UserOperationRequest<"0.7.0"> =>
+    "paymaster" in userOperation && "factory" in userOperation,
+} as SupportedEntryPoint<"0.7.0", Chain, typeof EntryPointAbi_v7>;
+
+export function packAccountGasLimits(
+  data:
+    | Pick<UserOperationRequest_v7, "verificationGasLimit" | "callGasLimit">
+    | Pick<UserOperationRequest_v7, "maxPriorityFeePerGas" | "maxFeePerGas">
+): Hex {
+  return concat(Object.values(data).map((v) => pad(v, { size: 16 })));
+}
+
+export function packPaymasterData({
+  paymaster,
+  paymasterVerificationGasLimit,
+  paymasterPostOpGasLimit,
+  paymasterData,
+}: Pick<
+  UserOperationRequest_v7,
+  | "paymaster"
+  | "paymasterVerificationGasLimit"
+  | "paymasterPostOpGasLimit"
+  | "paymasterData"
+>): Hex {
+  return concat([
+    paymaster,
+    pad(paymasterVerificationGasLimit, { size: 16 }),
+    pad(paymasterPostOpGasLimit, { size: 16 }),
+    paymasterData,
+  ]);
+}
+
+export function unpackAccountGasLimits(accountGasLimits: string): {
+  verificationGasLimit: number;
+  callGasLimit: number;
+} {
+  return {
+    verificationGasLimit: parseInt(accountGasLimits.slice(2, 34), 16),
+    callGasLimit: parseInt(accountGasLimits.slice(34), 16),
+  };
+}

--- a/packages/core/src/entrypoint/index.ts
+++ b/packages/core/src/entrypoint/index.ts
@@ -1,0 +1,189 @@
+import { type Chain } from "viem";
+import { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6.js";
+import { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7.js";
+import {
+  EntryPointNotFoundError,
+  MismatchingEntryPointError,
+} from "../errors/entrypoint.js";
+import type { UserOperationLike } from "../types.js";
+import EntryPoint_v6 from "./0.6.js";
+import EntryPoint_v7 from "./0.7.js";
+import type {
+  DefaultEntryPointVersion,
+  EntryPointDef,
+  EntryPointDefRegistry,
+  EntryPointRegistry,
+  EntryPointVersion,
+  GetEntryPointOptions,
+  SupportedEntryPoint,
+} from "./types.js";
+
+export const defaultEntryPointVersion: DefaultEntryPointVersion = "0.6.0";
+
+export const entryPointRegistry: EntryPointRegistry = {
+  "0.6.0": EntryPoint_v6,
+  "0.7.0": EntryPoint_v7,
+};
+
+export const coerceEntryPointVersion = <
+  TEntryPointVersion extends EntryPointVersion
+>(
+  entryPoint: EntryPointRegistry[EntryPointVersion],
+  userOperation: UserOperationLike,
+  throwable?: boolean
+): UserOperationLike<TEntryPointVersion> | undefined => {
+  if (entryPoint.isUserOpVersion(userOperation)) {
+    return userOperation as UserOperationLike<TEntryPointVersion>;
+  }
+  if (!throwable) {
+    return undefined;
+  }
+  throw new MismatchingEntryPointError(entryPoint.version, userOperation);
+};
+
+export function getEntryPoint<
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion,
+  TChain extends Chain = Chain
+>(
+  chain: TChain,
+  options: GetEntryPointOptions<TEntryPointVersion>
+): EntryPointDefRegistry<TChain>[TEntryPointVersion];
+
+export function getEntryPoint<
+  TEntryPointVersion extends DefaultEntryPointVersion = DefaultEntryPointVersion,
+  TChain extends Chain = Chain
+>(
+  chain: TChain,
+  options?: GetEntryPointOptions<TEntryPointVersion>
+): EntryPointDefRegistry<TChain>[TEntryPointVersion];
+
+export function getEntryPoint<TChain extends Chain = Chain>(
+  chain: TChain,
+  options?: GetEntryPointOptions<DefaultEntryPointVersion>
+): EntryPointDefRegistry<TChain>[DefaultEntryPointVersion];
+
+export function getEntryPoint<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain
+>(
+  chain: TChain,
+  options: GetEntryPointOptions<TEntryPointVersion>
+): EntryPointDefRegistry<TChain>[EntryPointVersion] {
+  const { version, addressOverride } = options ?? {
+    version: defaultEntryPointVersion,
+  };
+  const entryPoint = entryPointRegistry[version ?? defaultEntryPointVersion];
+  const address = addressOverride || entryPoint.address[chain.id];
+  if (!address) {
+    throw new EntryPointNotFoundError(chain, version);
+  }
+
+  if (version === "0.6.0") {
+    const v6 = entryPoint as SupportedEntryPoint<
+      "0.6.0",
+      TChain,
+      typeof EntryPointAbi_v6
+    >;
+    return {
+      version: v6.version,
+      address,
+      chain,
+      abi: v6.abi,
+      getUserOperationHash: (r) =>
+        v6.getUserOperationHash(r, address, chain.id),
+      packUserOperation: v6.packUserOperation,
+      isUserOpVersion: v6.isUserOpVersion,
+      coerce: (userOperation, throwable) =>
+        coerceEntryPointVersion(v6, userOperation, throwable),
+    } as EntryPointDef<"0.6.0", TChain, typeof EntryPointAbi_v6>;
+  } else if (version === "0.7.0") {
+    const v7 = entryPoint as SupportedEntryPoint<
+      "0.7.0",
+      TChain,
+      typeof EntryPointAbi_v7
+    >;
+    return {
+      version: v7.version,
+      address,
+      chain,
+      abi: v7.abi,
+      getUserOperationHash: (r) =>
+        v7.getUserOperationHash(r, address, chain.id),
+      packUserOperation: v7.packUserOperation,
+      isUserOpVersion: v7.isUserOpVersion,
+      coerce: (userOperation, throwable) =>
+        coerceEntryPointVersion(v7, userOperation, throwable),
+    } as EntryPointDef<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+  }
+
+  throw new EntryPointNotFoundError(chain, version);
+}
+
+// // =================================================================================
+// // TODO: Add tests for the following cases
+
+// const chain: Chain = mainnet;
+
+// // 1. left and right hand side version type should match, as well as the param
+
+// // === Error ===
+// const ep1_a: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   version: "0.7.0",
+// }); // error
+// const ep1_b: EntryPointDef<"0.7.0"> = getEntryPoint(chain); // error
+// const ep1_c: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   version: "0.7.0",
+// }); // error
+// const ep1_d: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain, {
+//   version: "0.7.0",
+// }); // error
+
+// // === Valid ===
+// const ep1a: EntryPointDef<"0.6.0"> = getEntryPoint(chain);
+// const ep1b: EntryPointDef<"0.6.0"> = getEntryPoint(chain, { version: "0.6.0" });
+// const ep1c: EntryPointDef<"0.7.0"> = getEntryPoint(chain, { version: "0.7.0" });
+// const ep1d: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+// const ep1e: EntryPointDef<"0.6.0"> = getEntryPoint(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+//   version: "0.6.0",
+// });
+// const ep1f: EntryPointDef<"0.7.0"> = getEntryPoint(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+//   version: "0.7.0",
+// });
+
+// // 2. If non-default type is specified, version option param of the type is required
+
+// // === Error ===
+// const ep2_a: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain); // error
+// const ep2_b: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+
+// // === Valid ===
+// const ep2a: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain, {
+//   version: "0.7.0",
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+// const ep2b: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain, {
+//   version: "0.6.0",
+// });
+// const ep2c: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain);
+// const ep2d: EntryPointDef<"0.6.0"> = getEntryPoint<"0.6.0">(chain, {
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+// const ep2e: EntryPointDef<"0.7.0"> = getEntryPoint<"0.7.0">(chain, {
+//   version: "0.7.0",
+//   addressOverride: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+// });
+
+// // 3. type needs to be only one of EntryPointVersion type not the union type itself
+
+// // === Error ===
+// const ep3_a: EntryPointDef<EntryPointVersion> = getEntryPoint(chain, {
+//   version: "0.6.0",
+// }); // error
+
+// // =================================================================================

--- a/packages/core/src/entrypoint/types.ts
+++ b/packages/core/src/entrypoint/types.ts
@@ -126,13 +126,3 @@ export type EntryPointParameter<
 > = {
   entryPoint?: EntryPointDef<TEntryPointVersion, TChain>;
 };
-
-// EQ<TEntryPointVersion, DefaultEntryPointVersion> extends true
-//   ? {
-//       entryPoint?: EntryPointDef<TEntryPointVersion, TChain>;
-//     }
-//   : {
-//       entryPoint: IsOneOf<TEntryPointVersion, EntryPointVersion> extends true
-//         ? EntryPointDef<TEntryPointVersion, TChain>
-//         : never;
-//     };

--- a/packages/core/src/entrypoint/types.ts
+++ b/packages/core/src/entrypoint/types.ts
@@ -1,9 +1,138 @@
-import type { Address, Chain, Hex } from "viem";
+import type {
+  Abi,
+  Account,
+  Address,
+  Chain,
+  GetContractParameters,
+  Hash,
+  Hex,
+  Transport,
+} from "viem";
+import type { EntryPointAbi_v6 } from "../abis/EntryPointAbi_v6";
+import type { EntryPointAbi_v7 } from "../abis/EntryPointAbi_v7";
+import type {
+  UserOperationLike,
+  UserOperationOverrides,
+  UserOperationRequest,
+} from "../types";
+import type { EQ, OneOf } from "../utils";
 
-export type EntryPointDef<EntryPointUserOperation> = {
-  version: string;
-  address: Address;
-  chain: Chain;
-  packUserOperation: (userOperation: EntryPointUserOperation) => Hex;
-  getUserOperationHash: (userOperation: EntryPointUserOperation) => Hex;
+export interface EntryPointRegistryBase<T> {
+  "0.6.0": T;
+  "0.7.0": T;
+}
+export type EntryPointVersion = keyof EntryPointRegistryBase<unknown>;
+export type DefaultEntryPointVersion = OneOf<"0.6.0", EntryPointVersion>;
+
+export type SupportedEntryPoint<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain,
+  TAbi extends Abi | readonly unknown[] = Abi
+> = {
+  version: TEntryPointVersion;
+  address: Record<TChain["id"], Address>;
+  abi: GetContractParameters<Transport, TChain, Account, TAbi>["abi"];
+
+  /**
+   * Generates a hash for a UserOperation valid from entry point version 0.6 onwards
+   *
+   * @param request - the UserOperation to get the hash for
+   * @param entryPointAddress - the entry point address that will be used to execute the UserOperation
+   * @param chainId - the chain on which this UserOperation will be executed
+   * @returns the hash of the UserOperation
+   */
+  getUserOperationHash: (
+    request: UserOperationRequest<TEntryPointVersion>,
+    entryPointAddress: Address,
+    chainId: number
+  ) => Hash;
+
+  /**
+   * Pack the user operation data into bytes for hashing for entry point version 0.6 onwards
+   * Reference:
+   * v6: https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.6/test/UserOp.ts#L16-L61
+   * v7: https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.7/test/UserOp.ts#L28-L67
+   *
+   * @param request - the UserOperation to get the hash for
+   * @returns the hash of the UserOperation
+   */
+  packUserOperation: (
+    userOperation: UserOperationRequest<TEntryPointVersion>
+  ) => Hex;
+
+  isUserOpVersion: (
+    userOperation: UserOperationLike
+  ) => userOperation is UserOperationRequest<TEntryPointVersion>;
 };
+
+export interface EntryPointRegistry<TChain extends Chain = Chain>
+  extends EntryPointRegistryBase<
+    SupportedEntryPoint<EntryPointVersion, TChain, Abi>
+  > {
+  "0.6.0": SupportedEntryPoint<"0.6.0", TChain, typeof EntryPointAbi_v6>;
+  "0.7.0": SupportedEntryPoint<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+}
+
+export type EntryPointDef<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain,
+  TAbi extends Abi | readonly unknown[] = Abi
+> = {
+  version: TEntryPointVersion;
+  address: Address;
+  chain: TChain;
+  overrides: UserOperationOverrides<TEntryPointVersion> | undefined;
+  abi: GetContractParameters<Transport, TChain, Account, TAbi>["abi"];
+  getUserOperationHash: (
+    request: UserOperationRequest<TEntryPointVersion>
+  ) => Hex;
+  packUserOperation: (
+    userOperation: UserOperationRequest<TEntryPointVersion>
+  ) => Hex;
+  isUserOpVersion: (
+    userOperation: UserOperationLike
+  ) => userOperation is UserOperationRequest<TEntryPointVersion>;
+  coerce: (
+    userOperation: UserOperationLike,
+    throwable?: boolean
+  ) => UserOperationLike<TEntryPointVersion> | undefined;
+};
+
+export interface EntryPointDefRegistry<TChain extends Chain = Chain>
+  extends EntryPointRegistryBase<
+    EntryPointDef<EntryPointVersion, TChain, Abi>
+  > {
+  "0.6.0": EntryPointDef<"0.6.0", TChain, typeof EntryPointAbi_v6>;
+  "0.7.0": EntryPointDef<"0.7.0", TChain, typeof EntryPointAbi_v7>;
+}
+
+export type GetEntryPointOptions<
+  TEntryPointVersion extends EntryPointVersion = DefaultEntryPointVersion
+> = EQ<TEntryPointVersion, DefaultEntryPointVersion> extends true
+  ?
+      | {
+          addressOverride?: Address;
+          version?: OneOf<TEntryPointVersion, EntryPointVersion>;
+        }
+      | undefined
+  : {
+      addressOverride?: Address;
+      version: OneOf<TEntryPointVersion, EntryPointVersion>;
+    };
+
+export type EntryPointParameter<
+  TEntryPointVersion extends EntryPointVersion,
+  TChain extends Chain = Chain
+> = {
+  entryPoint?: EntryPointDef<TEntryPointVersion, TChain>;
+};
+
+// EQ<TEntryPointVersion, DefaultEntryPointVersion> extends true
+//   ? {
+//       entryPoint?: EntryPointDef<TEntryPointVersion, TChain>;
+//     }
+//   : {
+//       entryPoint: IsOneOf<TEntryPointVersion, EntryPointVersion> extends true
+//         ? EntryPointDef<TEntryPointVersion, TChain>
+//         : never;
+//     };

--- a/packages/core/src/errors/entrypoint.ts
+++ b/packages/core/src/errors/entrypoint.ts
@@ -8,7 +8,7 @@ export class EntryPointNotFoundError extends BaseError {
   constructor(chain: Chain, entryPointVersion: any) {
     super(
       [
-        `No default entry point v${entryPointVersion} exists for ${chain.name}.`,
+        `No default entry point v.${entryPointVersion} exists for ${chain.name}.`,
         `Supply an override.`,
       ].join("\n")
     );

--- a/packages/core/src/errors/entrypoint.ts
+++ b/packages/core/src/errors/entrypoint.ts
@@ -1,15 +1,38 @@
 import type { Chain } from "viem";
+import type { UserOperationLike } from "../types.js";
 import { BaseError } from "./base.js";
 
 export class EntryPointNotFoundError extends BaseError {
-  override name = "EntrypointNotFoundError";
+  override name = "EntryPointNotFoundError";
 
-  constructor(chain: Chain) {
+  constructor(chain: Chain, entryPointVersion: any) {
     super(
       [
-        `No default entry point exists for ${chain.name}.`,
+        `No default entry point v${entryPointVersion} exists for ${chain.name}.`,
         `Supply an override.`,
       ].join("\n")
+    );
+  }
+}
+
+export class InvalidEntryPointError extends BaseError {
+  override name = "InvalidEntryPointError";
+
+  constructor(chain: Chain, entryPointVersion: any) {
+    super(
+      `Invalid entry point: unexpected version ${entryPointVersion} for ${chain.name}.`
+    );
+  }
+}
+
+export class MismatchingEntryPointError extends BaseError {
+  override name = "MismatchingEntryPointError";
+
+  constructor(version: any, uo: UserOperationLike) {
+    super(
+      `Mismatching user operation type for entry point version ${version}: ${JSON.stringify(
+        uo
+      )}.`
     );
   }
 }

--- a/packages/core/src/errors/useroperation.ts
+++ b/packages/core/src/errors/useroperation.ts
@@ -1,9 +1,10 @@
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import type { UserOperationStruct } from "../types.js";
 import { BaseError } from "./base.js";
 
 export class InvalidUserOperationError extends BaseError {
   override name = "InvalidUserOperationError";
-  constructor(uo: UserOperationStruct) {
+  constructor(uo: UserOperationStruct<EntryPointVersion>) {
     super(
       `Request is missing parameters. All properties on UserOperationStruct must be set. uo: ${JSON.stringify(
         uo,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,8 @@ export type { Abi } from "abitype";
 export type { Address, HttpTransport } from "viem";
 export * as chains from "viem/chains";
 
-export { EntryPointAbi } from "./abis/EntryPointAbi.js";
+export { EntryPointAbi_v6 } from "./abis/EntryPointAbi_v6.js";
+export { EntryPointAbi_v7 } from "./abis/EntryPointAbi_v7.js";
 export { SimpleAccountAbi } from "./abis/SimpleAccountAbi.js";
 export { SimpleAccountFactoryAbi } from "./abis/SimpleAccountFactoryAbi.js";
 export { BaseSmartContractAccount } from "./account/base.js";
@@ -70,8 +71,8 @@ export {
   convertCoinTypeToChain,
   convertCoinTypeToChainId,
 } from "./ens/utils.js";
-export { getVersion060EntryPoint } from "./entrypoint/0.6.js";
-export { type EntryPointDef } from "./entrypoint/types.js";
+export * from "./entrypoint/index.js";
+export type * from "./entrypoint/types.js";
 export {
   AccountNotFoundError,
   DefaultFactoryNotDefinedError,
@@ -84,7 +85,7 @@ export {
   IncompatibleClientError,
   InvalidRpcUrlError,
 } from "./errors/client.js";
-export { EntryPointNotFoundError as EntrypointNotFoundError } from "./errors/entrypoint.js";
+export * from "./errors/entrypoint.js";
 export { InvalidSignerTypeError } from "./errors/signer.js";
 export {
   FailedToFindTransactionError,
@@ -125,10 +126,9 @@ export {
   defineReadOnly,
   filterUndefined,
   getChain,
-  getDefaultEntryPointAddress,
   getDefaultSimpleAccountFactoryAddress,
   getDefaultUserOperationFeeOptions,
-  getUserOperationHash,
+  getEntryPointVersionFromUserOp,
   isBigNumberish,
   isMultiplier,
   resolveProperties,

--- a/packages/core/src/middleware/actions.ts
+++ b/packages/core/src/middleware/actions.ts
@@ -11,6 +11,7 @@ import type {
   BundlerRpcSchema,
 } from "../client/decorators/bundlerClient.js";
 import type { ClientMiddlewareConfig } from "../client/types.js";
+import type { EntryPointVersion } from "../entrypoint/types.js";
 import { defaultFeeEstimator } from "./defaults/feeEstimator.js";
 import { defaultGasEstimator } from "./defaults/gasEstimator.js";
 import { defaultPaymasterAndData } from "./defaults/paymasterAndData.js";
@@ -18,29 +19,31 @@ import { noopMiddleware } from "./noopMiddleware.js";
 import type { ClientMiddleware } from "./types.js";
 
 export type MiddlewareClient<
+  TEntryPointVersion extends EntryPointVersion,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+    | SmartContractAccount<TEntryPointVersion>
     | undefined
 > = Client<
   TTransport,
   TChain,
   TAccount,
-  [...BundlerRpcSchema, ...PublicRpcSchema],
-  PublicActions & BundlerActions
+  [...BundlerRpcSchema<TEntryPointVersion>, ...PublicRpcSchema],
+  PublicActions & BundlerActions<TEntryPointVersion>
 >;
 
 export const middlewareActions =
   (overrides: ClientMiddlewareConfig) =>
   <
+    TEntryPointVersion extends EntryPointVersion,
     TTransport extends Transport = Transport,
     TChain extends Chain | undefined = Chain | undefined,
-    TAccount extends SmartContractAccount | undefined =
-      | SmartContractAccount
+    TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+      | SmartContractAccount<TEntryPointVersion>
       | undefined
   >(
-    client: MiddlewareClient<TTransport, TChain, TAccount>
+    client: MiddlewareClient<TEntryPointVersion, TTransport, TChain, TAccount>
   ): { middleware: ClientMiddleware } => ({
     middleware: {
       customMiddleware: overrides.customMiddleware ?? noopMiddleware,

--- a/packages/core/src/middleware/defaults/feeEstimator.ts
+++ b/packages/core/src/middleware/defaults/feeEstimator.ts
@@ -1,9 +1,13 @@
+import type { EntryPointVersion } from "../../entrypoint/types";
 import type { BigNumberish } from "../../types";
 import { applyUserOpOverrideOrFeeOption } from "../../utils/index.js";
 import type { MiddlewareClient } from "../actions";
 import type { ClientMiddlewareFn } from "../types";
 
-export const defaultFeeEstimator: <C extends MiddlewareClient>(
+export const defaultFeeEstimator: <
+  TEntryPointVersion extends EntryPointVersion,
+  C extends MiddlewareClient<TEntryPointVersion>
+>(
   client: C
 ) => ClientMiddlewareFn =
   (client) =>

--- a/packages/core/src/middleware/defaults/gasEstimator.ts
+++ b/packages/core/src/middleware/defaults/gasEstimator.ts
@@ -1,9 +1,13 @@
+import type { EntryPointVersion } from "../../entrypoint/types.js";
 import { deepHexlify, resolveProperties } from "../../utils/index.js";
 import { applyUserOpOverrideOrFeeOption } from "../../utils/userop.js";
 import type { MiddlewareClient } from "../actions.js";
 import type { ClientMiddlewareFn } from "../types.js";
 
-export const defaultGasEstimator: <C extends MiddlewareClient>(
+export const defaultGasEstimator: <
+  TEntryPointVersion extends EntryPointVersion,
+  C extends MiddlewareClient<TEntryPointVersion>
+>(
   client: C
 ) => ClientMiddlewareFn =
   (client) =>

--- a/packages/core/src/middleware/defaults/overridePaymasterData.ts
+++ b/packages/core/src/middleware/defaults/overridePaymasterData.ts
@@ -1,10 +1,36 @@
+import { MismatchingEntryPointError } from "../../errors/entrypoint.js";
+import type { UserOperationOverrides, UserOperationStruct } from "../../types";
 import type { ClientMiddlewareFn } from "../types";
 
 export const overridePaymasterDataMiddleware: ClientMiddlewareFn = async (
   struct,
-  { overrides }
+  { overrides, account }
 ) => {
-  struct.paymasterAndData =
-    overrides?.paymasterAndData != null ? overrides?.paymasterAndData : "0x";
+  const entryPoint = account.getEntryPoint();
+  if (
+    overrides &&
+    entryPoint.isUserOpVersion(struct) &&
+    entryPoint.isUserOpVersion(overrides)
+  ) {
+    throw new MismatchingEntryPointError(entryPoint.version, overrides);
+  }
+
+  if (entryPoint.version === "0.6.0" && entryPoint.isUserOpVersion(struct)) {
+    const _struct = struct as UserOperationStruct<"0.6.0">;
+    _struct.paymasterAndData =
+      _struct?.paymasterAndData != null ? _struct.paymasterAndData : "0x";
+  } else {
+    const _struct = struct as UserOperationStruct<"0.7.0">;
+    const _overrides = overrides as UserOperationOverrides<"0.7.0">;
+
+    _struct.paymaster =
+      _overrides?.paymaster != null ? _overrides?.paymaster : "0x";
+    _struct.paymasterData =
+      _overrides?.paymasterData != null ? _overrides.paymasterData : "0x";
+    _struct.paymasterPostOpGasLimit = _overrides?.paymasterPostOpGasLimit;
+    _struct.paymasterVerificationGasLimit =
+      _overrides?.paymasterVerificationGasLimit;
+  }
+
   return struct;
 };

--- a/packages/core/src/middleware/defaults/paymasterAndData.ts
+++ b/packages/core/src/middleware/defaults/paymasterAndData.ts
@@ -1,6 +1,21 @@
+import { MismatchingEntryPointError } from "../../errors/entrypoint.js";
+import type { UserOperationStruct } from "../../types";
 import type { ClientMiddlewareFn } from "../types";
 
-export const defaultPaymasterAndData: ClientMiddlewareFn = async (struct) => {
-  struct.paymasterAndData = "0x";
+export const defaultPaymasterAndData: ClientMiddlewareFn = async (
+  struct,
+  { account }
+) => {
+  const entryPoint = account.getEntryPoint();
+  if (entryPoint.isUserOpVersion(struct)) {
+    throw new MismatchingEntryPointError(entryPoint.version, struct);
+  }
+
+  if (entryPoint.version === "0.6.0") {
+    (struct as UserOperationStruct<"0.6.0">).paymasterAndData = "0x";
+  } else {
+    (struct as UserOperationStruct<"0.7.0">).paymaster = "0x0";
+    (struct as UserOperationStruct<"0.7.0">).paymasterData = "0x";
+  }
   return struct;
 };

--- a/packages/core/src/middleware/types.ts
+++ b/packages/core/src/middleware/types.ts
@@ -1,4 +1,5 @@
 import type { SmartContractAccount } from "../account/smartContractAccount";
+import type { EntryPointVersion } from "../entrypoint/types";
 import type {
   UserOperationFeeOptions,
   UserOperationOverrides,
@@ -7,14 +8,17 @@ import type {
 import type { Deferrable } from "../utils";
 
 //#region ClientMiddlewareFn
-export type ClientMiddlewareFn = <TAccount extends SmartContractAccount>(
-  struct: Deferrable<UserOperationStruct>,
+export type ClientMiddlewareFn = <
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion>
+>(
+  struct: Deferrable<UserOperationStruct<TEntryPointVersion>>,
   args: {
-    overrides?: UserOperationOverrides;
+    overrides?: UserOperationOverrides<TEntryPointVersion>;
     feeOptions?: UserOperationFeeOptions;
     account: TAccount;
   }
-) => Promise<Deferrable<UserOperationStruct>>;
+) => Promise<Deferrable<UserOperationStruct<TEntryPointVersion>>>;
 //#endregion ClientMiddlewareFn
 
 //#region ClientMiddleware

--- a/packages/core/src/signer/local-account.ts
+++ b/packages/core/src/signer/local-account.ts
@@ -1,11 +1,11 @@
-import {
-  type HDAccount,
-  type Hex,
-  type LocalAccount,
-  type PrivateKeyAccount,
-  type SignableMessage,
-  type TypedData,
-  type TypedDataDefinition,
+import type {
+  HDAccount,
+  Hex,
+  LocalAccount,
+  PrivateKeyAccount,
+  SignableMessage,
+  TypedData,
+  TypedDataDefinition,
 } from "viem";
 import { mnemonicToAccount, privateKeyToAccount } from "viem/accounts";
 import type { SmartAccountSigner } from "./types.js";

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -12,42 +12,12 @@ import {
   optimismGoerli,
   optimismSepolia,
   polygon,
-  polygonMumbai,
   polygonAmoy,
+  polygonMumbai,
   sepolia,
 } from "../chains/index.js";
 import { DefaultFactoryNotDefinedError } from "../errors/account.js";
-import { EntryPointNotFoundError } from "../errors/entrypoint.js";
 import type { UserOperationFeeOptions } from "../types";
-
-/**
- * Utility method returning the entry point contract address given a {@link Chain} object
- *
- * @param chain - a {@link Chain} object
- * @returns a {@link abi.Address} for the given chain
- * @throws if the chain doesn't have an address currently deployed
- */
-export const getDefaultEntryPointAddress = (chain: Chain): Address => {
-  switch (chain.id) {
-    case mainnet.id:
-    case sepolia.id:
-    case goerli.id:
-    case polygon.id:
-    case polygonMumbai.id:
-    case polygonAmoy.id:
-    case optimism.id:
-    case optimismGoerli.id:
-    case optimismSepolia.id:
-    case arbitrum.id:
-    case arbitrumGoerli.id:
-    case arbitrumSepolia.id:
-    case base.id:
-    case baseGoerli.id:
-    case baseSepolia.id:
-      return "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
-  }
-  throw new EntryPointNotFoundError(chain);
-};
 
 /**
  * Utility method returning the default simple account factory address given a {@link Chain} object

--- a/packages/core/src/utils/entrypoint.ts
+++ b/packages/core/src/utils/entrypoint.ts
@@ -1,0 +1,18 @@
+import { entryPointRegistry } from "../entrypoint/index.js";
+import type {
+  EntryPointVersion,
+  SupportedEntryPoint,
+} from "../entrypoint/types.js";
+import type { UserOperationLike } from "../types.js";
+
+export function getEntryPointVersionFromUserOp(op: UserOperationLike) {
+  const filtered = Object.values(entryPointRegistry).filter(
+    (ep: SupportedEntryPoint<EntryPointVersion>) => ep.isUserOpVersion(op)
+  );
+  if (filtered.length !== 1) {
+    throw new Error(
+      "The user operation does not match a unique entry point version."
+    );
+  }
+  return filtered[0].version;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,8 +1,8 @@
-import type { Address, Chain, Hash, Hex } from "viem";
-import { encodeAbiParameters, hexToBigInt, keccak256, toHex } from "viem";
+import type { Chain } from "viem";
+import { toHex } from "viem";
 import * as chains from "viem/chains";
 import * as alchemyChains from "../chains/index.js";
-import type { PromiseOrValue, UserOperationRequest } from "../types.js";
+import type { PromiseOrValue } from "../types.js";
 
 export const AlchemyChainMap = new Map<number, Chain>(
   Object.values(alchemyChains).map((c) => [c.id, c])
@@ -94,60 +94,6 @@ export function deepHexlify(obj: any): any {
   );
 }
 
-/**
- * Generates a hash for a UserOperation valid from entry point version 0.6 onwards
- *
- * @param request - the UserOperation to get the hash for
- * @param entryPointAddress - the entry point address that will be used to execute the UserOperation
- * @param chainId - the chain on which this UserOperation will be executed
- * @returns the hash of the UserOperation
- */
-export function getUserOperationHash(
-  request: UserOperationRequest,
-  entryPointAddress: Address,
-  chainId: number
-): Hash {
-  const encoded = encodeAbiParameters(
-    [{ type: "bytes32" }, { type: "address" }, { type: "uint256" }],
-    [keccak256(packUo(request)), entryPointAddress, BigInt(chainId)]
-  ) as `0x${string}`;
-
-  return keccak256(encoded);
-}
-
-export function packUo(request: UserOperationRequest): Hex {
-  const hashedInitCode = keccak256(request.initCode);
-  const hashedCallData = keccak256(request.callData);
-  const hashedPaymasterAndData = keccak256(request.paymasterAndData);
-
-  return encodeAbiParameters(
-    [
-      { type: "address" },
-      { type: "uint256" },
-      { type: "bytes32" },
-      { type: "bytes32" },
-      { type: "uint256" },
-      { type: "uint256" },
-      { type: "uint256" },
-      { type: "uint256" },
-      { type: "uint256" },
-      { type: "bytes32" },
-    ],
-    [
-      request.sender as Address,
-      hexToBigInt(request.nonce),
-      hashedInitCode,
-      hashedCallData,
-      hexToBigInt(request.callGasLimit),
-      hexToBigInt(request.verificationGasLimit),
-      hexToBigInt(request.preVerificationGas),
-      hexToBigInt(request.maxFeePerGas),
-      hexToBigInt(request.maxPriorityFeePerGas),
-      hashedPaymasterAndData,
-    ]
-  );
-}
-
 // borrowed from ethers.js
 export function defineReadOnly<T, K extends keyof T>(
   object: T,
@@ -178,8 +124,23 @@ export function pick(obj: Record<string, unknown>, keys: string | string[]) {
     .reduce((res, k) => Object.assign(res, { [k]: obj[k] }), {});
 }
 
+/**
+ * Utility method for checking if the passed in values are all equal (strictly)
+ *
+ * @param params - values to check
+ * @returns a boolean indicating if all values are the same
+ * @throws if no values are passed in
+ */
+export const allEqual = (...params: any[]): boolean => {
+  if (params.length === 0) {
+    throw new Error("no values passed in");
+  }
+  return params.every((v) => v === params[0]);
+};
+
 export * from "./bigint.js";
 export * from "./defaults.js";
+export * from "./entrypoint.js";
 export * from "./schema.js";
 export type * from "./types.js";
 export * from "./userop.js";

--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -11,7 +11,7 @@ export const ChainSchema = z.custom<Chain>(
 );
 
 export const HexSchema = z.custom<`0x${string}` | "0x">((val) => {
-  return isHex(val);
+  return isHex(val, { strict: true });
 });
 
 //#region BigNumberish

--- a/packages/core/src/utils/testUtils.ts
+++ b/packages/core/src/utils/testUtils.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, custom, type Chain } from "viem";
+import { createPublicClient, custom, type Chain, type Transport } from "viem";
 import {
   toSmartContractAccount,
   type SmartContractAccount,
@@ -7,15 +7,18 @@ import {
   createBundlerClientFromExisting,
   type BundlerClient,
 } from "../client/bundlerClient.js";
-import { getVersion060EntryPoint } from "../entrypoint/0.6.js";
+import { getEntryPoint } from "../entrypoint/index.js";
+import type { DefaultEntryPointVersion } from "../entrypoint/types.js";
 
-export const createDummySmartContractAccount = async <C extends BundlerClient>(
+export const createDummySmartContractAccount = async <
+  C extends BundlerClient<DefaultEntryPointVersion, Transport>
+>(
   client: C
-): Promise<SmartContractAccount> => {
+): Promise<SmartContractAccount<DefaultEntryPointVersion>> => {
   return toSmartContractAccount({
     source: "dummy",
     accountAddress: "0x1234567890123456789012345678901234567890",
-    entryPoint: getVersion060EntryPoint(client.chain),
+    entryPoint: getEntryPoint(client.chain),
     chain: client.chain,
     transport: custom(client),
     signMessage: async () => "0xdeadbeef",

--- a/packages/core/src/utils/userop.ts
+++ b/packages/core/src/utils/userop.ts
@@ -1,30 +1,86 @@
+import { isAddress, toHex } from "viem";
+import type { EntryPointVersion } from "../entrypoint/types";
 import type {
   BigNumberish,
   Multiplier,
   UserOperationFeeOptionsField,
   UserOperationRequest,
   UserOperationStruct,
+  UserOperationStruct_v6,
+  UserOperationStruct_v7,
 } from "../types";
 import { bigIntClamp, bigIntMultiply } from "./bigint.js";
-import { isBigNumberish } from "./index.js";
+import { allEqual, isBigNumberish } from "./index.js";
 
 /**
- * Utility method for asserting a {@link UserOperationStruct} is a {@link UserOperationRequest}
+ * Utility method for asserting a {@link UserOperationStruct} has valid fields for the given entry point version
  *
  * @param request a {@link UserOperationStruct} to validate
- * @returns a type guard that asserts the {@link UserOperationStruct} is a {@link UserOperationRequest}
+ * @param entryPointVersion a {@link EntryPointVersion} entry point version
+ * @returns a type guard that asserts the {@link UserOperationRequest} is valid
  */
-export function isValidRequest(
-  request: UserOperationStruct
-): request is UserOperationRequest {
+export function isValidRequest<TEntryPointVersion extends EntryPointVersion>(
+  request: UserOperationStruct<TEntryPointVersion>
+): request is UserOperationRequest<TEntryPointVersion> {
   // These are the only ones marked as optional in the interface above
   return (
-    !!request.callGasLimit &&
-    !!request.maxFeePerGas &&
-    request.maxPriorityFeePerGas != null &&
-    !!request.preVerificationGas &&
-    !!request.verificationGasLimit
+    BigInt(request.callGasLimit || 0n) > 0n &&
+    BigInt(request.maxFeePerGas || 0n) > 0n &&
+    BigInt(request.preVerificationGas || 0n) > 0n &&
+    BigInt(request.verificationGasLimit || 0n) > 0n &&
+    isValidPaymasterAndData(request) &&
+    isValidFactoryAndData(request)
   );
+}
+
+/**
+ * Utility method for asserting a {@link UserOperationRequest} has valid fields for the paymaster data
+ *
+ * @param request a {@link UserOperationRequest} to validate
+ * @param entryPointVersion a {@link EntryPointVersion} entry point version
+ * @returns a type guard that asserts the {@link UserOperationRequest} is a {@link UserOperationRequest}
+ */
+export function isValidPaymasterAndData<
+  TEntryPointVersion extends EntryPointVersion
+>(request: UserOperationStruct<TEntryPointVersion>): boolean {
+  if (!("paymaster" in request)) {
+    const { paymasterAndData } = request as UserOperationStruct_v6;
+    return paymasterAndData != null;
+  }
+
+  const {
+    paymaster,
+    paymasterData,
+    paymasterPostOpGasLimit,
+    paymasterVerificationGasLimit,
+  } = request as UserOperationStruct_v7;
+  // either all exist, or none.
+  return allEqual(
+    isAddress(paymaster),
+    toHex(paymasterData || "0x") !== "0x",
+    BigInt(paymasterPostOpGasLimit || 0n) > 0n,
+    BigInt(paymasterVerificationGasLimit || 0n) > 0n
+  );
+}
+
+/**
+ * Utility method for asserting a {@link UserOperationStruct} has valid fields for the paymaster data
+ *
+ * @param request a {@link UserOperationRequest} to validate
+ * @param entryPointVersion a {@link EntryPointVersion} entry point version
+ * @returns a type guard that asserts the {@link UserOperationStruct} is a {@link UserOperationRequest}
+ */
+export function isValidFactoryAndData<
+  TEntryPointVersion extends EntryPointVersion
+>(request: UserOperationStruct<TEntryPointVersion>): boolean {
+  if (!("factory" in request)) {
+    const { initCode } = request as UserOperationStruct_v6;
+    return initCode != null;
+  }
+
+  const { factory, factoryData } = request as UserOperationStruct_v7;
+  // either all exist, or none.
+  return allEqual(isAddress(factory), toHex(factoryData || "0x") !== "0x");
 }
 
 export function applyUserOpOverride(

--- a/packages/ethers/src/account-signer.ts
+++ b/packages/ethers/src/account-signer.ts
@@ -3,6 +3,7 @@ import {
   resolveProperties,
   type BatchUserOperationCallData,
   type BundlerClient,
+  type EntryPointVersion,
   type SmartContractAccount,
   type UserOperationCallData,
   type UserOperationOverrides,
@@ -14,7 +15,7 @@ import {
   type TransactionRequest,
   type TransactionResponse,
 } from "@ethersproject/providers";
-import { isHex, toBytes } from "viem";
+import { isHex, toBytes, type Transport } from "viem";
 import { EthersProviderAdapter } from "./provider-adapter.js";
 
 const hexlifyOptional = (value: any): `0x${string}` | undefined => {
@@ -26,7 +27,8 @@ const hexlifyOptional = (value: any): `0x${string}` | undefined => {
 };
 
 export class AccountSigner<
-  TAccount extends SmartContractAccount = SmartContractAccount
+  TEntryPointVersion extends EntryPointVersion,
+  TAccount extends SmartContractAccount<TEntryPointVersion> = SmartContractAccount<TEntryPointVersion>
 > extends Signer {
   readonly account: TAccount;
 
@@ -39,7 +41,7 @@ export class AccountSigner<
 
     this.sendUserOperation = (
       args: UserOperationCallData | BatchUserOperationCallData,
-      overrides?: UserOperationOverrides
+      overrides?: UserOperationOverrides<TEntryPointVersion>
     ) =>
       this.provider.accountProvider.sendUserOperation({
         uo: args,
@@ -75,23 +77,19 @@ export class AccountSigner<
   }
 
   async sendTransaction(
-    transaction: Deferrable<TransactionRequest>,
-    overrides?: UserOperationOverrides
+    transaction: Deferrable<TransactionRequest>
   ): Promise<TransactionResponse> {
     if (!this.provider.accountProvider.account || !this.account) {
       throw new AccountNotFoundError();
     }
 
     const resolved = await resolveProperties(transaction);
-    const txHash = await this.provider.accountProvider.sendTransaction(
-      {
-        to: resolved.to as `0x${string}` | undefined,
-        data: hexlifyOptional(resolved.data),
-        chain: this.provider.accountProvider.chain,
-        account: this.account,
-      },
-      overrides
-    );
+    const txHash = await this.provider.accountProvider.sendTransaction({
+      to: resolved.to as `0x${string}` | undefined,
+      data: hexlifyOptional(resolved.data),
+      chain: this.provider.accountProvider.chain,
+      account: this.account,
+    });
 
     return this.provider.getTransaction(txHash);
   }
@@ -104,11 +102,13 @@ export class AccountSigner<
     );
   }
 
-  getPublicErc4337Client(): BundlerClient {
+  getPublicErc4337Client(): BundlerClient<TEntryPointVersion, Transport> {
     return this.provider.getBundlerClient();
   }
 
-  connect(provider: EthersProviderAdapter): AccountSigner<TAccount> {
+  connect(
+    provider: EthersProviderAdapter
+  ): AccountSigner<TEntryPointVersion, TAccount> {
     this.provider = provider;
 
     return this;

--- a/packages/ethers/src/types.ts
+++ b/packages/ethers/src/types.ts
@@ -7,21 +7,24 @@ import {
 import type { Chain, Transport } from "viem";
 
 export type EthersProviderAdapterOpts<
+  TAccount extends SmartContractAccount<TEntryPointVersion> | undefined,
+  TEntryPointVersion extends EntryPointVersion = TAccount extends SmartContractAccount<
+    infer U
+  >
+    ? U
+    : EntryPointVersion,
   TTransport extends Transport = Transport,
-  TChain extends Chain = Chain,
-  TAccount extends SmartContractAccount<EntryPointVersion> | undefined =
-    | SmartContractAccount<EntryPointVersion>
-    | undefined
+  TChain extends Chain = Chain
 > = {
   account?: TAccount;
 } & (
   | {
-      rpcProvider: string | BundlerClient<EntryPointVersion, TTransport>;
+      rpcProvider: string | BundlerClient<TEntryPointVersion, TTransport>;
       chainId: number;
     }
   | {
       accountProvider: SmartAccountClient<
-        EntryPointVersion,
+        TEntryPointVersion,
         TTransport,
         TChain,
         TAccount

--- a/packages/ethers/src/types.ts
+++ b/packages/ethers/src/types.ts
@@ -1,5 +1,6 @@
 import {
   type BundlerClient,
+  type EntryPointVersion,
   type SmartAccountClient,
   type SmartContractAccount,
 } from "@alchemy/aa-core";
@@ -8,12 +9,22 @@ import type { Chain, Transport } from "viem";
 export type EthersProviderAdapterOpts<
   TTransport extends Transport = Transport,
   TChain extends Chain = Chain,
-  TAccount extends SmartContractAccount | undefined =
-    | SmartContractAccount
+  TAccount extends SmartContractAccount<EntryPointVersion> | undefined =
+    | SmartContractAccount<EntryPointVersion>
     | undefined
 > = {
   account?: TAccount;
 } & (
-  | { rpcProvider: string | BundlerClient; chainId: number }
-  | { accountProvider: SmartAccountClient<TTransport, TChain, TAccount> }
+  | {
+      rpcProvider: string | BundlerClient<EntryPointVersion, TTransport>;
+      chainId: number;
+    }
+  | {
+      accountProvider: SmartAccountClient<
+        EntryPointVersion,
+        TTransport,
+        TChain,
+        TAccount
+      >;
+    }
 );

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts
@@ -24,9 +24,16 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
       true
     );
     addType(
-      "ManagementActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>",
+      `ManagementActions<
+        TEntryPointVersion extends EntryPointVersion,
+        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+          | SmartContractAccount<TEntryPointVersion>
+          | undefined
+      >`,
       dedent`{
-      install${pluginConfig.name}: (args: {overrides?: UserOperationOverrides} & Install${pluginConfig.name}Params & GetAccountParameter<TAccount>) => Promise<SendUserOperationResult>
+      install${pluginConfig.name}: (args: UserOperationOverridesParameter<TEntryPointVersion> &
+        Install${pluginConfig.name}Params & GetAccountParameter<TEntryPointVersion, TAccount>) =>
+          Promise<SendUserOperationResult<TEntryPointVersion>>
     }`
     );
 

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/read-actions.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/read-actions.ts
@@ -48,8 +48,12 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
       const readMethodName = `read${pascalCase(n.name)}`;
       accountFunctionActionDefs.push(
         n.inputs.length > 0
-          ? dedent`${readMethodName}: (args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> & GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
-          : dedent`${readMethodName}: (args: GetAccountParameter<TAccount>) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          ? dedent`${readMethodName}: (
+            args: Pick<EncodeFunctionDataParameters<typeof ${executionAbiConst}, "${n.name}">, "args"> &
+              GetAccountParameter<TEntryPointVersion, TAccount>
+          ) => Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
+          : dedent`${readMethodName}: (args: GetAccountParameter<TEntryPointVersion, TAccount>) =>
+              Promise<ReadContractReturnType<typeof ${executionAbiConst}, "${n.name}">>`
       );
 
       methodContent.push(dedent`
@@ -76,7 +80,11 @@ export const AccountReadActionsGenPhase: Phase = async (input) => {
   });
 
   const typeName = input.hasReadMethods
-    ? "ReadAndEncodeActions<TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined>"
+    ? `ReadAndEncodeActions<
+        TEntryPointVersion extends EntryPointVersion,
+        TAccount extends SmartContractAccount<TEntryPointVersion> | undefined =
+          SmartContractAccount<TEntryPointVersion> | undefined
+      >`
     : "ReadAndEncodeActions";
 
   addType(

--- a/site/packages/aa-core/accounts/index.md
+++ b/site/packages/aa-core/accounts/index.md
@@ -84,6 +84,6 @@ export type SmartContractAccount<Name extends string = string> =
     isAccountDeployed: () => Promise<boolean>;
     getFactoryAddress: () => Address;
     getEntrypoint: () => Address;
-    getImplementationAddress: () => Promise<"0x0" | Address>;
+    getImplementationAddress: () => Promise<NullAddress | Address>;
   };
 ```


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various files across different packages to improve compatibility and consistency with entry point versions.

### Detailed summary
- Updated error message for default entry point version
- Adjusted test snapshots
- Added `type Hex` import in `viem`
- Refactored `sendUserOperation` function in `smartAccount`
- Simplified `account` object creation in `account.ts`
- Updated types in `ethers` package
- Modified `getMSCAUpgradeToData` function in `msca/utils.ts`
- Updated imports and types in `smartAccountClientFromRpc.ts`
- Refactored `createSmartAccountClient` and related functions in `smartAccountClient.ts`
- Updated imports and types in `lightAccountClient.ts`
- Improved `createMultiOwnerModularAccountClient` function in `client.ts`

> The following files were skipped due to too many changes: `packages/accounts/src/msca/client.ts`, `packages/ethers/src/account-signer.ts`, `packages/accounts/src/light-account/client.ts`, `packages/ethers/src/provider-adapter.ts`, `packages/alchemy/src/client/modularAccountClient.ts`, `packages/accounts/src/msca/account/multiOwnerAccount.ts`, `packages/core/src/account/smartContractAccount.ts`, `packages/core/src/account/simple.ts`, `packages/accounts/src/light-account/account.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->