### PR TITLE
fix: hexadecimal and doc related

### DIFF
--- a/packages/core/src/actions/smartAccount/buildUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperation.ts
@@ -1,4 +1,4 @@
-import type { Chain, Client, Transport } from "viem";
+import { toHex, type Chain, type Client, type Transport } from "viem";
 import {
   type GetEntryPointFromAccount,
   type SmartContractAccount,
@@ -48,7 +48,7 @@ export async function buildUserOperation<
 
   const signature = account.getDummySignature();
 
-  const nonce = account.getNonce(overrides?.nonceKey);
+  const nonce = toHex(await account.getNonce(overrides?.nonceKey));
 
   const _uo =
     entryPoint.version === "0.6.0"

--- a/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
+++ b/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
@@ -48,10 +48,10 @@ const request = await smartAccountClient.signUserOperation({ uoStruct });
 // to send the signed user operation request to the bundler, requesting the bundler to send the signed uo to the
 // EntryPoint contract pointed at the entryPoint address parameter
 const entryPointAddress = client.account.getEntryPoint().address;
-const uoHash = await smartAccountClient.sendRawUserOperation({
+const uoHash = await smartAccountClient.sendRawUserOperation(
   request,
-  entryPoint: entryPointAddress,
-});
+  entryPointAddress,
+);
 
 // build batch
 
@@ -74,16 +74,16 @@ const batchedUoStruct = await smartAccountClient.buildUserOperation({
 
 // signUserOperation signs the above unsigned user operation struct built
 // using the account connected to the smart account client
-const request = await smartAccountClient.signUserOperation({ uoStruct });
+const request = await smartAccountClient.signUserOperation({ batchedUoStruct });
 
 // You can use the BundlerAction `sendRawUserOperation` (packages/core/src/actions/bundler/sendRawUserOperation.ts)
 // to send the signed user operation request to the bundler, requesting the bundler to send the signed uo to the
 // EntryPoint contract pointed at the entryPoint address parameter
 const entryPointAddress = client.account.getEntryPoint().address;
-const uoHash = await smartAccountClient.sendRawUserOperation({
+const uoHash = await smartAccountClient.sendRawUserOperation(
   request,
-  entryPoint: entryPointAddress,
-});
+  entryPointAddress,
+);
 ```
 
 <<< @/snippets/aa-core/smartAccountClient.ts

--- a/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
+++ b/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
@@ -74,7 +74,7 @@ const batchedUoStruct = await smartAccountClient.buildUserOperation({
 
 // signUserOperation signs the above unsigned user operation struct built
 // using the account connected to the smart account client
-const request = await smartAccountClient.signUserOperation({ batchedUoStruct });
+const request = await smartAccountClient.signUserOperation({ uoStruct: batchedUoStruct });
 
 // You can use the BundlerAction `sendRawUserOperation` (packages/core/src/actions/bundler/sendRawUserOperation.ts)
 // to send the signed user operation request to the bundler, requesting the bundler to send the signed uo to the

--- a/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
+++ b/site/packages/aa-core/smart-account-client/actions/buildUserOperation.md
@@ -50,7 +50,7 @@ const request = await smartAccountClient.signUserOperation({ uoStruct });
 const entryPointAddress = client.account.getEntryPoint().address;
 const uoHash = await smartAccountClient.sendRawUserOperation(
   request,
-  entryPointAddress,
+  entryPointAddress
 );
 
 // build batch
@@ -82,7 +82,7 @@ const request = await smartAccountClient.signUserOperation({ batchedUoStruct });
 const entryPointAddress = client.account.getEntryPoint().address;
 const uoHash = await smartAccountClient.sendRawUserOperation(
   request,
-  entryPointAddress,
+  entryPointAddress
 );
 ```
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `buildUserOperation` function in `buildUserOperation.ts` to use the `toHex` function for nonce conversion and refactors the `sendRawUserOperation` function in `buildUserOperation.md` to pass `entryPointAddress` directly.

### Detailed summary
- Updated `buildUserOperation.ts` to use `toHex` for nonce conversion
- Refactored `sendRawUserOperation` function in `buildUserOperation.md` to pass `entryPointAddress` directly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->