### PR TITLE
feat: use erc-712 envelope in light account v2 1271 signatures

### DIFF
--- a/packages/accounts/src/utils/erc1271/erc1271.ts
+++ b/packages/accounts/src/utils/erc1271/erc1271.ts
@@ -1,0 +1,97 @@
+import type {
+  Address,
+  SmartAccountSigner,
+  ToSmartContractAccountParams,
+} from "@alchemy/aa-core";
+import { hashDomain } from "./utils/hashDomain.js";
+import { concat, hashMessage, hashTypedData } from "viem";
+import { hashType, hashStruct } from "./utils/hashTypedData.js";
+
+export interface GetErc1271SigningFunctionsParams {
+  accountAddress: Address;
+  accountName: string;
+  accountVersion: string;
+  chainId: number;
+  signer: SmartAccountSigner;
+  wrapperTypeName: string;
+}
+
+export const getErc1271SigningFunctions = ({
+  accountAddress,
+  accountName,
+  accountVersion,
+  chainId,
+  signer,
+  wrapperTypeName,
+}: GetErc1271SigningFunctionsParams) => {
+  const domain = {
+    name: accountName,
+    version: accountVersion,
+    chainId,
+    verifyingContract: accountAddress,
+  };
+  const personalSignParentTypehash = hashType({
+    primaryType: wrapperTypeName,
+    types: {
+      [wrapperTypeName]: [{ name: "childHash", type: "bytes32" }],
+    },
+  });
+
+  const signMessage: ToSmartContractAccountParams["signMessage"] = async ({
+    message,
+  }) => {
+    const childHash = hashMessage(message);
+    const rsv = await signer.signTypedData({
+      domain,
+      types: {
+        [wrapperTypeName]: [{ name: "childHash", type: "bytes32" }],
+      },
+      primaryType: wrapperTypeName,
+      message: { childHash },
+    });
+    return concat([rsv, personalSignParentTypehash]);
+  };
+
+  const signTypedData: ToSmartContractAccountParams["signTypedData"] = async (
+    typedData
+  ) => {
+    const { domain: childDomain, message, primaryType, types } = typedData;
+    if ((types as any)[wrapperTypeName]) {
+      throw new Error(
+        `Wrapper type name ${wrapperTypeName} already in use in requested typed data`
+      );
+    }
+    if (!childDomain) {
+      throw new Error("Domain missing");
+    }
+    const childDomainHash = hashDomain(childDomain);
+    const contentsHash = hashStruct({
+      data: message as any,
+      primaryType: typedData.primaryType,
+      types: types as any,
+    });
+    const childHash = hashTypedData(typedData);
+    const typeInfo = {
+      types: {
+        [wrapperTypeName]: [
+          { name: "childHash", type: "bytes32" },
+          { name: "child", type: primaryType },
+        ],
+        ...types,
+      },
+      primaryType: wrapperTypeName,
+    };
+    const parentTypeHash = hashType(typeInfo as any);
+    const rsv = await signer.signTypedData({
+      domain,
+      ...typeInfo,
+      message: { childHash, child: message },
+    });
+    return concat([rsv, parentTypeHash, childDomainHash, contentsHash]);
+  };
+
+  return {
+    signMessage,
+    signTypedData,
+  };
+};

--- a/packages/accounts/src/utils/erc1271/utils/hashDomain.ts
+++ b/packages/accounts/src/utils/erc1271/utils/hashDomain.ts
@@ -1,0 +1,25 @@
+import type { Hex, TypedDataDomain, TypedDataParameter } from "viem";
+import { hashDomain as _hashDomain } from "viem";
+
+export function hashDomain(domain: TypedDataDomain): Hex {
+  return _hashDomain({
+    domain,
+    types: { EIP712Domain: makeEIP712DomainType(domain) },
+  });
+}
+
+function makeEIP712DomainType(domain: TypedDataDomain): TypedDataParameter[] {
+  return [
+    typeof domain?.name === "string" && { name: "name", type: "string" },
+    domain?.version && { name: "version", type: "string" },
+    typeof domain?.chainId === "number" && {
+      name: "chainId",
+      type: "uint256",
+    },
+    domain?.verifyingContract && {
+      name: "verifyingContract",
+      type: "address",
+    },
+    domain?.salt && { name: "salt", type: "bytes32" },
+  ].filter(Boolean) as any;
+}

--- a/packages/accounts/src/utils/erc1271/utils/hashTypedData.ts
+++ b/packages/accounts/src/utils/erc1271/utils/hashTypedData.ts
@@ -1,0 +1,278 @@
+// Copied from https://github.com/wevm/viem/blob/viem%402.9.12/src/utils/signature/hashTypedData.ts.
+// Unfortunately, viem does not export `hashDomain`, `hashStruct`, or `hashType`.
+
+// Implementation forked and adapted from https://github.com/MetaMask/eth-sig-util/blob/main/src/sign-typed-data.ts
+
+import type { AbiParameter, TypedData, TypedDataDomain } from "abitype";
+import {
+  type TypedDataDefinition,
+  type Hex,
+  type GetTypesForEIP712DomainErrorType,
+  type ValidateTypedDataErrorType,
+  getTypesForEIP712Domain,
+  validateTypedData,
+  keccak256,
+  concat,
+  type Keccak256ErrorType,
+  type EncodeAbiParametersErrorType,
+  encodeAbiParameters,
+  type ToHexErrorType,
+  toHex,
+} from "viem";
+
+type ErrorType<name extends string = "Error"> = Error & { name: name };
+
+type MessageTypeProperty = {
+  name: string;
+  type: string;
+};
+
+export type HashTypedDataParameters<
+  typedData extends TypedData | Record<string, unknown> = TypedData,
+  primaryType extends keyof typedData | "EIP712Domain" = keyof typedData
+> = TypedDataDefinition<typedData, primaryType>;
+
+export type HashTypedDataReturnType = Hex;
+
+export type HashTypedDataErrorType =
+  | GetTypesForEIP712DomainErrorType
+  | HashDomainErrorType
+  | HashStructErrorType
+  | ValidateTypedDataErrorType
+  | ErrorType;
+
+export function hashTypedData<
+  const typedData extends TypedData | Record<string, unknown>,
+  primaryType extends keyof typedData | "EIP712Domain"
+>(
+  parameters: HashTypedDataParameters<typedData, primaryType>
+): HashTypedDataReturnType {
+  const {
+    domain = {},
+    message,
+    // eslint-disable-next-line @typescript-eslint/no-redeclare
+    primaryType,
+  } = parameters as HashTypedDataParameters;
+  const types = {
+    EIP712Domain: getTypesForEIP712Domain({ domain }),
+    ...parameters.types,
+  };
+
+  // Need to do a runtime validation check on addresses, byte ranges, integer ranges, etc
+  // as we can't statically check this with TypeScript.
+  validateTypedData({
+    domain,
+    message,
+    primaryType,
+    types,
+  });
+
+  const parts: Hex[] = ["0x1901"];
+  if (domain)
+    parts.push(
+      hashDomain({
+        domain,
+        types: types as Record<string, MessageTypeProperty[]>,
+      })
+    );
+
+  if (primaryType !== "EIP712Domain")
+    parts.push(
+      hashStruct({
+        data: message,
+        primaryType,
+        types: types as Record<string, MessageTypeProperty[]>,
+      })
+    );
+
+  return keccak256(concat(parts));
+}
+
+export type HashDomainErrorType = HashStructErrorType | ErrorType;
+
+export function hashDomain({
+  domain,
+  types,
+}: {
+  domain: TypedDataDomain;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  return hashStruct({
+    data: domain,
+    primaryType: "EIP712Domain",
+    types,
+  });
+}
+
+type HashStructErrorType = EncodeDataErrorType | Keccak256ErrorType | ErrorType;
+
+export function hashStruct({
+  data,
+  primaryType,
+  types,
+}: {
+  data: Record<string, unknown>;
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  const encoded = encodeData({
+    data,
+    primaryType,
+    types,
+  });
+  return keccak256(encoded);
+}
+
+type EncodeDataErrorType =
+  | EncodeAbiParametersErrorType
+  | EncodeFieldErrorType
+  | HashTypeErrorType
+  | ErrorType;
+
+function encodeData({
+  data,
+  primaryType,
+  types,
+}: {
+  data: Record<string, unknown>;
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  const encodedTypes: AbiParameter[] = [{ type: "bytes32" }];
+  const encodedValues: unknown[] = [hashType({ primaryType, types })];
+
+  for (const field of types[primaryType]) {
+    const [type, value] = encodeField({
+      types,
+      name: field.name,
+      type: field.type,
+      value: data[field.name],
+    });
+    encodedTypes.push(type);
+    encodedValues.push(value);
+  }
+
+  return encodeAbiParameters(encodedTypes, encodedValues);
+}
+
+type HashTypeErrorType =
+  | ToHexErrorType
+  | EncodeTypeErrorType
+  | Keccak256ErrorType
+  | ErrorType;
+
+export function hashType({
+  primaryType,
+  types,
+}: {
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  const encodedHashType = toHex(encodeType({ primaryType, types }));
+  return keccak256(encodedHashType);
+}
+
+type EncodeTypeErrorType = FindTypeDependenciesErrorType;
+
+function encodeType({
+  primaryType,
+  types,
+}: {
+  primaryType: string;
+  types: Record<string, MessageTypeProperty[]>;
+}) {
+  let result = "";
+  const unsortedDeps = findTypeDependencies({ primaryType, types });
+  unsortedDeps.delete(primaryType);
+
+  const deps = [primaryType, ...Array.from(unsortedDeps).sort()];
+  for (const type of deps) {
+    result += `${type}(${types[type]
+      .map(({ name, type: t }) => `${t} ${name}`)
+      .join(",")})`;
+  }
+
+  return result;
+}
+
+type FindTypeDependenciesErrorType = ErrorType;
+
+function findTypeDependencies(
+  {
+    primaryType: primaryType_,
+    types,
+  }: {
+    primaryType: string;
+    types: Record<string, MessageTypeProperty[]>;
+  },
+  results: Set<string> = new Set()
+): Set<string> {
+  const match = primaryType_.match(/^\w*/u);
+  const primaryType = match?.[0]!;
+  if (results.has(primaryType) || types[primaryType] === undefined) {
+    return results;
+  }
+
+  results.add(primaryType);
+
+  for (const field of types[primaryType]) {
+    findTypeDependencies({ primaryType: field.type, types }, results);
+  }
+  return results;
+}
+
+type EncodeFieldErrorType =
+  | Keccak256ErrorType
+  | EncodeAbiParametersErrorType
+  | ToHexErrorType
+  | ErrorType;
+
+function encodeField({
+  types,
+  name,
+  type,
+  value,
+}: {
+  types: Record<string, MessageTypeProperty[]>;
+  name: string;
+  type: string;
+  value: any;
+}): [type: AbiParameter, value: any] {
+  if (types[type] !== undefined) {
+    return [
+      { type: "bytes32" },
+      keccak256(encodeData({ data: value, primaryType: type, types })),
+    ];
+  }
+
+  if (type === "bytes") {
+    const prepend = value.length % 2 ? "0" : "";
+    value = `0x${prepend + value.slice(2)}`;
+    return [{ type: "bytes32" }, keccak256(value)];
+  }
+
+  if (type === "string") return [{ type: "bytes32" }, keccak256(toHex(value))];
+
+  if (type.lastIndexOf("]") === type.length - 1) {
+    const parsedType = type.slice(0, type.lastIndexOf("["));
+    const typeValuePairs = (value as [AbiParameter, any][]).map((item) =>
+      encodeField({
+        name,
+        type: parsedType,
+        types,
+        value: item,
+      })
+    );
+    return [
+      { type: "bytes32" },
+      keccak256(
+        encodeAbiParameters(
+          typeValuePairs.map(([t]) => t),
+          typeValuePairs.map(([, v]) => v)
+        )
+      ),
+    ];
+  }
+
+  return [{ type }, value];
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -148,10 +148,10 @@ export const toRecord = <
   selector: K,
   fn: (item: T) => V
 ): Record<T[K], V> =>
-  array.reduce(
-    (acc, item) => ((acc[item[selector]] = fn(item)), acc),
-    {} as Record<T[K], V>
-  );
+  array.reduce((acc, item) => {
+    acc[item[selector]] = fn(item);
+    return acc;
+  }, {} as Record<T[K], V>);
 
 export * from "./bigint.js";
 export * from "./bytes.js";


### PR DESCRIPTION
Light account v2 uses a new format in its ERC-1271 signatures to prevent replay attacks where the same signed message could be approved by several accounts that shared an owner.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances ERC1271 signing functionality in the accounts module by refactoring hashing and signing logic for typed data.

### Detailed summary
- Refactored hashing and signing logic for ERC1271 functionality.
- Added `hashTypedData` and `hashDomain` functions.
- Improved error handling and validation for typed data.
- Updated `createLightAccountBase` to support ERC1271 signing.
- Added `getErc1271SigningFunctions` to retrieve signing functions.

> The following files were skipped due to too many changes: `packages/accounts/src/utils/erc1271/utils/hashTypedData.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->