### PR TITLE
fix: invalid user operation error mesages to correctly serialize bigint fields

### DIFF
--- a/packages/core/src/errors/useroperation.ts
+++ b/packages/core/src/errors/useroperation.ts
@@ -7,7 +7,13 @@ export class InvalidUserOperationError extends BaseError {
     super(
       `Request is missing parameters. All properties on UserOperationStruct must be set. uo: ${JSON.stringify(
         uo,
-        null,
+        (_key, value) =>
+          typeof value === "bigint"
+            ? {
+                type: "bigint",
+                value: value.toString(),
+              }
+            : value,
         2
       )}`
     );


### PR DESCRIPTION
Without the replace to correctly convert bigint values in the uo struct to serializable format, errors for invalid user operation (which we use before signing any user operation) fail to generate error messages. Was caught while using staging environment for e2e testing. 

- Without replacer:
![Screenshot 2024-04-08 at 11 09 27 PM](https://github.com/alchemyplatform/aa-sdk/assets/3278577/31f147c2-7cdb-43d6-a5ec-59b2f64ddb8f)

- With replacer:
![Screenshot 2024-04-08 at 11 12 47 PM](https://github.com/alchemyplatform/aa-sdk/assets/3278577/dd1dff6f-1010-4e79-8532-259b79c741c9)


# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the error message in `useroperation.ts` to handle `bigint` values properly.

### Detailed summary
- Updated error message handling to stringify `bigint` values in `UserOperationStruct` properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->