### PR TITLE
fix: add the signer header when using aa-alchemy

### DIFF
--- a/packages/alchemy/src/client/lightAccountClient.test.ts
+++ b/packages/alchemy/src/client/lightAccountClient.test.ts
@@ -23,7 +23,10 @@ describe("Light Account Client Tests", () => {
     expect(spy.mock.results[0].value.transport).toMatchInlineSnapshot(
       {
         fetchOptions: {
-          headers: { "Alchemy-AA-Sdk-Version": expect.any(String) },
+          headers: {
+            "Alchemy-AA-Sdk-Version": expect.any(String),
+            "Alchemy-Aa-Sdk-Signer": "local",
+          },
         },
       },
       `
@@ -31,6 +34,7 @@ describe("Light Account Client Tests", () => {
         "fetchOptions": {
           "headers": {
             "Alchemy-AA-Sdk-Version": Any<String>,
+            "Alchemy-Aa-Sdk-Signer": "local",
             "Authorization": "Bearer test",
           },
         },

--- a/packages/alchemy/src/client/rpcClient.ts
+++ b/packages/alchemy/src/client/rpcClient.ts
@@ -1,14 +1,21 @@
-import { createBundlerClient, type ConnectionConfig } from "@alchemy/aa-core";
-import { http, type Chain } from "viem";
+import {
+  createBundlerClient,
+  type ConnectionConfig,
+  type NoUndefined,
+} from "@alchemy/aa-core";
+import { http, type Chain, type HttpTransportConfig } from "viem";
 import { AlchemyChainSchema } from "../schema.js";
+import { VERSION } from "../version.js";
 import type { ClientWithAlchemyMethods } from "./types.js";
 
 export const createAlchemyPublicRpcClient = ({
   chain: chain_,
   connectionConfig,
+  fetchOptions = {},
 }: {
   connectionConfig: ConnectionConfig;
   chain: Chain;
+  fetchOptions?: NoUndefined<HttpTransportConfig["fetchOptions"]>;
 }): ClientWithAlchemyMethods => {
   const chain = AlchemyChainSchema.parse(chain_);
 
@@ -17,16 +24,27 @@ export const createAlchemyPublicRpcClient = ({
       ? `${chain.rpcUrls.alchemy.http[0]}/${connectionConfig.apiKey ?? ""}`
       : connectionConfig.rpcUrl;
 
+  fetchOptions.headers = {
+    ...fetchOptions.headers,
+    "Alchemy-AA-Sdk-Version": VERSION,
+  };
+
+  if (connectionConfig.jwt != null) {
+    fetchOptions.headers = {
+      ...fetchOptions.headers,
+      Authorization: `Bearer ${connectionConfig.jwt}`,
+    };
+  }
+
   return createBundlerClient({
     chain: chain,
-    transport: http(rpcUrl, {
-      ...(connectionConfig.jwt != null && {
-        fetchOptions: {
-          headers: {
-            Authorization: `Bearer ${connectionConfig.jwt}`,
-          },
-        },
-      }),
-    }),
-  });
+    transport: http(rpcUrl, { fetchOptions }),
+  }).extend(() => ({
+    updateHeaders(newHeaders: HeadersInit) {
+      fetchOptions.headers = {
+        ...fetchOptions.headers,
+        ...newHeaders,
+      };
+    },
+  }));
 };

--- a/packages/alchemy/src/client/smartAccountClient.test.ts
+++ b/packages/alchemy/src/client/smartAccountClient.test.ts
@@ -1,0 +1,182 @@
+import { createLightAccount } from "@alchemy/aa-accounts";
+import {
+  LocalAccountSigner,
+  sepolia,
+  type ClientMiddlewareFn,
+  type SmartContractAccount,
+} from "@alchemy/aa-core";
+import { http, zeroAddress } from "viem";
+import { generatePrivateKey } from "viem/accounts";
+import { createAlchemySmartAccountClient } from "./smartAccountClient.js";
+
+const headerMatcher = {
+  "Alchemy-AA-Sdk-Version": expect.any(String),
+};
+
+describe("AlchemySmartAccountClient tests", () => {
+  let ogFetch = fetch;
+  beforeAll(() => {
+    global.fetch = vi.fn();
+  });
+
+  beforeEach(() => {
+    // @ts-expect-error - fetch is mocked
+    global.fetch.mockClear();
+  });
+  afterAll(() => {
+    global.fetch = ogFetch;
+  });
+
+  it("should set the headers when using non-hoisted accounts", async () => {
+    const client = givenClient();
+    client
+      .request({ method: "eth_supportedEntryPoints", params: [] })
+      .catch(() => {});
+    expect(
+      // @ts-expect-error - fetch is mocked
+      fetch.mock.calls.map((x) => x[1].headers)[0]
+    ).toMatchInlineSnapshot(
+      headerMatcher,
+      `
+      {
+        "Alchemy-AA-Sdk-Version": Any<String>,
+        "Content-Type": "application/json",
+      }
+    `
+    );
+
+    await client.middleware
+      // @ts-expect-error this is actually still there
+      .customMiddleware(
+        {},
+        {
+          account: await createLightAccount({
+            chain: sepolia,
+            transport: http(),
+            signer: LocalAccountSigner.privateKeyToAccountSigner(
+              generatePrivateKey()
+            ),
+            accountAddress: zeroAddress,
+          }),
+        }
+      )
+      .catch(() => {});
+
+    // clear the mock calls so we only get the latest call below
+    // @ts-expect-error - fetch is mocked
+    global.fetch.mockClear();
+    client
+      .request({ method: "eth_supportedEntryPoints", params: [] })
+      .catch(() => {});
+
+    expect(
+      // @ts-expect-error - fetch is mocked
+      fetch.mock.calls.map((x) => x[1].headers)[0]
+    ).toMatchInlineSnapshot(
+      headerMatcher,
+      `
+      {
+        "Alchemy-AA-Sdk-Version": Any<String>,
+        "Alchemy-Aa-Sdk-Signer": "local",
+        "Content-Type": "application/json",
+      }
+    `
+    );
+  });
+
+  it("should set the headers when using hoisted accounts", async () => {
+    const client = givenClient({
+      account: await createLightAccount({
+        chain: sepolia,
+        transport: http(),
+        signer: LocalAccountSigner.privateKeyToAccountSigner(
+          generatePrivateKey()
+        ),
+        accountAddress: zeroAddress,
+      }),
+    });
+
+    client
+      .request({ method: "eth_supportedEntryPoints", params: [] })
+      .catch(() => {});
+
+    expect(
+      // @ts-expect-error - fetch is mocked
+      fetch.mock.calls.map((x) => x[1].headers)[0]
+    ).toMatchInlineSnapshot(
+      headerMatcher,
+      `
+      {
+        "Alchemy-AA-Sdk-Version": Any<String>,
+        "Alchemy-Aa-Sdk-Signer": "local",
+        "Content-Type": "application/json",
+      }
+    `
+    );
+  });
+
+  it("should still use customMiddleware if it is passed in", async () => {
+    const client = givenClient({
+      customMiddleware: async (struct) => {
+        return {
+          ...struct,
+          callGasLimit: "0xdeadbeef",
+        };
+      },
+    });
+
+    expect(
+      // @ts-expect-error - this is available but not typed as public
+      await client.middleware.customMiddleware(
+        {},
+        {
+          account: await createLightAccount({
+            chain: sepolia,
+            transport: http(),
+            signer: LocalAccountSigner.privateKeyToAccountSigner(
+              generatePrivateKey()
+            ),
+            accountAddress: zeroAddress,
+          }),
+        }
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "callGasLimit": "0xdeadbeef",
+      }
+    `);
+
+    client
+      .request({ method: "eth_supportedEntryPoints", params: [] })
+      .catch(() => {});
+
+    expect(
+      // @ts-expect-error - fetch is mocked
+      fetch.mock.calls.map((x) => x[1].headers)[0]
+    ).toMatchInlineSnapshot(
+      headerMatcher,
+      `
+      {
+        "Alchemy-AA-Sdk-Version": Any<String>,
+        "Alchemy-Aa-Sdk-Signer": "local",
+        "Content-Type": "application/json",
+      }
+    `
+    );
+  });
+
+  const givenClient = ({
+    account,
+    customMiddleware,
+  }: {
+    account?: SmartContractAccount;
+    customMiddleware?: ClientMiddlewareFn;
+  } = {}) => {
+    return createAlchemySmartAccountClient({
+      rpcUrl: "https://localhost:3000",
+      account,
+      chain: sepolia,
+      customMiddleware,
+    });
+  };
+});

--- a/packages/alchemy/src/client/types.ts
+++ b/packages/alchemy/src/client/types.ts
@@ -97,4 +97,6 @@ export type ClientWithAlchemyMethods = BundlerClient<HttpTransport> & {
         params: [];
       }): Promise<Hex>;
     }["request"];
+} & {
+  updateHeaders: (headers: HeadersInit) => void;
 };

--- a/packages/core/src/client/bundlerClient.ts
+++ b/packages/core/src/client/bundlerClient.ts
@@ -75,24 +75,25 @@ export function createBundlerClient(
 
   const client = (() => {
     if (resolvedTransport.config.type === "http") {
-      const { url, fetchOptions } = resolvedTransport.value as {
+      const { url, fetchOptions: fetchOptions_ } = resolvedTransport.value as {
         fetchOptions: HttpTransportConfig["fetchOptions"];
         url: string;
       };
+
+      const fetchOptions = fetchOptions_ ?? {};
+
+      if (url.toLowerCase().indexOf("alchemy") > -1) {
+        fetchOptions.headers = {
+          ...fetchOptions.headers,
+          "Alchemy-AA-Sdk-Version": VERSION,
+        };
+      }
 
       return createClient<Transport, Chain>({
         ...baseParameters,
         transport: http(url, {
           ...resolvedTransport.config,
-          fetchOptions: {
-            ...fetchOptions,
-            headers: {
-              ...fetchOptions?.headers,
-              ...(url.toLowerCase().indexOf("alchemy") > -1
-                ? { "Alchemy-AA-Sdk-Version": VERSION }
-                : undefined),
-            },
-          },
+          fetchOptions,
         }),
       });
     }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances Alchemy client functionality by adding headers update capability and improving smart account client handling.

### Detailed summary
- Added `updateHeaders` method to modify headers in `fetchOptions`
- Updated headers in `lightAccountClient.test.ts`
- Improved handling of headers in `bundlerClient.ts`
- Enhanced `rpcClient.ts` to update headers with `fetchOptions`
- Added `isSmartAccountWithSigner` and `getSignerTypeHeader` in `smartAccountClientFromRpc.ts`
- Updated tests in `smartAccountClient.test.ts` for header setting

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->