### PR TITLE
refactor: type user operation context for better type readability

### DIFF
--- a/packages/accounts/plugingen/phases/plugin-actions/index.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/index.ts
@@ -36,6 +36,10 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     name: "UserOperationOverridesParameter",
     isType: true,
   });
+  addImport("@alchemy/aa-core", {
+    name: "UserOperationContext",
+    isType: true,
+  });
   addImport("@alchemy/aa-core", { name: "AccountNotFoundError" });
   addImport("@alchemy/aa-core", { name: "isSmartAccountClient" });
   addImport("@alchemy/aa-core", { name: "IncompatibleClientError" });
@@ -94,7 +98,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     `ExecutionActions<
       TAccount extends SmartContractAccount | undefined =
         SmartContractAccount | undefined,
-      TContext extends Record<string, any> | undefined = Record<string, any> | undefined,
+      TContext extends UserOperationContext | undefined = UserOperationContext | undefined,
       TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
     >`,
     dedent`{
@@ -115,8 +119,8 @@ export const PluginActionsGenPhase: Phase = async (input) => {
       TAccount extends SmartContractAccount | undefined =
           | SmartContractAccount
           | undefined,
-      TContext extends Record<string, any> | undefined =
-          | Record<string, any>
+      TContext extends UserOperationContext | undefined =
+          | UserOperationContext
           | undefined
     >`,
     dedent`
@@ -134,7 +138,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
         TAccount extends SmartContractAccount | undefined =
             | SmartContractAccount
             | undefined,
-        TContext extends Record<string, any> | undefined = Record<string, any> | undefined
+        TContext extends UserOperationContext | undefined = UserOperationContext | undefined
     >(
         client: Client<TTransport, TChain, TAccount>
     ) => ${

--- a/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
+++ b/packages/accounts/plugingen/phases/plugin-actions/management-actions.ts
@@ -26,7 +26,7 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
     addType(
       `ManagementActions<
         TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined,
-        TContext extends Record<string, any> | undefined = Record<string,any> | undefined,
+        TContext extends UserOperationContext | undefined = UserOperationContext | undefined,
         TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
       >`,
       dedent`{
@@ -130,6 +130,10 @@ const addImports = (
   });
   addImport("@alchemy/aa-core", {
     name: "GetEntryPointFromAccount",
+    isType: true,
+  });
+  addImport("@alchemy/aa-core", {
+    name: "UserOperationContext",
     isType: true,
   });
   // TODO: after plugingen becomes its own cli tool package, this should be changed to

--- a/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
+++ b/packages/accounts/src/msca/plugin-manager/uninstallPlugin.ts
@@ -6,6 +6,7 @@ import {
   type GetContextParameter,
   type GetEntryPointFromAccount,
   type SmartContractAccount,
+  type UserOperationContext,
   type UserOperationOverridesParameter,
 } from "@alchemy/aa-core";
 import {
@@ -22,8 +23,8 @@ export type UninstallPluginParams<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -40,8 +41,8 @@ export async function uninstallPlugin<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,

--- a/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
+++ b/packages/accounts/src/msca/plugins/multi-owner/plugin.ts
@@ -22,6 +22,7 @@ import {
   type SendUserOperationResult,
   type GetEntryPointFromAccount,
   type UserOperationOverridesParameter,
+  type UserOperationContext,
   type GetContextParameter,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
@@ -36,8 +37,8 @@ type ExecutionActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -67,8 +68,8 @@ type ManagementActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -145,8 +146,8 @@ export type MultiOwnerPluginActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = ExecutionActions<TAccount, TContext> &
   ManagementActions<TAccount, TContext> &
@@ -195,8 +196,8 @@ export const multiOwnerPluginActions: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>

--- a/packages/accounts/src/msca/plugins/multisig/plugin.ts
+++ b/packages/accounts/src/msca/plugins/multisig/plugin.ts
@@ -22,6 +22,7 @@ import {
   type SendUserOperationResult,
   type GetEntryPointFromAccount,
   type UserOperationOverridesParameter,
+  type UserOperationContext,
   type GetContextParameter,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
@@ -36,8 +37,8 @@ type ExecutionActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -67,8 +68,8 @@ type ManagementActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -145,8 +146,8 @@ export type MultisigPluginActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = ExecutionActions<TAccount, TContext> &
   ManagementActions<TAccount, TContext> &
@@ -182,8 +183,8 @@ export const multisigPluginActions: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>

--- a/packages/accounts/src/msca/plugins/session-key/plugin.ts
+++ b/packages/accounts/src/msca/plugins/session-key/plugin.ts
@@ -22,6 +22,7 @@ import {
   type SendUserOperationResult,
   type GetEntryPointFromAccount,
   type UserOperationOverridesParameter,
+  type UserOperationContext,
   type GetContextParameter,
 } from "@alchemy/aa-core";
 import { type Plugin } from "../types.js";
@@ -37,8 +38,8 @@ type ExecutionActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -124,8 +125,8 @@ type ManagementActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -193,8 +194,8 @@ export type SessionKeyPluginActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = ExecutionActions<TAccount, TContext> &
   ManagementActions<TAccount, TContext> &
@@ -243,8 +244,8 @@ export const sessionKeyPluginActions: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>

--- a/packages/alchemy/src/client/decorators/smartAccount.ts
+++ b/packages/alchemy/src/client/decorators/smartAccount.ts
@@ -1,6 +1,7 @@
 import type {
   SendUserOperationParameters,
   SmartContractAccount,
+  UserOperationContext,
 } from "@alchemy/aa-core";
 import type { Chain, Client, Transport } from "viem";
 import { simulateUserOperationChanges } from "../../actions/simulateUserOperationChanges.js";
@@ -10,8 +11,8 @@ export type AlchemySmartAccountClientActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = {
   simulateUserOperation: (
@@ -25,8 +26,8 @@ export const alchemyActions: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>

--- a/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
+++ b/packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts
@@ -4,6 +4,7 @@ import {
   isSmartAccountWithSigner,
   type SmartContractAccount,
   type SmartContractAccountWithSigner,
+  type UserOperationContext,
 } from "@alchemy/aa-core";
 import type { Chain, CustomTransport, Transport } from "viem";
 import { alchemyFeeEstimator } from "../../middleware/feeEstimator.js";
@@ -20,8 +21,8 @@ export type CreateAlchemySmartAccountClientFromRpcClient<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Omit<
   AlchemySmartAccountClientConfig<Transport, Chain, TAccount, TContext>,
@@ -43,8 +44,8 @@ export function createAlchemySmartAccountClientFromRpcClient<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   args: CreateAlchemySmartAccountClientFromRpcClient<TAccount, TContext>

--- a/packages/alchemy/src/client/smartAccountClient.ts
+++ b/packages/alchemy/src/client/smartAccountClient.ts
@@ -5,6 +5,7 @@ import {
   type SmartAccountClientConfig,
   type SmartAccountClientRpcSchema,
   type SmartContractAccount,
+  type UserOperationContext,
 } from "@alchemy/aa-core";
 import { type Chain, type Transport } from "viem";
 import { getDefaultUserOperationFeeOptions } from "../defaults.js";
@@ -23,8 +24,8 @@ export type AlchemySmartAccountClientConfig<
   account extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = {
   account?: account;
@@ -42,8 +43,8 @@ export type BaseAlchemyActions<
   account extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = SmartAccountClientActions<chain, account, context> &
   AlchemySmartAccountClientActions<account, context>;
@@ -55,8 +56,8 @@ export type AlchemySmartAccountClient_Base<
     | SmartContractAccount
     | undefined,
   actions extends Record<string, unknown> = Record<string, unknown>,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Prettify<
   SmartAccountClient<
@@ -76,8 +77,8 @@ export type AlchemySmartAccountClient<
     | SmartContractAccount
     | undefined,
   actions extends Record<string, unknown> = Record<string, unknown>,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Prettify<
   AlchemySmartAccountClient_Base<transport, chain, account, actions, context>
@@ -89,8 +90,8 @@ export function createAlchemySmartAccountClient<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >({
   account,

--- a/packages/core/src/actions/smartAccount/buildUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperation.ts
@@ -9,7 +9,10 @@ import { IncompatibleClientError } from "../../errors/client.js";
 import type { UserOperationStruct } from "../../types.js";
 import type { Deferrable } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
-import type { SendUserOperationParameters } from "./types";
+import type {
+  SendUserOperationParameters,
+  UserOperationContext,
+} from "./types";
 
 export async function buildUserOperation<
   TTransport extends Transport = Transport,
@@ -17,8 +20,8 @@ export async function buildUserOperation<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(

--- a/packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../types.js";
 import { filterUndefined } from "../../utils/index.js";
 import { buildUserOperation } from "./buildUserOperation.js";
+import type { UserOperationContext } from "./types.js";
 
 export async function buildUserOperationFromTx<
   TChain extends Chain | undefined = Chain | undefined,
@@ -25,8 +26,8 @@ export async function buildUserOperationFromTx<
     | SmartContractAccount
     | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(

--- a/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
+++ b/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
@@ -5,7 +5,10 @@ import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import type { UserOperationStruct } from "../../types.js";
 import { buildUserOperation } from "./buildUserOperation.js";
-import type { SendUserOperationParameters } from "./types";
+import type {
+  SendUserOperationParameters,
+  UserOperationContext,
+} from "./types";
 
 export const checkGasSponsorshipEligibility: <
   TTransport extends Transport = Transport,
@@ -13,8 +16,8 @@ export const checkGasSponsorshipEligibility: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -15,7 +15,10 @@ import type {
 import { bigIntMax, bigIntMultiply } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
-import type { DropAndReplaceUserOperationParameters } from "./types";
+import type {
+  DropAndReplaceUserOperationParameters,
+  UserOperationContext,
+} from "./types";
 
 export async function dropAndReplaceUserOperation<
   TTransport extends Transport = Transport,
@@ -23,8 +26,8 @@ export async function dropAndReplaceUserOperation<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(

--- a/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
+++ b/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
@@ -13,6 +13,7 @@ import type {
   UserOperationStruct,
 } from "../../../types";
 import { resolveProperties, type Deferrable } from "../../../utils/index.js";
+import type { UserOperationContext } from "../types";
 
 const asyncPipe =
   <S, Opts>(...fns: ((s: S, opts: Opts) => Promise<S>)[]) =>
@@ -30,8 +31,8 @@ export async function _runMiddlewareStack<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(

--- a/packages/core/src/actions/smartAccount/sendTransaction.ts
+++ b/packages/core/src/actions/smartAccount/sendTransaction.ts
@@ -16,6 +16,7 @@ import { TransactionMissingToParamError } from "../../errors/transaction.js";
 import type { UserOperationOverrides } from "../../types.js";
 import { buildUserOperationFromTx } from "./buildUserOperationFromTx.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
+import type { UserOperationContext } from "./types.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export async function sendTransaction<
@@ -24,8 +25,8 @@ export async function sendTransaction<
     | SmartContractAccount
     | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(

--- a/packages/core/src/actions/smartAccount/sendTransactions.ts
+++ b/packages/core/src/actions/smartAccount/sendTransactions.ts
@@ -5,7 +5,7 @@ import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { buildUserOperationFromTxs } from "./buildUserOperationFromTxs.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
-import type { SendTransactionsParameters } from "./types";
+import type { SendTransactionsParameters, UserOperationContext } from "./types";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export async function sendTransactions<
@@ -14,7 +14,7 @@ export async function sendTransactions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined = Record<string, any>
+  TContext extends UserOperationContext | undefined = UserOperationContext
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: SendTransactionsParameters<TAccount, TContext>

--- a/packages/core/src/actions/smartAccount/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/sendUserOperation.ts
@@ -9,7 +9,10 @@ import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { buildUserOperation } from "./buildUserOperation.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
-import type { SendUserOperationParameters } from "./types.js";
+import type {
+  SendUserOperationParameters,
+  UserOperationContext,
+} from "./types.js";
 
 export const sendUserOperation: <
   TTransport extends Transport = Transport,
@@ -17,8 +20,8 @@ export const sendUserOperation: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(

--- a/packages/core/src/actions/smartAccount/types.ts
+++ b/packages/core/src/actions/smartAccount/types.ts
@@ -21,8 +21,8 @@ import type { IsUndefined } from "../../utils";
 //#region UpgradeAccountParams
 export type UpgradeAccountParams<
   TAccount extends SmartContractAccount | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -36,8 +36,8 @@ export type UpgradeAccountParams<
 //#region SendUserOperationParameters
 export type SendUserOperationParameters<
   TAccount extends SmartContractAccount | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -61,8 +61,8 @@ export type SignUserOperationParameters<
 //#region SendTransactionsParameters
 export type SendTransactionsParameters<
   TAccount extends SmartContractAccount | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -75,8 +75,8 @@ export type SendTransactionsParameters<
 //#region DropAndReplaceUserOperationParameters
 export type DropAndReplaceUserOperationParameters<
   TAccount extends SmartContractAccount | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -101,12 +101,18 @@ export type BuildUserOperationFromTransactionsResult<
 } & UserOperationOverridesParameter<TEntryPointVersion, true>;
 //#endregion BuildUserOperationFromTransactionsResult
 
+//#region UserOperationContext
+export type UserOperationContext = Record<string, any>;
+//#endregion UserOperationContext
+
+//#region GetContextParameter
 export type GetContextParameter<
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = IsUndefined<TContext> extends true
   ? {
       context?: TContext;
     }
   : { context: TContext };
+//#endregion GetContextParameter

--- a/packages/core/src/actions/smartAccount/upgradeAccount.ts
+++ b/packages/core/src/actions/smartAccount/upgradeAccount.ts
@@ -4,7 +4,7 @@ import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { sendUserOperation } from "./sendUserOperation.js";
-import type { UpgradeAccountParams } from "./types.js";
+import type { UpgradeAccountParams, UserOperationContext } from "./types.js";
 import { waitForUserOperationTransaction } from "./waitForUserOperationTransacation.js";
 
 export const upgradeAccount: <
@@ -13,8 +13,8 @@ export const upgradeAccount: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,

--- a/packages/core/src/client/decorators/smartAccountClient.ts
+++ b/packages/core/src/client/decorators/smartAccountClient.ts
@@ -40,6 +40,7 @@ import type {
   SendUserOperationParameters,
   SignUserOperationParameters,
   UpgradeAccountParams,
+  UserOperationContext,
 } from "../../actions/smartAccount/types";
 import { upgradeAccount } from "../../actions/smartAccount/upgradeAccount.js";
 import { waitForUserOperationTransaction } from "../../actions/smartAccount/waitForUserOperationTransacation.js";
@@ -57,8 +58,8 @@ export type BaseSmartAccountClientActions<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
@@ -74,8 +75,8 @@ export type BaseSmartAccountClientActions<
     args: SendTransactionsParameters<TAccount, TContext>
   ) => Promise<BuildUserOperationFromTransactionsResult<TEntryPointVersion>>;
   checkGasSponsorshipEligibility: <
-    TContext extends Record<string, any> | undefined =
-      | Record<string, any>
+    TContext extends UserOperationContext | undefined =
+      | UserOperationContext
       | undefined
   >(
     args: SendUserOperationParameters<TAccount, TContext>
@@ -132,8 +133,8 @@ export const smartAccountClientActions: <
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   client: Client<TTransport, TChain, TAccount>

--- a/packages/core/src/client/smartAccountClient.ts
+++ b/packages/core/src/client/smartAccountClient.ts
@@ -12,6 +12,7 @@ import {
 } from "viem";
 import { z } from "zod";
 import type { SmartContractAccount } from "../account/smartContractAccount.js";
+import type { UserOperationContext } from "../actions/smartAccount/types.js";
 import { AccountNotFoundError } from "../errors/account.js";
 import { ChainNotFoundError } from "../errors/client.js";
 import { middlewareActions } from "../middleware/actions.js";
@@ -37,8 +38,8 @@ export type SmartAccountClientConfig<
   account extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Prettify<
   Pick<
@@ -67,8 +68,8 @@ export type SmartAccountClientActions<
   account extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = BaseSmartAccountClientActions<chain, account, context> &
   BundlerActions &
@@ -84,8 +85,8 @@ export type SmartAccountClient<
     | undefined,
   actions extends Record<string, unknown> = Record<string, unknown>,
   rpcSchema extends RpcSchema = SmartAccountClientRpcSchema,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Prettify<
   Client<
@@ -104,8 +105,8 @@ export type BaseSmartAccountClient<
   account extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  context extends Record<string, any> | undefined =
-    | Record<string, any>
+  context extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Prettify<
   Client<
@@ -125,8 +126,8 @@ export function createSmartAccountClient<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   config: SmartAccountClientConfig<TTransport, TChain, TAccount, TContext>
@@ -243,8 +244,8 @@ export function createSmartAccountClientFromExisting<
     TContext
   > = SmartAccountClientActions<TChain, TAccount>,
   TRpcSchema extends SmartAccountClientRpcSchema = SmartAccountClientRpcSchema,
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 >(
   config: Omit<

--- a/packages/core/src/client/types.ts
+++ b/packages/core/src/client/types.ts
@@ -1,6 +1,7 @@
 import type { Address } from "abitype";
 import type { Hash, Hex } from "viem";
 import type { z } from "zod";
+import type { UserOperationContext } from "../actions/smartAccount/types.js";
 import type { EntryPointVersion } from "../entrypoint/types.js";
 import type {
   ClientMiddleware,
@@ -32,8 +33,8 @@ export type UpgradeToData = {
 //#endregion UpgradeToData
 
 export type ClientMiddlewareConfig<
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = Omit<
   Partial<ClientMiddleware<TContext>>,

--- a/packages/core/src/middleware/types.ts
+++ b/packages/core/src/middleware/types.ts
@@ -2,6 +2,7 @@ import type {
   GetEntryPointFromAccount,
   SmartContractAccount,
 } from "../account/smartContractAccount";
+import type { UserOperationContext } from "../actions/smartAccount/types";
 import type {
   UserOperationFeeOptions,
   UserOperationOverrides,
@@ -12,8 +13,8 @@ import type { MiddlewareClient } from "./actions";
 
 //#region ClientMiddlewareFn
 export type ClientMiddlewareFn<
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = <
   TAccount extends SmartContractAccount,
@@ -33,8 +34,8 @@ export type ClientMiddlewareFn<
 
 //#region ClientMiddleware
 export type ClientMiddleware<
-  TContext extends Record<string, any> | undefined =
-    | Record<string, any>
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
     | undefined
 > = {
   dummyPaymasterAndData: ClientMiddlewareFn<TContext>;

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts
@@ -35,6 +35,10 @@ export const PluginActionsGenPhase: Phase = async (input) => {
     name: "EntryPointVersion",
     isType: true,
   });
+  addImport("@alchemy/aa-core", {
+    name: "UserOperationContext",
+    isType: true,
+  });
   addImport("@alchemy/aa-core", { name: "AccountNotFoundError" });
   addImport("@alchemy/aa-core", { name: "isSmartAccountClient" });
   addImport("@alchemy/aa-core", { name: "IncompatibleClientError" });
@@ -92,7 +96,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
   addType(
     `ExecutionActions<
       TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined,
-      TContext extends Record<string, any> | undefined = Record<string, any> | undefined,
+      TContext extends UserOperationContext | undefined = UserOperationContext | undefined,
       TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
     >`,
     dedent`{
@@ -113,7 +117,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
       TAccount extends SmartContractAccount | undefined =
           | SmartContractAccount
           | undefined,
-      TContext extends Record<string, any> | undefined = Record<string, any> | undefined>`,
+      TContext extends UserOperationContext | undefined = UserOperationContext | undefined>`,
     dedent`
     ExecutionActions<TAccount, TContext> & ManagementActions<TAccount, TContext> & ReadAndEncodeActions${
       hasReadMethods ? "<TAccount>" : ""
@@ -129,7 +133,7 @@ export const PluginActionsGenPhase: Phase = async (input) => {
         TAccount extends SmartContractAccount | undefined =
             | SmartContractAccount
             | undefined,
-        TContext extends Record<string, any> | undefined = Record<string, any> | undefined
+        TContext extends UserOperationContext | undefined = UserOperationContext | undefined
     >(
       client: Client<TTransport, TChain, TAccount>
     ) => ${

--- a/packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts
+++ b/packages/plugingen/src/commands/generate/phases/plugin-actions/management-actions.ts
@@ -26,7 +26,7 @@ export const ManagementActionsGenPhase: Phase = async (input) => {
     addType(
       `ManagementActions<
         TAccount extends SmartContractAccount | undefined = SmartContractAccount | undefined,
-        TContext extends Record<string, any> | undefined = Record<string,any> | undefined,
+        TContext extends UserOperationContext | undefined = Record<string,any> | undefined,
         TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
       >`,
       dedent`{
@@ -127,6 +127,10 @@ const addImports = (
   });
   addImport("@alchemy/aa-accounts", {
     name: "FunctionReference",
+    isType: true,
+  });
+  addImport("@alchemy/aa-accounts", {
+    name: "UserOperationContext",
     isType: true,
   });
   addImport("@alchemy/aa-core", { name: "GetContextParameter", isType: true });


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates type annotations to use `UserOperationContext` instead of `Record<string, any`.

### Detailed summary
- Updated type annotations to use `UserOperationContext` in various files
- Added imports for `UserOperationContext` in relevant files

> The following files were skipped due to too many changes: `packages/alchemy/src/client/decorators/smartAccount.ts`, `packages/alchemy/src/client/internal/smartAccountClientFromRpc.ts`, `packages/accounts/plugingen/phases/plugin-actions/index.ts`, `packages/core/src/client/decorators/smartAccountClient.ts`, `packages/plugingen/src/commands/generate/phases/plugin-actions/index.ts`, `packages/accounts/src/msca/plugins/multisig/plugin.ts`, `packages/accounts/src/msca/plugins/multi-owner/plugin.ts`, `packages/accounts/src/msca/plugins/session-key/plugin.ts`, `packages/alchemy/src/client/smartAccountClient.ts`, `packages/core/src/actions/smartAccount/types.ts`, `packages/core/src/client/smartAccountClient.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->