### PR TITLE
feat: move signUserOperation middleware step out of asyncPipe

### DIFF
--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -1,8 +1,6 @@
 // Add you exports here, make sure to export types separately from impls and use the `type` keyword when exporting them
 // Don't use wildcard exports, instead use named exports
 
-export * from "./light-account/utils.js";
-
 //light-account exports
 export type * from "./light-account/accounts/account.js";
 export { createLightAccount } from "./light-account/accounts/account.js";
@@ -10,6 +8,14 @@ export { transferOwnership as transferLightAccountOwnership } from "./light-acco
 export { createLightAccountClient } from "./light-account/clients/lightAccount.js";
 export type * from "./light-account/decorators/lightAccount.js";
 export { lightAccountClientActions } from "./light-account/decorators/lightAccount.js";
+export type * from "./light-account/types.js";
+export {
+  AccountVersionRegistry,
+  LightAccountUnsupported1271Factories,
+  LightAccountUnsupported1271Impls,
+  defaultLightAccountVersion,
+  getLightAccountVersionDef,
+} from "./light-account/utils.js";
 
 //multi-owner-light-account exports
 export type * from "./light-account/accounts/multiOwner.js";

--- a/packages/accounts/src/msca/e2e-tests/multisig-modular-account.e2e.test.ts
+++ b/packages/accounts/src/msca/e2e-tests/multisig-modular-account.e2e.test.ts
@@ -2,20 +2,20 @@ import {
   LocalAccountSigner,
   LogLevel,
   Logger,
+  parseFactoryAddressFromAccountInitCode,
   sepolia,
   wrapSignatureWith6492,
-  parseFactoryAddressFromAccountInitCode,
   type SmartAccountSigner,
   type UserOperationFeeOptions,
 } from "@alchemy/aa-core";
 import {
+  createPublicClient,
+  fromHex,
   http,
+  pad,
   type Address,
   type Chain,
   type HDAccount,
-  createPublicClient,
-  fromHex,
-  pad,
 } from "viem";
 import { createMultisigModularAccountClient } from "../client.js";
 import { formatSignatures } from "../plugins/multisig/index.js";
@@ -239,7 +239,7 @@ describe("Multisig Modular Account Tests", async () => {
     );
 
     const wrappedSig = wrapSignatureWith6492({
-      factoryAddress: provider1.account.getFactoryAddress(),
+      factoryAddress: await provider1.account.getFactoryAddress(),
       factoryCalldata,
       signature: combined,
     });
@@ -327,7 +327,7 @@ describe("Multisig Modular Account Tests", async () => {
     );
 
     const wrappedSig = wrapSignatureWith6492({
-      factoryAddress: provider1.account.getFactoryAddress(),
+      factoryAddress: await provider1.account.getFactoryAddress(),
       factoryCalldata,
       signature: combined,
     });
@@ -537,6 +537,7 @@ const givenConnectedProvider = async ({
         ...feeOptions,
         maxFeePerGas: { multiplier: 1.5 },
         maxPriorityFeePerGas: { multiplier: 1.5 },
+        preVerificationGas: { multiplier: 1.5 },
       },
       txMaxRetries: 100,
     },

--- a/packages/accounts/src/msca/plugins/multisig/actions/signMultisigUserOperation.ts
+++ b/packages/accounts/src/msca/plugins/multisig/actions/signMultisigUserOperation.ts
@@ -8,12 +8,12 @@ import {
 } from "@alchemy/aa-core";
 import { type Chain, type Client, type Transport } from "viem";
 import { MultisigMissingSignatureError } from "../../../errors.js";
+import { combineSignatures, getSignerType } from "../index.js";
 import {
-  type Signature,
   type SignMultisigUserOperationParams,
   type SignMultisigUserOperationResult,
+  type Signature,
 } from "../types.js";
-import { combineSignatures, getSignerType } from "../index.js";
 
 export async function signMultisigUserOperation<
   TTransport extends Transport = Transport,

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -34,7 +34,7 @@ export async function dropAndReplaceUserOperation<
   client: Client<TTransport, TChain, TAccount>,
   args: DropAndReplaceUserOperationParameters<TAccount, TContext>
 ): Promise<SendUserOperationResult<TEntryPointVersion>> {
-  const { account = client.account, uoToDrop, overrides } = args;
+  const { account = client.account, uoToDrop, overrides, context } = args;
   if (!account) {
     throw new AccountNotFoundError();
   }
@@ -105,5 +105,6 @@ export async function dropAndReplaceUserOperation<
   return _sendUserOperation(client, {
     uoStruct: uoToSend,
     account,
+    context,
   });
 }

--- a/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
+++ b/packages/core/src/actions/smartAccount/internal/runMiddlewareStack.ts
@@ -66,8 +66,7 @@ export async function _runMiddlewareStack<
     overridePaymasterData
       ? overridePaymasterDataMiddleware
       : client.middleware.paymasterAndData,
-    client.middleware.userOperationSimulator,
-    client.middleware.signUserOperation
+    client.middleware.userOperationSimulator
   )(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
 
   return resolveProperties<

--- a/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/internal/sendUserOperation.ts
@@ -10,6 +10,7 @@ import { AccountNotFoundError } from "../../../errors/account.js";
 import { ChainNotFoundError } from "../../../errors/client.js";
 import type { UserOperationStruct } from "../../../types";
 import { deepHexlify, resolveProperties } from "../../../utils/index.js";
+import type { GetContextParameter, UserOperationContext } from "../types";
 
 export async function _sendUserOperation<
   TTransport extends Transport = Transport,
@@ -17,14 +18,18 @@ export async function _sendUserOperation<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
+    | undefined,
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: BaseSmartAccountClient<TTransport, TChain, TAccount>,
   args: {
     uoStruct: UserOperationStruct<TEntryPointVersion>;
-  } & GetAccountParameter<TAccount>
+  } & GetAccountParameter<TAccount> &
+    GetContextParameter<TContext>
 ): Promise<SendUserOperationResult<TEntryPointVersion>> {
-  const { account = client.account } = args;
+  const { account = client.account, context } = args;
   if (!account) {
     throw new AccountNotFoundError();
   }
@@ -38,6 +43,7 @@ export async function _sendUserOperation<
       ...args,
       account,
       client,
+      context,
     })
     .then(resolveProperties)
     .then(deepHexlify);

--- a/packages/core/src/actions/smartAccount/sendTransaction.ts
+++ b/packages/core/src/actions/smartAccount/sendTransaction.ts
@@ -61,6 +61,7 @@ export async function sendTransaction<
   const { hash } = await _sendUserOperation(client, {
     account: account as SmartContractAccount,
     uoStruct,
+    context,
   });
 
   return waitForUserOperationTransaction(client, { hash });

--- a/packages/core/src/actions/smartAccount/sendTransactions.ts
+++ b/packages/core/src/actions/smartAccount/sendTransactions.ts
@@ -19,7 +19,7 @@ export async function sendTransactions<
   client: Client<TTransport, TChain, TAccount>,
   args: SendTransactionsParameters<TAccount, TContext>
 ): Promise<Hex> {
-  const { requests, overrides, account = client.account } = args;
+  const { requests, overrides, account = client.account, context } = args;
   if (!account) {
     throw new AccountNotFoundError();
   }
@@ -41,6 +41,7 @@ export async function sendTransactions<
   const { hash } = await _sendUserOperation(client, {
     account,
     uoStruct,
+    context,
   });
 
   return waitForUserOperationTransaction(client, { hash });

--- a/packages/core/src/actions/smartAccount/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/sendUserOperation.ts
@@ -31,7 +31,7 @@ export const sendUserOperation: <
   client,
   args
 ) => {
-  const { account = client.account } = args;
+  const { account = client.account, context } = args;
 
   if (!account) {
     throw new AccountNotFoundError();
@@ -49,5 +49,6 @@ export const sendUserOperation: <
   return _sendUserOperation(client, {
     account,
     uoStruct,
+    context,
   });
 };


### PR DESCRIPTION
From the multisig pr https://github.com/alchemyplatform/aa-sdk/pull/519, we moved the user operation signing step to happen within the smart account client middleware pipeline. This is actually incorrect thing to do.

The reason is that build user op method of client should not return already signed user operation. running middleware stack is involved not only for sending user op, but for drop and replace user op (runs middleware stack twice) or checking gas sponsorship eligibility, etc.

We should not cause the signer of the account to sign the user op until user specifies explicit intent to send the user operation to the bundler for transactions.

cc: @moldy530 @adam-alchemy @howydev @dphilipson @jaypaik 

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `context` parameter to various functions in the smart account module.

### Detailed summary
- Added `context` parameter to functions `sendTransaction`, `sendUserOperation`, `runMiddlewareStack`, `sendTransactions`, `dropAndReplaceUserOperation`, and `_sendUserOperation`
- Updated function `signUserOperation` to use middleware for signing
- Imported and exported functions `combineSignatures` and `getSignerType` in `signMultisigUserOperation.ts`
- Removed unused imports in `signMultisigUserOperation.ts`
- Updated `multisig-modular-account.e2e.test.ts` to await `getFactoryAddress`
- Added `preVerificationGas` to `givenConnectedProvider` function
- Updated `_sendUserOperation` to use middleware for signing and added `context` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->