### PR TITLE
refactor: moves title for commitlint to be an env var

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -19,7 +19,9 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Use commitlint to check PR title
-        run: echo "${{ github.event.pull_request.title }}" | yarn commitlint
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$TITLE" | yarn commitlint
 
   build_and_lint_and_test:
     name: Lint and Build and Test


### PR DESCRIPTION
# Pull Request Checklist

- [x] ~Did you add new tests and confirm existing tests pass? (`yarn test`)~ N/A
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [-] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the GitHub Actions workflow by storing the pull request title in an environment variable for commitlint usage.

### Detailed summary
- Stored pull request title in an environment variable for commitlint usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->