### PR TITLE
fix: addes permissions to write to repo for publish

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,6 +33,12 @@ jobs:
   build_and_test_deploy:
     name: Build and Test and Deploy
     runs-on: ubuntu-latest
+
+    # Needed for Publishing
+    permissions:
+      contents: write  
+      packages: write
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding permissions for publishing packages in the GitHub Actions workflow.

### Detailed summary
- Added permissions for writing contents and packages
- Updated the workflow to include necessary permissions for publishing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->