### PR TITLE
feat: add js docs to account provider undefined error

### DIFF
--- a/packages/alchemy/src/react/errors.ts
+++ b/packages/alchemy/src/react/errors.ts
@@ -1,5 +1,9 @@
 import { BaseError } from "../errors/base.js";
 
+/**
+ * Error thrown when a hook is called without a AlchemyAccountProvider.
+ * @param hookName The name of the hook.
+ */
 export class NoAlchemyAccountContextError extends BaseError {
   constructor(hookName: string) {
     super(`${hookName} must be used within a AlchemyAccountProvider`);


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new custom error class `NoAlchemyAccountContextError` for when a hook is called without an `AlchemyAccountProvider`.

### Detailed summary
- Added a new custom error class `NoAlchemyAccountContextError`
- Constructor takes the hook name as a parameter
- Error message includes the hook name and a reference to `AlchemyAccountProvider`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->