### PR TITLE
docs: doc site styling for increasing sidebar width to prevent text cutoff

### DIFF
--- a/site/.vitepress/theme/style.css
+++ b/site/.vitepress/theme/style.css
@@ -12,7 +12,7 @@
  *
  * Each colors have exact same color scale system with 3 levels of solid
  * colors with different brightness, and 1 soft color.
- * 
+ *
  * - `XXX-1`: The most solid color used mainly for colored text. It must
  *   satisfy the contrast ratio against when used on top of `XXX-soft`.
  *
@@ -167,4 +167,12 @@
 
 .transparent-text-fill {
   -webkit-text-fill-color: transparent;
+}
+
+/**
+ * Component: Sidebar
+ * -------------------------------------------------------------------------- */
+
+:root {
+  --vp-sidebar-width: 360px;
 }


### PR DESCRIPTION
Now the long texts in the sidebar is not cutoff.

- Before:
<img width="369" alt="Screenshot 2024-04-21 at 9 42 07 PM" src="https://github.com/alchemyplatform/aa-sdk/assets/3278577/13e12710-cce4-4591-901a-0689c454ac93">

- After:
<img width="1171" alt="Screenshot 2024-04-21 at 9 39 09 PM" src="https://github.com/alchemyplatform/aa-sdk/assets/3278577/f17cca9c-49ac-4d10-94ab-c4b92dcb5ba6">
<img width="1206" alt="Screenshot 2024-04-21 at 9 38 59 PM" src="https://github.com/alchemyplatform/aa-sdk/assets/3278577/fc71361a-959b-4878-a702-41ebd8b57302">


# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the styling for the Sidebar component in the VitePress theme.

### Detailed summary
- Added custom CSS variable for sidebar width in `style.css`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->