### PR TITLE
chore: fix docs auto deploy so it only runs if code hasn't changed too

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "site/**"
-      - ".github/workflows/deploy-site.yml"
-      - "!packages/**"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -21,10 +17,37 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'site/**'
+              - '.github/workflows/deploy-site.yml'
+            code:
+              - 'packages/**'
   # Build job
   build:
+    needs: changes
     runs-on: ubuntu-latest
     name: Build
+    if: ${{ needs.changes.outputs.docs == 'true' && needs.changes.outputs.code == 'false' }}
     env:
       NO_BASE_PATH: ${{ inputs.no_base_path }}
     steps:
@@ -61,6 +84,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ needs.changes.outputs.docs == 'true' && needs.changes.outputs.code == 'false' }}
     needs: build
     runs-on: ubuntu-latest
     name: Deploy


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow to deploy specific paths based on changes in documentation and code.

### Detailed summary
- Added a new job `changes` to filter paths based on changes
- Updated the `build` job to run only if docs changed
- Updated the `deploy` job to run only if docs changed

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->