### PR TITLE
refactor: leverage signUserOperation within the various methods for multisig

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "es2021": true,
     "node": true
   },
+  "plugins": ["import"],
   "parserOptions": {
     "sourceType": "module"
   },

--- a/packages/accounts/src/msca/account/multisigAccount.ts
+++ b/packages/accounts/src/msca/account/multisigAccount.ts
@@ -27,7 +27,11 @@ export const MULTISIG_ACCOUNT_SOURCE = "MultisigModularAccount";
 
 export type MultisigModularAccount<
   TSigner extends SmartAccountSigner = SmartAccountSigner
-> = SmartContractAccountWithSigner<typeof MULTISIG_ACCOUNT_SOURCE, TSigner> & {
+> = SmartContractAccountWithSigner<
+  typeof MULTISIG_ACCOUNT_SOURCE,
+  TSigner,
+  "0.6.0"
+> & {
   getLocalThreshold: () => bigint;
 };
 

--- a/packages/accounts/src/msca/plugins/multisig/actions/signMultisigUserOperation.ts
+++ b/packages/accounts/src/msca/plugins/multisig/actions/signMultisigUserOperation.ts
@@ -8,11 +8,10 @@ import {
 } from "@alchemy/aa-core";
 import { type Chain, type Client, type Transport } from "viem";
 import { MultisigMissingSignatureError } from "../../../errors.js";
-import { combineSignatures, getSignerType } from "../index.js";
+import { combineSignatures, splitAggregatedSignature } from "../index.js";
 import {
   type SignMultisigUserOperationParams,
   type SignMultisigUserOperationResult,
-  type Signature,
 } from "../types.js";
 
 export async function signMultisigUserOperation<
@@ -47,32 +46,48 @@ export async function signMultisigUserOperation<
     throw new MultisigMissingSignatureError();
   }
 
-  const ep = account.getEntryPoint();
-  const uoHash = ep.getUserOperationHash(userOperationRequest);
-  const signature = await account.signUserOperationHash(uoHash);
   const signerAddress = await account.getSigner().getAddress();
-  const signerType = await getSignerType({
-    client,
-    signature,
-    signer: account.getSigner(),
+
+  const signedRequest = await client.signUserOperation({
+    account,
+    uoStruct: userOperationRequest,
+    context: {
+      aggregatedSignature: combineSignatures({
+        signatures,
+        upperLimitMaxFeePerGas: userOperationRequest.maxFeePerGas,
+        upperLimitMaxPriorityFeePerGas:
+          userOperationRequest.maxPriorityFeePerGas,
+        upperLimitPvg: userOperationRequest.preVerificationGas,
+        usingMaxValues: false,
+      }),
+      signatures,
+      userOpSignatureType: "UPPERLIMIT",
+    },
   });
 
-  const signatureObj: Signature = {
-    signerType,
-    signer: signerAddress,
-    signature,
-    userOpSigType: "UPPERLIMIT",
-  };
+  const splitSignatures = await splitAggregatedSignature({
+    account,
+    request: signedRequest,
+    aggregatedSignature: signedRequest.signature,
+    // split works on the assumption that we have t - 1 signatures
+    // we have signatures.length + 1 signatures now, so we need sl + 1 + 1
+    threshold: signatures.length + 2,
+  });
+
+  const signatureObj = splitSignatures.signatures.find(
+    (x) => x.signer === signerAddress
+  );
+
+  if (!signatureObj) {
+    // TODO: strongly type this
+    throw new Error(
+      "INTERNAL ERROR: signature not found in split signatures, this is an internal bug please report"
+    );
+  }
 
   return {
     signatureObj,
-    signature,
-    aggregatedSignature: combineSignatures({
-      signatures: [...signatures, signatureObj],
-      upperLimitMaxFeePerGas: userOperationRequest.maxFeePerGas,
-      upperLimitMaxPriorityFeePerGas: userOperationRequest.maxPriorityFeePerGas,
-      upperLimitPvg: userOperationRequest.preVerificationGas,
-      usingMaxValues: false,
-    }),
+    signature: signatureObj.signature,
+    aggregatedSignature: signedRequest.signature,
   };
 }

--- a/packages/accounts/src/msca/plugins/multisig/extension.ts
+++ b/packages/accounts/src/msca/plugins/multisig/extension.ts
@@ -1,5 +1,6 @@
 import {
   type GetAccountParameter,
+  type GetEntryPointFromAccount,
   type IsUndefined,
   type SendUserOperationParameters,
   type SmartContractAccount,
@@ -42,7 +43,9 @@ export type MultisigPluginActions<
 
   proposeUserOperation: (
     params: SendUserOperationParameters<TAccount, undefined>
-  ) => Promise<ProposeUserOperationResult<TAccount>>;
+  ) => Promise<
+    ProposeUserOperationResult<TAccount, GetEntryPointFromAccount<TAccount>>
+  >;
 
   signMultisigUserOperation: (
     params: SignMultisigUserOperationParams<TAccount>

--- a/packages/accounts/src/msca/plugins/multisig/middleware.ts
+++ b/packages/accounts/src/msca/plugins/multisig/middleware.ts
@@ -9,22 +9,32 @@ import {
   type UserOperationRequest_v6,
   type UserOperationRequest_v7,
 } from "@alchemy/aa-core";
-import { isHex, type Hex } from "viem";
+import { type Hex } from "viem";
 import { isMultisigModularAccount } from "../../account/multisigAccount.js";
 import {
   InvalidContextSignatureError,
   MultisigAccountExpectedError,
 } from "../../errors.js";
-import { getThreshold } from "./actions/getThreshold.js";
 import {
   combineSignatures,
   getSignerType,
   splitAggregatedSignature,
+  type MultisigUserOperationContext,
 } from "./index.js";
 
-export const multisigSignatureMiddleware: ClientMiddlewareFn<{
-  signature: Hex;
-}> = async (struct, { account, client, context }) => {
+export const multisigSignatureMiddleware: ClientMiddlewareFn<
+  MultisigUserOperationContext
+> = async (struct, { account, client, context }) => {
+  // if the signature is not present, this has to be UPPERLIMIT because it's likely a propose operation
+  if (
+    !context ||
+    (context.userOpSignatureType === "ACTUAL" &&
+      !context.signatures &&
+      !context.aggregatedSignature)
+  ) {
+    throw new InvalidContextSignatureError();
+  }
+
   if (!isSmartAccountWithSigner(account)) {
     throw new SmartAccountWithSignerRequiredError();
   }
@@ -34,6 +44,7 @@ export const multisigSignatureMiddleware: ClientMiddlewareFn<{
   }
 
   const resolvedStruct = await resolveProperties(struct);
+
   const request = deepHexlify(resolvedStruct);
   if (!isValidRequest(request)) {
     throw new InvalidUserOperationError(resolvedStruct);
@@ -49,36 +60,50 @@ export const multisigSignatureMiddleware: ClientMiddlewareFn<{
     signer: account.getSigner(),
   });
 
-  // TODO: this needs to actually check the account's installed plugins and fetch the multisig plugin address
-  const threshold = await getThreshold(client, { account });
-
-  // if there is no override, then return the dummy signature
-  if (context?.signature == null) {
+  // then this is a propose operation
+  if (
+    context.userOpSignatureType === "UPPERLIMIT" &&
+    context?.signatures?.length == null &&
+    context?.aggregatedSignature == null
+  ) {
     return {
       ...resolvedStruct,
-      signature: await account.getDummySignature(),
+      signature: combineSignatures({
+        signatures: [
+          {
+            signature,
+            signer: await account.getSigner().getAddress(),
+            signerType,
+            userOpSigType: context.userOpSignatureType,
+          },
+        ],
+        upperLimitMaxFeePerGas: request.maxFeePerGas,
+        upperLimitMaxPriorityFeePerGas: request.maxPriorityFeePerGas,
+        upperLimitPvg: request.preVerificationGas,
+        usingMaxValues: false,
+      }),
     };
   }
 
-  if (!isHex(context.signature)) {
+  if (context.aggregatedSignature == null || context.signatures == null) {
     throw new InvalidContextSignatureError();
   }
 
+  // otherwise this is a sign operation
   const {
     upperLimitPvg,
     upperLimitMaxFeePerGas,
     upperLimitMaxPriorityFeePerGas,
-    signatures,
   } = await splitAggregatedSignature({
-    aggregatedSignature: context.signature,
-    threshold: Number(threshold),
+    aggregatedSignature: context.aggregatedSignature,
+    threshold: context.signatures.length + 1,
     account,
     request,
   });
 
   const finalSignature = combineSignatures({
-    signatures: signatures.concat({
-      userOpSigType: "ACTUAL",
+    signatures: context.signatures.concat({
+      userOpSigType: context.userOpSignatureType,
       signerType,
       signature,
       signer: await account.getSigner().getAddress(),

--- a/packages/accounts/src/msca/plugins/multisig/types.ts
+++ b/packages/accounts/src/msca/plugins/multisig/types.ts
@@ -46,6 +46,14 @@ export type ProposeUserOperationResult<
   signatureObj: Signature;
 };
 
-export type MultisigUserOperationContext = {
-  signature: Hex;
-};
+export type MultisigUserOperationContext =
+  | {
+      userOpSignatureType: Extract<UserOpSignatureType, "UPPERLIMIT">;
+      aggregatedSignature?: Hex;
+      signatures?: Signature[];
+    }
+  | {
+      aggregatedSignature: Hex;
+      signatures: Signature[];
+      userOpSignatureType: Extract<UserOpSignatureType, "ACTUAL">;
+    };

--- a/packages/alchemy/src/react/hooks/useClientActions.ts
+++ b/packages/alchemy/src/react/hooks/useClientActions.ts
@@ -81,6 +81,9 @@ export type ClientActionParameters<
  * and await them in your UX. This is particularly useful for using Plugins
  * with Modular Accounts.
  *
+ * @param args the hooks arguments highlighted below
+ * @param args.client the smart account client returned from {@link useSmartAccountClient}
+ * @param args.actions the smart account client decorator you want to execute actions from
  * @example
  * ```tsx
  * const Foo = () => {
@@ -96,6 +99,7 @@ export type ClientActionParameters<
  *  });
  * };
  * ```
+ * @returns an object containing methods to execute the actions as well loading and error states (see: {@link UseClientActionsResult})
  */
 export function useClientActions<
   TTransport extends Transport = Transport,
@@ -103,14 +107,10 @@ export function useClientActions<
   TActions extends { [x: string]: (...args: any[]) => any } = {
     [x: string]: (...args: any[]) => any;
   }
->({
-  client,
-  actions,
-}: UseClientActionsProps<
-  TTransport,
-  TChain,
-  TActions
->): UseClientActionsResult<TActions> {
+>(
+  args: UseClientActionsProps<TTransport, TChain, TActions>
+): UseClientActionsResult<TActions> {
+  const { actions, client } = args;
   const {
     mutate,
     isPending: isExecutingAction,

--- a/packages/core/src/actions/smartAccount/buildUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperation.ts
@@ -10,7 +10,7 @@ import type { UserOperationStruct } from "../../types.js";
 import { conditionalReturn, type Deferrable } from "../../utils/index.js";
 import { _runMiddlewareStack } from "./internal/runMiddlewareStack.js";
 import type {
-  SendUserOperationParameters,
+  BuildUserOperationParameters,
   UserOperationContext,
 } from "./types";
 
@@ -26,7 +26,7 @@ export async function buildUserOperation<
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendUserOperationParameters<TAccount, TContext>
+  args: BuildUserOperationParameters<TAccount, TContext, TEntryPointVersion>
 ): Promise<UserOperationStruct<TEntryPointVersion>> {
   const { account = client.account, overrides, uo, context } = args;
   if (!account) {

--- a/packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts
@@ -19,6 +19,81 @@ import type {
 import { buildUserOperation } from "./buildUserOperation.js";
 import type { UserOperationContext } from "./types.js";
 
+/**
+ * Performs [`buildUserOperationFromTx`](./buildUserOperationFromTx.md) in batch and builds into a single, yet to be signed `UserOperation` (UO) struct. The output user operation struct will be filled with all gas fields (and paymaster data if a paymaster is used) based on the transactions data (`to`, `data`, `value`, `maxFeePerGas`, `maxPriorityFeePerGas`) computed using the configured [`ClientMiddlewares`](/packages/aa-core/smart-account-client/middleware/index) on the `SmartAccountClient`
+ * 
+ * @example
+ * ```ts
+import type { RpcTransactionRequest } from "viem";
+import { smartAccountClient } from "./smartAccountClient";
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+ * @param skipSigning
+// [!code focus:99]
+// buildUserOperationFromTxs converts traditional Ethereum transactions in batch and returns
+// the unsigned user operation struct after constructing the user operation struct
+// through the middleware pipeline
+const requests: RpcTransactionRequest[] = [
+  {
+    from, // ignored
+    to,
+    data: encodeFunctionData({
+      abi: ContractABI.abi,
+      functionName: "func",
+      args: [arg1, arg2, ...],
+    }),
+  },
+  {
+    from, // ignored
+    to,
+    data: encodeFunctionData({
+      abi: ContractABI.abi,
+      functionName: "func",
+      args: [arg1, arg2, ...],
+    }),
+  },
+  ...
+  {
+    from, // ignored
+    to,
+    data: encodeFunctionData({
+      abi: ContractABI.abi,
+      functionName: "func",
+      args: [arg1, arg2, ...],
+    }),
+  },
+];
+const uoStruct = await smartAccountClient.buildUserOperationFromTxs({
+  requests,
+});
+ 
+// signUserOperation signs the above unsigned user operation struct built
+// using the account connected to the smart account client
+const request = await smartAccountClient.signUserOperation({ uoStruct });
+ 
+// You can use the BundlerAction `sendRawUserOperation` (packages/core/src/actions/bundler/sendRawUserOperation.ts)
+// to send the signed user operation request to the bundler, requesting the bundler to send the signed uo to the
+// EntryPoint contract pointed at the entryPoint address parameter
+const entryPointAddress = client.account.getEntryPoint().address;
+const uoHash = await smartAccountClient.sendRawUserOperation({
+  request,
+  entryPoint: entryPointAddress,
+});
+```
+ * 
+ * @param client the smart account client to use for RPC requests
+ * @param args {@link SendTransactionParameters}
+ * @param overrides optional {@link UserOperationOverrides} to use for any of the fields
+ * @param context if the smart account client requires additinoal context for building UOs
+ * @returns a Promise containing the built user operation
+ */
 export async function buildUserOperationFromTx<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =

--- a/packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts
+++ b/packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts
@@ -11,20 +11,94 @@ import type { UserOperationOverrides } from "../../types";
 import { bigIntMax } from "../../utils/index.js";
 import { buildUserOperation } from "./buildUserOperation.js";
 import type {
+  BuildTransactionParameters,
   BuildUserOperationFromTransactionsResult,
-  SendTransactionsParameters,
+  UserOperationContext,
 } from "./types";
 
+/**
+ * Performs {@link buildUserOperationFromTx} in batch and builds into a single,
+ * yet to be signed `UserOperation` (UO) struct. The output user operation struct
+ * will be filled with all gas fields (and paymaster data if a paymaster is used)
+ * based on the transactions data (`to`, `data`, `value`, `maxFeePerGas`,
+ * `maxPriorityFeePerGas`) computed using the configured
+ * [`ClientMiddlewares`](/packages/aa-core/smart-account-client/middleware/index) on the `SmartAccountClient`
+ * 
+ * @example
+ * ```ts
+ * import type { RpcTransactionRequest } from "viem";
+import { smartAccountClient } from "./smartAccountClient";
+// [!code focus:99]
+// buildUserOperationFromTxs converts traditional Ethereum transactions in batch and returns
+// the unsigned user operation struct after constructing the user operation struct
+// through the middleware pipeline
+const requests: RpcTransactionRequest[] = [
+  {
+    from, // ignored
+    to,
+    data: encodeFunctionData({
+      abi: ContractABI.abi,
+      functionName: "func",
+      args: [arg1, arg2, ...],
+    }),
+  },
+  {
+    from, // ignored
+    to,
+    data: encodeFunctionData({
+      abi: ContractABI.abi,
+      functionName: "func",
+      args: [arg1, arg2, ...],
+    }),
+  },
+  ...
+  {
+    from, // ignored
+    to,
+    data: encodeFunctionData({
+      abi: ContractABI.abi,
+      functionName: "func",
+      args: [arg1, arg2, ...],
+    }),
+  },
+];
+const uoStruct = await smartAccountClient.buildUserOperationFromTxs({
+  requests,
+});
+ 
+// signUserOperation signs the above unsigned user operation struct built
+// using the account connected to the smart account client
+const request = await smartAccountClient.signUserOperation({ uoStruct });
+ 
+// You can use the BundlerAction `sendRawUserOperation` (packages/core/src/actions/bundler/sendRawUserOperation.ts)
+// to send the signed user operation request to the bundler, requesting the bundler to send the signed uo to the
+// EntryPoint contract pointed at the entryPoint address parameter
+const entryPointAddress = client.account.getEntryPoint().address;
+const uoHash = await smartAccountClient.sendRawUserOperation({
+  request,
+  entryPoint: entryPointAddress,
+});
+ * ```
+ *
+ * @param client the smart account client to use to make RPC calls
+ * @param args {@link BuildTransactionParameters} an object containing the requests
+ * to build as well as, the account if not hoisted, the context, the overrides, and
+ * optionally a flag to enable signing of the UO via the underlying middleware
+ * @returns a Promise containing the built user operation
+ */
 export async function buildUserOperationFromTxs<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>,
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
+    | undefined
 >(
   client: Client<TTransport, TChain, TAccount>,
-  args: SendTransactionsParameters<TAccount>
+  args: BuildTransactionParameters<TAccount, TContext, TEntryPointVersion>
 ): Promise<BuildUserOperationFromTransactionsResult<TEntryPointVersion>> {
   const { account = client.account, requests, overrides, context } = args;
   if (!account) {
@@ -80,9 +154,9 @@ export async function buildUserOperationFromTxs<
 
   const uoStruct = await buildUserOperation(client, {
     uo: batch,
-    overrides: _overrides,
     account,
     context,
+    overrides: _overrides,
   });
 
   return {

--- a/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
+++ b/packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts
@@ -10,7 +10,35 @@ import type {
   UserOperationContext,
 } from "./types";
 
-export const checkGasSponsorshipEligibility: <
+/**
+ * This function verifies the eligibility of the connected account for gas sponsorship concerning the upcoming `UserOperation` (UO) that is intended to be sent.
+ * Internally, this method invokes [`buildUserOperation`](./buildUserOperation.md), which navigates through the middleware pipeline, including the `PaymasterMiddleware`. Its purpose is to construct the UO struct meant for transmission to the bundler. Following the construction of the UO struct, this function verifies if the resulting structure contains a non-empty `paymasterAndData` field.
+ * You can utilize this method before sending the user operation to confirm its eligibility for gas sponsorship. Depending on the outcome, it allows you to tailor the user experience accordingly, based on eligibility.
+ *
+ * @example
+ * ```ts
+ * import { smartAccountClient } from "./smartAccountClient";
+// [!code focus:99]
+const eligible = await smartAccountClient.checkGasSponsorshipEligibility({
+  uo: {
+    data: "0xCalldata",
+    target: "0xTarget",
+    value: 0n,
+  },
+});
+ 
+console.log(
+  `User Operation is ${
+    eligible ? "eligible" : "ineligible"
+  } for gas sponsorship.`
+);
+ * ```
+ * 
+ * @param client the smart account client to use for making RPC calls
+ * @param args {@link SendUserOperationParameters} containing the user operation, account, context, and overrides
+ * @returns a Promise containing a boolean indicating if the account is elgibile for sponsorship
+ */
+export function checkGasSponsorshipEligibility<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
@@ -22,8 +50,8 @@ export const checkGasSponsorshipEligibility: <
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: SendUserOperationParameters<TAccount, TContext>
-) => Promise<boolean> = async (client, args) => {
-  const { account = client.account } = args;
+): Promise<boolean> {
+  const { account = client.account, overrides, context } = args;
 
   if (!account) {
     throw new AccountNotFoundError();
@@ -37,7 +65,12 @@ export const checkGasSponsorshipEligibility: <
     );
   }
 
-  return buildUserOperation(client, args)
+  return buildUserOperation(client, {
+    uo: args.uo,
+    account,
+    overrides,
+    context,
+  })
     .then((userOperationStruct) =>
       account.getEntryPoint().version === "0.6.0"
         ? (userOperationStruct as UserOperationStruct<"0.6.0">)
@@ -50,4 +83,4 @@ export const checkGasSponsorshipEligibility: <
             .paymasterData !== null
     )
     .catch(() => false);
-};
+}

--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -106,5 +106,6 @@ export async function dropAndReplaceUserOperation<
     uoStruct: uoToSend,
     account,
     context,
+    overrides: _overrides,
   });
 }

--- a/packages/core/src/actions/smartAccount/sendTransactions.ts
+++ b/packages/core/src/actions/smartAccount/sendTransactions.ts
@@ -36,6 +36,7 @@ export async function sendTransactions<
     requests,
     overrides,
     account,
+    context,
   });
 
   const { hash } = await _sendUserOperation(client, {

--- a/packages/core/src/actions/smartAccount/sendUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/sendUserOperation.ts
@@ -14,7 +14,14 @@ import type {
   UserOperationContext,
 } from "./types.js";
 
-export const sendUserOperation: <
+/**
+ * Sends a user operation or batch of user operations using the connected account. Before executing, sendUserOperation will run the user operation through the middleware pipeline.
+ *
+ * @param client the smart account client to use for RPC requests
+ * @param args {@link SendUserOperationParameters} containg the UO or batch to send, context, overrides, and account if not hoisted on the client
+ * @returns a Promise containing the {@link SendUserOperationResult}
+ */
+export async function sendUserOperation<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends SmartContractAccount | undefined =
@@ -27,10 +34,7 @@ export const sendUserOperation: <
 >(
   client: Client<TTransport, TChain, TAccount>,
   args: SendUserOperationParameters<TAccount, TContext>
-) => Promise<SendUserOperationResult<TEntryPointVersion>> = async (
-  client,
-  args
-) => {
+): Promise<SendUserOperationResult<TEntryPointVersion>> {
   const { account = client.account, context, overrides } = args;
 
   if (!account) {
@@ -45,11 +49,17 @@ export const sendUserOperation: <
     );
   }
 
-  const uoStruct = await buildUserOperation(client, args);
+  const uoStruct = await buildUserOperation(client, {
+    uo: args.uo,
+    account,
+    context,
+    overrides,
+  });
+
   return _sendUserOperation(client, {
     account,
     uoStruct,
     context,
     overrides,
   });
-};
+}

--- a/packages/core/src/actions/smartAccount/signUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/signUserOperation.ts
@@ -9,9 +9,8 @@ import {
   ChainNotFoundError,
   IncompatibleClientError,
 } from "../../errors/client.js";
-import { InvalidUserOperationError } from "../../errors/useroperation.js";
 import type { UserOperationRequest } from "../../types";
-import { deepHexlify, isValidRequest } from "../../utils/index.js";
+import { deepHexlify, resolveProperties } from "../../utils/index.js";
 import type { SignUserOperationParameters } from "./types";
 
 export async function signUserOperation<
@@ -25,7 +24,7 @@ export async function signUserOperation<
   client: Client<TTransport, TChain, TAccount>,
   args: SignUserOperationParameters<TAccount>
 ): Promise<UserOperationRequest<TEntryPointVersion>> {
-  const { account = client.account } = args;
+  const { account = client.account, context } = args;
 
   if (!account) {
     throw new AccountNotFoundError();
@@ -43,14 +42,13 @@ export async function signUserOperation<
     throw new ChainNotFoundError();
   }
 
-  const request = deepHexlify(args.uoStruct);
-  if (!isValidRequest(request)) {
-    throw new InvalidUserOperationError(args.uoStruct);
-  }
-
-  const entryPoint = account.getEntryPoint();
-  request.signature = await account.signUserOperationHash(
-    entryPoint.getUserOperationHash(request)
-  );
-  return request as UserOperationRequest<TEntryPointVersion>;
+  return await client.middleware
+    .signUserOperation(args.uoStruct, {
+      ...args,
+      account,
+      client,
+      context,
+    })
+    .then(resolveProperties)
+    .then(deepHexlify);
 }

--- a/packages/core/src/actions/smartAccount/types.ts
+++ b/packages/core/src/actions/smartAccount/types.ts
@@ -44,15 +44,29 @@ export type SendUserOperationParameters<
   UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendUserOperationParameters
 
+//#region BuildUserOperationParameters
+export type BuildUserOperationParameters<
+  TAccount extends SmartContractAccount | undefined,
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+> = SendUserOperationParameters<TAccount, TContext, TEntryPointVersion>;
+//#endregion BuildUserOperationParameters
+
 //#region SignUserOperationParameters
 export type SignUserOperationParameters<
   TAccount extends SmartContractAccount | undefined =
     | SmartContractAccount
     | undefined,
-  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>,
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
+    | undefined
 > = {
   uoStruct: UserOperationStruct<TEntryPointVersion>;
-} & GetAccountParameter<TAccount>;
+} & GetAccountParameter<TAccount> &
+  GetContextParameter<TContext>;
 //#endregion SignUserOperationParameters
 
 //#region SendTransactionsParameters
@@ -68,6 +82,16 @@ export type SendTransactionsParameters<
   GetContextParameter<TContext> &
   UserOperationOverridesParameter<TEntryPointVersion>;
 //#endregion SendTransactionsParameters
+
+//#region BuildTransactionParameters
+export type BuildTransactionParameters<
+  TAccount extends SmartContractAccount | undefined,
+  TContext extends UserOperationContext | undefined =
+    | UserOperationContext
+    | undefined,
+  TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
+> = SendTransactionsParameters<TAccount, TContext, TEntryPointVersion>;
+//#endregion BuildTransactionParameters
 
 //#region DropAndReplaceUserOperationParameters
 export type DropAndReplaceUserOperationParameters<

--- a/packages/core/src/client/decorators/smartAccountClient.ts
+++ b/packages/core/src/client/decorators/smartAccountClient.ts
@@ -34,7 +34,9 @@ import {
 import { signTypedDataWith6492 } from "../../actions/smartAccount/signTypedDataWith6492.js";
 import { signUserOperation } from "../../actions/smartAccount/signUserOperation.js";
 import type {
+  BuildTransactionParameters,
   BuildUserOperationFromTransactionsResult,
+  BuildUserOperationParameters,
   DropAndReplaceUserOperationParameters,
   SendTransactionsParameters,
   SendUserOperationParameters,
@@ -64,7 +66,7 @@ export type BaseSmartAccountClientActions<
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount> = GetEntryPointFromAccount<TAccount>
 > = {
   buildUserOperation: (
-    args: SendUserOperationParameters<TAccount, TContext>
+    args: BuildUserOperationParameters<TAccount, TContext>
   ) => Promise<UserOperationStruct<TEntryPointVersion>>;
   buildUserOperationFromTx: (
     args: SendTransactionParameters<TChain, TAccount>,
@@ -72,7 +74,7 @@ export type BaseSmartAccountClientActions<
     context?: TContext
   ) => Promise<UserOperationStruct<TEntryPointVersion>>;
   buildUserOperationFromTxs: (
-    args: SendTransactionsParameters<TAccount, TContext>
+    args: BuildTransactionParameters<TAccount, TContext>
   ) => Promise<BuildUserOperationFromTransactionsResult<TEntryPointVersion>>;
   checkGasSponsorshipEligibility: <
     TContext extends UserOperationContext | undefined =
@@ -82,7 +84,7 @@ export type BaseSmartAccountClientActions<
     args: SendUserOperationParameters<TAccount, TContext>
   ) => Promise<boolean>;
   signUserOperation: (
-    args: SignUserOperationParameters<TAccount>
+    args: SignUserOperationParameters<TAccount, TEntryPointVersion, TContext>
   ) => Promise<UserOperationRequest<TEntryPointVersion>>;
   dropAndReplaceUserOperation: (
     args: DropAndReplaceUserOperationParameters<TAccount, TContext>
@@ -98,7 +100,11 @@ export type BaseSmartAccountClientActions<
     args: SendTransactionsParameters<TAccount, TContext>
   ) => Promise<Hex>;
   sendUserOperation: (
-    args: SendUserOperationParameters<TAccount, TContext>
+    args: SendUserOperationParameters<
+      TAccount,
+      TContext,
+      GetEntryPointFromAccount<TAccount>
+    >
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   waitForUserOperationTransaction: (
     args: WaitForTransactionReceiptParameters

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,7 +121,8 @@ export type UserOperationOverrides<
      */
     nonceKey: bigint;
 
-    /** The same state overrides for
+    /**
+     * The same state overrides for
      * [`eth_call`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth#eth-call) method.
      * An address-to-state mapping, where each entry specifies some state to be ephemerally overridden
      * prior to executing the call. State overrides allow you to customize the network state for


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the `import` plugin in ESLint and introduces changes related to user operation context, smart account actions, and transaction parameters.

### Detailed summary
- Added support for the `import` plugin in ESLint configuration
- Updated user operation context types in various files
- Modified smart account actions and parameters handling
- Refactored internal functions for sending user operations

> The following files were skipped due to too many changes: `packages/core/src/client/decorators/smartAccountClient.ts`, `packages/accounts/src/msca/plugins/multisig/actions/proposeUserOperation.ts`, `packages/accounts/src/msca/plugins/multisig/actions/signMultisigUserOperation.ts`, `packages/core/src/actions/smartAccount/checkGasSponsorshipEligibility.ts`, `packages/core/src/actions/smartAccount/buildUserOperationFromTx.ts`, `packages/accounts/src/msca/plugins/multisig/middleware.ts`, `packages/alchemy/e2e-tests/multisig-account.e2e.test.ts`, `packages/accounts/src/msca/e2e-tests/multisig-modular-account.e2e.test.ts`, `packages/core/src/actions/smartAccount/buildUserOperationFromTxs.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->