### PR TITLE
small tweaks for aa-sdk react hooks

### DIFF
--- a/site/react/overview.md
+++ b/site/react/overview.md
@@ -20,7 +20,7 @@ head:
 
 # React Hooks Overview
 
-If you are using Alchemy's RPC and Smart Contract Accounts and building a React application, you can use the React Hooks exported by Account Kit to interact with your Smart Contract Accounts. You're not required to use these hooks to leverage all of the power of Account Kit. The hooks are exported from `@alchemy/aa-alchemy` and can be found within the `@alchemy/aa-alchemy/react` namespace.
+If you are using Smart Contract Accounts and building a React application, you can use the React Hooks exported by Account Kit to interact with your Smart Contract Accounts. You're not required to use these hooks to leverage all of the power of Account Kit. The hooks are exported from `@alchemy/aa-alchemy` and can be found within the `@alchemy/aa-alchemy/react` namespace.
 
 ::: warning
 React hooks are still being developed and the interfaces could change in the future!

--- a/site/react/useUser.md
+++ b/site/react/useUser.md
@@ -20,7 +20,7 @@ head:
 
 # useUser
 
-The `useUser` hook returns the authenticated `User` if the signer is authenticated.
+The `useUser` hook returns the authenticated [`User`](accountkit.alchemy.com/resources/types.html#user) if the signer is authenticated.
 
 ## Import
 


### PR DESCRIPTION
* removing comment about alchemy RPC being required to take advantage of hooks
* reference properties of the user object in the useUser hook

Slack reference: https://alchemyinsights.slack.com/archives/C05SX4YLJJZ/p1713881249940749

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the documentation for `useUser` hook and React Hooks Overview in the Account Kit documentation.

### Detailed summary
- Updated `useUser` hook description with a link to the `User` type documentation.
- Improved description in React Hooks Overview by removing mention of Alchemy's RPC and specifying the usage of React Hooks with Smart Contract Accounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->