### PR TITLE
fix: determine entry point version from light account version

### DIFF
--- a/packages/accounts/src/light-account/accounts/account.ts
+++ b/packages/accounts/src/light-account/accounts/account.ts
@@ -108,7 +108,10 @@ export async function createLightAccount({
   signer,
   initCode,
   version = defaultLightAccountVersion("LightAccount"),
-  entryPoint = getEntryPoint(chain),
+  entryPoint = getEntryPoint(chain, {
+    version: AccountVersionRegistry["LightAccount"][version]
+      .entryPointVersion as any,
+  }),
   accountAddress,
   factoryAddress = AccountVersionRegistry["LightAccount"][version].address[
     chain.id


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `entryPoint` initialization in the `account.ts` file to include the version from `AccountVersionRegistry`.

### Detailed summary
- Updated `entryPoint` initialization to include version from `AccountVersionRegistry`
- Utilized `AccountVersionRegistry` to fetch version and address information for `LightAccount`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->