### PR TITLE
fix: waitForUserOperationTx parameters were incorrect

### DIFF
--- a/packages/core/src/actions/smartAccount/types.ts
+++ b/packages/core/src/actions/smartAccount/types.ts
@@ -86,6 +86,25 @@ export type DropAndReplaceUserOperationParameters<
 //#region WaitForUserOperationTxParameters
 export type WaitForUserOperationTxParameters = {
   hash: Hex;
+  /**
+   * Exponential backoff paramters that can be used to override
+   * the configuration on the client. If not provided, this method
+   * will use the paramters passed via the `opts` parameter on the
+   * smart account client.
+   */
+  retries?: {
+    /**
+     * the base retry interval or delay between requests
+     */
+    intervalMs: number;
+    /**
+     * the multiplier to exponentiate based on the number retries
+     * setting this to one will result in a linear backoff
+     */
+    multiplier: number;
+    /** the maximum number of retries before failing */
+    maxRetries: number;
+  };
 };
 //#endregion WaitForUserOperationTxParameters
 

--- a/packages/core/src/actions/smartAccount/waitForUserOperationTransacation.ts
+++ b/packages/core/src/actions/smartAccount/waitForUserOperationTransacation.ts
@@ -13,8 +13,6 @@ export const waitForUserOperationTransaction: <
   client: Client<TTransport, TChain, any>,
   args: WaitForUserOperationTxParameters
 ) => Promise<Hex> = async (client, args) => {
-  const { hash } = args;
-
   if (!isBaseSmartAccountClient(client)) {
     throw new IncompatibleClientError(
       "BaseSmartAccountClient",
@@ -23,9 +21,18 @@ export const waitForUserOperationTransaction: <
     );
   }
 
-  for (let i = 0; i < client.txMaxRetries; i++) {
+  const {
+    hash,
+    retries = {
+      maxRetries: client.txMaxRetries,
+      intervalMs: client.txRetryIntervalMs,
+      multiplier: client.txRetryMultiplier,
+    },
+  } = args;
+
+  for (let i = 0; i < retries.maxRetries; i++) {
     const txRetryIntervalWithJitterMs =
-      client.txRetryIntervalMs * Math.pow(client.txRetryMultiplier, i) +
+      retries.intervalMs * Math.pow(retries.multiplier, i) +
       Math.random() * 100;
 
     await new Promise((resolve) =>

--- a/packages/core/src/client/decorators/smartAccountClient.ts
+++ b/packages/core/src/client/decorators/smartAccountClient.ts
@@ -6,7 +6,6 @@ import {
   type SendTransactionParameters,
   type Transport,
   type TypedData,
-  type WaitForTransactionReceiptParameters,
 } from "viem";
 import type {
   GetAccountParameter,
@@ -41,6 +40,7 @@ import type {
   SignUserOperationParameters,
   UpgradeAccountParams,
   UserOperationContext,
+  WaitForUserOperationTxParameters,
 } from "../../actions/smartAccount/types";
 import { upgradeAccount } from "../../actions/smartAccount/upgradeAccount.js";
 import { waitForUserOperationTransaction } from "../../actions/smartAccount/waitForUserOperationTransacation.js";
@@ -101,7 +101,7 @@ export type BaseSmartAccountClientActions<
     args: SendUserOperationParameters<TAccount, TContext>
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
   waitForUserOperationTransaction: (
-    args: WaitForTransactionReceiptParameters
+    args: WaitForUserOperationTxParameters
   ) => Promise<Hex>;
   upgradeAccount: (
     args: UpgradeAccountParams<TAccount, TContext>


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `waitForUserOperationTransaction` function in the smart account module by adding support for custom exponential backoff parameters.

### Detailed summary
- Added `retries` object to `WaitForUserOperationTxParameters` for custom backoff settings
- Updated `waitForUserOperationTransaction` function to use custom backoff settings if provided

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->