### PR TITLE
fix: don't set undefined estimates to 0n

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -228,7 +228,7 @@ export interface UserOperationEstimateGasResponse<
    * Note: `eth_estimateUserOperationGas` does not return paymasterPostOpGasLimit.
    */
   paymasterVerificationGasLimit: TEntryPointVersion extends "0.7.0"
-    ? BigNumberish
+    ? BigNumberish | undefined
     : never;
 }
 //#endregion UserOperationEstimateGasResponse

--- a/packages/core/src/utils/userop.ts
+++ b/packages/core/src/utils/userop.ts
@@ -87,10 +87,10 @@ export function isValidFactoryAndData<
  * @param override the override value to apply
  * @returns the new value of the field after applying the override
  */
-export function applyUserOpOverride(
-  value: BigNumberish | undefined,
+export function applyUserOpOverride<TValue extends BigNumberish | undefined>(
+  value: TValue,
   override?: BigNumberish | Multiplier
-): BigNumberish | undefined {
+): TValue | BigNumberish {
   if (override == null) {
     return value;
   }
@@ -113,13 +113,14 @@ export function applyUserOpOverride(
  * @param feeOption the fee option field value to apply
  * @returns the new value of the field after applying the fee option
  */
-export function applyUserOpFeeOption(
-  value: BigNumberish | undefined,
+export function applyUserOpFeeOption<TValue extends BigNumberish | undefined>(
+  value: TValue,
   feeOption?: UserOperationFeeOptionsField
-): BigNumberish {
+): TValue | BigNumberish {
   if (feeOption == null) {
-    return value ?? 0n;
+    return value;
   }
+
   return value != null
     ? bigIntClamp(
         feeOption.multiplier
@@ -141,11 +142,13 @@ export function applyUserOpFeeOption(
  * @param [feeOption] the fee option field value to apply
  * @returns the new value of the field after applying the override or fee option
  */
-export function applyUserOpOverrideOrFeeOption(
-  value: BigNumberish | undefined,
+export function applyUserOpOverrideOrFeeOption<
+  TValue extends BigNumberish | undefined
+>(
+  value: TValue,
   override?: BigNumberish | Multiplier,
   feeOption?: UserOperationFeeOptionsField
-): BigNumberish {
+): TValue | BigNumberish {
   return value != null && override != null
     ? applyUserOpOverride(value, override)!
     : applyUserOpFeeOption(value, feeOption);


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances type safety in user operation utility functions by introducing generics for `BigNumberish` values.

### Detailed summary
- Added generics to `applyUserOpOverride`, `applyUserOpFeeOption`, and `applyUserOpOverrideOrFeeOption` functions for better type safety
- Updated return types to `TValue | BigNumberish` for flexibility

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->