### PR TITLE
docs: add example to useSendUserOperation for retries

### DIFF
--- a/packages/alchemy/src/react/hooks/useSendTransaction.ts
+++ b/packages/alchemy/src/react/hooks/useSendTransaction.ts
@@ -42,9 +42,17 @@ export type UseSendTransactionResult = {
   error: Error | null;
 };
 
-export function useSendTransaction({
-  client,
-}: UseSendTransactionArgs): UseSendTransactionResult {
+/**
+ * @deprecated use useSendUserOperation instead
+ * Send a TX request as a user operation and wait for it to be mined
+ *
+ * @param params - see {@link UseSendUserOperationArgs}
+ * @returns functions and state for sending txs {@link UseSendTransactionResult}
+ */
+export function useSendTransaction(
+  params: UseSendTransactionArgs
+): UseSendTransactionResult {
+  const { client, ...mutationArgs } = params;
   const { queryClient } = useAlchemyAccountContext();
 
   const {
@@ -55,6 +63,7 @@ export function useSendTransaction({
     error,
   } = useMutation(
     {
+      ...mutationArgs,
       mutationFn: async (params: SendTransactionParameters) => {
         if (!client) {
           throw new ClientUndefinedHookError("useSendTransaction");

--- a/packages/core/src/actions/smartAccount/sendTransaction.ts
+++ b/packages/core/src/actions/smartAccount/sendTransaction.ts
@@ -13,6 +13,7 @@ import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
 import { TransactionMissingToParamError } from "../../errors/transaction.js";
+import { WaitForUserOperationError } from "../../errors/useroperation.js";
 import type { UserOperationOverrides } from "../../types.js";
 import { buildUserOperationFromTx } from "./buildUserOperationFromTx.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
@@ -58,12 +59,15 @@ export async function sendTransaction<
     overrides,
     context
   );
-  const { hash } = await _sendUserOperation(client, {
+
+  const { hash, request } = await _sendUserOperation(client, {
     account: account as SmartContractAccount,
     uoStruct,
     context,
     overrides,
   });
 
-  return waitForUserOperationTransaction(client, { hash });
+  return waitForUserOperationTransaction(client, { hash }).catch((e) => {
+    throw new WaitForUserOperationError(request, e);
+  });
 }

--- a/packages/core/src/actions/smartAccount/sendTransactions.ts
+++ b/packages/core/src/actions/smartAccount/sendTransactions.ts
@@ -3,6 +3,7 @@ import type { SmartContractAccount } from "../../account/smartContractAccount.js
 import { isBaseSmartAccountClient } from "../../client/isSmartAccountClient.js";
 import { AccountNotFoundError } from "../../errors/account.js";
 import { IncompatibleClientError } from "../../errors/client.js";
+import { WaitForUserOperationError } from "../../errors/useroperation.js";
 import { buildUserOperationFromTxs } from "./buildUserOperationFromTxs.js";
 import { _sendUserOperation } from "./internal/sendUserOperation.js";
 import type { SendTransactionsParameters, UserOperationContext } from "./types";
@@ -39,12 +40,14 @@ export async function sendTransactions<
     context,
   });
 
-  const { hash } = await _sendUserOperation(client, {
+  const { hash, request } = await _sendUserOperation(client, {
     account,
     uoStruct,
     context,
     overrides,
   });
 
-  return waitForUserOperationTransaction(client, { hash });
+  return waitForUserOperationTransaction(client, { hash }).catch((e) => {
+    throw new WaitForUserOperationError(request, e);
+  });
 }

--- a/packages/core/src/errors/useroperation.ts
+++ b/packages/core/src/errors/useroperation.ts
@@ -1,5 +1,7 @@
-import type { UserOperationStruct } from "../types.js";
+import type { UserOperationRequest, UserOperationStruct } from "../types.js";
 import { BaseError } from "./base.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { dropAndReplaceUserOperation } from "../actions/smartAccount/dropAndReplaceUserOperation.js";
 
 /**
  * Thrown when a {@link UserOperationStruct} is not a valid request
@@ -32,5 +34,21 @@ export class InvalidUserOperationError extends BaseError {
         2
       )}`
     );
+  }
+}
+
+/**
+ * Error thrown when waiting for user operation request to be mined.
+ *
+ * Includes the internal error as well as the request that failed. This request
+ * can then be used with {@link dropAndReplaceUserOperation} to retry the operation.
+ */
+export class WaitForUserOperationError extends BaseError {
+  /**
+   * @param request the user operation request that failed
+   * @param error the underlying error that caused the failure
+   */
+  constructor(public request: UserOperationRequest, error: Error) {
+    super(`Failed to find User Operation: ${error.message}`);
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,8 @@ export {
   base,
   baseGoerli,
   baseSepolia,
+  fraxtal,
+  fraxtalSepolia,
   goerli,
   mainnet,
   optimism,
@@ -47,8 +49,6 @@ export {
   polygonAmoy,
   polygonMumbai,
   sepolia,
-  fraxtal,
-  fraxtalSepolia,
   zora,
   zoraSepolia,
 } from "./chains/index.js";
@@ -112,7 +112,10 @@ export {
   FailedToFindTransactionError,
   TransactionMissingToParamError,
 } from "./errors/transaction.js";
-export { InvalidUserOperationError } from "./errors/useroperation.js";
+export {
+  InvalidUserOperationError,
+  WaitForUserOperationError,
+} from "./errors/useroperation.js";
 export { LogLevel, Logger } from "./logger.js";
 export { middlewareActions } from "./middleware/actions.js";
 export { defaultFeeEstimator } from "./middleware/defaults/feeEstimator.js";

--- a/site/react/useSendTransaction.md
+++ b/site/react/useSendTransaction.md
@@ -23,6 +23,8 @@ head:
 The `useSendTransaction` hook enables sending a transaction as a UserOperation on behalf of the user's Embedded Account.
 
 ::: warning
+This hook is deprecated in favor of [`useSendUserOperation`](/react/useSendUserOperation).
+
 This requires your user to be logged in. See [`useAuthenticate`](/react/useAuthenticate) for more details.
 :::
 

--- a/site/react/useSendTransactions.md
+++ b/site/react/useSendTransactions.md
@@ -23,6 +23,8 @@ head:
 The `useSendTransactions` hook enables sending a set of transactions as a UserOperation on behalf of the user's Embedded Account.
 
 ::: warning
+This hook is deprecated in favor of [`useSendUserOperation`](/react/useSendUserOperation).
+
 This requires your user to be logged in. See [`useAuthenticate`](/react/useAuthenticate) for more details.
 :::
 

--- a/site/react/useSendUserOperation.md
+++ b/site/react/useSendUserOperation.md
@@ -34,7 +34,15 @@ import { useSendUserOperation } from "@alchemy/aa-alchemy/react";
 
 ## Usage
 
+### Without awaiting the transaction hash
+
 <<< @/snippets/react/useSendUserOperation.tsx
+
+### Await the tx to mine and retry failures
+
+The below example uses the useSendUserOperation with the `waitForTxn` flag set to `true` and makes one drop and replace call if the UserOperation fails to be mined.
+
+<<< @/snippets/react/useSendUserOperationWithRetries.tsx
 
 ## Params
 

--- a/site/snippets/react/useSendUserOperationWithRetries.tsx
+++ b/site/snippets/react/useSendUserOperationWithRetries.tsx
@@ -1,0 +1,46 @@
+import {
+  useDropAndReplace,
+  useSendUserOperation,
+  useSmartAccountClient,
+} from "@alchemy/aa-alchemy/react";
+import { WaitForUserOperationError } from "@alchemy/aa-core";
+
+export function ComponentWithSendUserOperation() {
+  /**
+   * Assumes the app has context of a signer with an authenticated user
+   * by using the `AlchemyAccountProvider` from `@alchemy/aa-alchemy/react`.
+   */
+  const { client } = useSmartAccountClient({
+    type: "MultiOwnerModularAccount",
+  });
+  // [!code ++:3]
+  const { dropAndReplace, isDroppingAndReplacingUserOperation } =
+    useDropAndReplace({ client });
+
+  const { sendUserOperation, isSendingUserOperation } = useSendUserOperation({
+    client,
+    waitForTxn: true, // [!code ++:6]
+    onError: (error) => {
+      if (error instanceof WaitForUserOperationError) {
+        dropAndReplace({ uoToDrop: error.request });
+      }
+    },
+  });
+
+  return (
+    <div>
+      <button
+        onClick={() =>
+          sendUserOperation({
+            target: "0xTARGET_ADDRESS",
+            data: "0x",
+            value: 0n,
+          })
+        }
+        disabled={isSendingUserOperation || isDroppingAndReplacingUserOperation} // [!code ++]
+      >
+        {isSendingUserOperation ? "Sending..." : "Send UO"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR deprecates `useSendTransaction` and `useSendTransactions` in favor of `useSendUserOperation`. 

### Detailed summary
- Deprecated `useSendTransaction` and `useSendTransactions`
- Introduced `useSendUserOperation`
- Added `WaitForUserOperationError` class
- Updated related files and examples

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->