### PR TITLE
fix: alchemy paymaster 0x override was not awaiting gas estimates

### DIFF
--- a/packages/alchemy/e2e-tests/light-account.e2e.test.ts
+++ b/packages/alchemy/e2e-tests/light-account.e2e.test.ts
@@ -1,6 +1,8 @@
 import {
   LocalAccountSigner,
   sepolia,
+  type UserOperationCallData,
+  type UserOperationOverrides,
   type UserOperationStruct,
 } from "@alchemy/aa-core";
 import { Alchemy, Network } from "alchemy-sdk";
@@ -98,17 +100,24 @@ describe("Light Account Client Tests", () => {
       },
     });
 
-    const uoStruct = (await provider.buildUserOperation({
+    const toSend = {
       uo: {
         target: provider.getAddress(),
         data: "0x",
-      },
+      } as UserOperationCallData,
       overrides: {
         paymasterAndData: "0x", // bypass paymaster
-      },
-    })) as UserOperationStruct<"0.6.0">;
+      } as UserOperationOverrides<"0.6.0">,
+    };
+    const uoStruct = (await provider.buildUserOperation(
+      toSend
+    )) as UserOperationStruct<"0.6.0">;
 
     expect(uoStruct.paymasterAndData).toBe("0x");
+
+    await expect(
+      provider.sendUserOperation(toSend)
+    ).resolves.not.toThrowError();
   }, 100000);
 
   it("should successfully override fees and gas when using paymaster", async () => {

--- a/packages/alchemy/src/middleware/gasManager.ts
+++ b/packages/alchemy/src/middleware/gasManager.ts
@@ -200,12 +200,12 @@ export function alchemyGasManagerMiddleware<C extends ClientWithAlchemyMethods>(
           if (bypassPaymasterAndData(overrides)) {
             return {
               ...struct,
-              ...fallbackGasEstimator(struct, {
+              ...(await fallbackGasEstimator(struct, {
                 overrides,
                 account,
                 feeOptions,
                 client,
-              }),
+              })),
             };
           }
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the gasManager middleware and add new types and functionality related to user operations in the light account client.

### Detailed summary
- Updated `gasManager.ts` middleware to use `fallbackGasEstimator` with `await`
- Added new types `UserOperationCallData` and `UserOperationOverrides`
- Updated user operation creation and testing in `light-account.e2e.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->