### PR TITLE
fix(light-account): light account v2 signatures should have sig type

### DIFF
--- a/packages/accounts/src/light-account/accounts/base.ts
+++ b/packages/accounts/src/light-account/accounts/base.ts
@@ -220,7 +220,14 @@ export async function createLightAccountBase({
       });
     },
     signUserOperationHash: async (uoHash: Hex) => {
-      return signer.signMessage({ raw: uoHash });
+      const signature = await signer.signMessage(uoHash);
+      switch (version) {
+        case "v2.0.0":
+          // TODO: handle case where signer is an SCA.
+          return concat([SignatureType.EOA, signature]);
+        default:
+          return signature;
+      }
     },
     async signMessage({ message }) {
       switch (version as string) {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `signUserOperationHash` function in `base.ts` to handle different signer versions and return the signature accordingly.

### Detailed summary
- Refactored `signUserOperationHash` to handle different signer versions
- Added a switch statement to handle different cases based on the signer version
- Changed the signature generation logic to concatenate with `SignatureType.EOA` for version "v2.0.0"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->