### PR TITLE
docs: clarify session key gas spend permission

### DIFF
--- a/packages/accounts/src/msca/plugins/session-key/permissions.ts
+++ b/packages/accounts/src/msca/plugins/session-key/permissions.ts
@@ -47,6 +47,9 @@ export type Erc20TokenLimit = {
 
 // uint256 spendLimit, uint48 refreshInterval
 export type GasSpendLimit = {
+  // The amount, in wei, of native tokens that a session key can spend on gas.
+  // Note that this is not the same as the gas limit for a user operation, which is measured in units of gas.
+  // This tracks gas units * gas price.
   spendLimit: bigint;
   // The time interval over which the spend limit is enforced. If unset, there is no time
   /// interval by which the limit is refreshed.

--- a/site/snippets/session-keys/supported-permissions.ts
+++ b/site/snippets/session-keys/supported-permissions.ts
@@ -150,7 +150,7 @@ const [gasSpendingLimit, shouldReset] =
 
 const {
   hasLimit: hasGasSpendLimit, // Whether or not a gas spending limit is enforced on the session key
-  limit: gasSpendLimit, // The limit's maximum value. If a refresh interval is set, this is the max per interval.
+  limit: gasSpendLimit, // The gas limit's maximum spend amount, in wei. If a refresh interval is set, this is the max per interval.
   limitUsed: gasSpendLimitUsed, // How much of the limit is used. If a refresh interval is set, this is the amount used in the current interval.
   refreshInterval: gasRefreshInterval, // How often to reset the limit and start counting again. If zero, never refresh the limit.
   lastUsedTime: gasLastUsedTime, // The start of the latest interval, if using the refresh interval.

--- a/site/using-smart-accounts/session-keys/index.md
+++ b/site/using-smart-accounts/session-keys/index.md
@@ -58,6 +58,8 @@ Supports limiting how much of the native token, e.g. ETH or MATIC, a key may spe
 
 ### Gas spending limits
 
-Supports limiting how much a session key can spend native token amounts on gas. This may be a total for the key, or refreshing on an interval (e.g. 1 ETH per week).
+Supports limiting how much of the native token (e.g. ETH or MATIC) a session key can spend on gas. This may be a total for the key, or refreshing on an interval (e.g. 1 ETH per week).
 
 Alternatively, you can also require that a session key uses a specific paymaster address, instead of spending the account’s native token for gas.
+
+Note that the gas limit is tracked in terms of native token units (wei), not in units of gas. The gas usage of a user operation is considered to be the maximum gas a user operation can spend, i.e. `total gas limit * maxFeePerGas`. This can overestimate when compared to the actual gas cost of each user operation.

--- a/site/using-smart-accounts/session-keys/supported-permissions.md
+++ b/site/using-smart-accounts/session-keys/supported-permissions.md
@@ -38,13 +38,15 @@ Supports limiting how much of the native token, e.g. ETH or MATIC, a key may spe
 
 ### Gas spending limits
 
-Supports limiting how much a session key can spend native token amounts on gas. This may be a total for the key, or refreshing on an interval (e.g. 1 ETH per week).
+Supports limiting how much of the native token (e.g. ETH or MATIC) a session key can spend on gas. This may be a total for the key, or refreshing on an interval (e.g. 1 ETH per week).
 
 Alternatively, you can also require that a session key uses a specific paymaster address, instead of spending the account’s native token for gas.
 
 ## Importance of Gas Limits
 
 Gas spend limits are critically important to protecting the account. If you are using a session key, you should configure either a required paymaster rule or a gas spend limit. Failing to do so could allow a compromised session key to drain the account’s native token balance.
+
+Note that the gas limit is tracked in terms of native token units (wei), not in units of gas. The gas usage of a user operation is considered to be the maximum gas a user operation can spend, i.e. `total gas limit * maxFeePerGas`. This can overestimate when compared to the actual gas cost of each user operation.
 
 ## Default values
 
@@ -56,7 +58,7 @@ Permissions start with the following default values:
 | Time range               | Unlimited                                                                                                                                        |
 | Native token spend limit | 0 <br /> This means all calls spending the native token will be denied, unless the limit is updated or removed.                                  |
 | ERC-20 spend limit       | Unset. If you want to enabled an ERC-20 spend limit, add the ERC-20 token contract to the access control list and set the spending limit amount. |
-| Gas spend limits         | Unset. When defining the session key’s permissions, you should specify either a spending limit or a required paymaster.                          |
+| Gas spend limits         | Unset. When defining the session key’s permissions, you should specify either a gas spending limit or a required paymaster.                      |
 
 ## Using the PermissionsBuilder
 
@@ -179,6 +181,7 @@ function getNativeTokenSpendLimitInfo(address account, address sessionKey)
     returns (SpendLimitInfo memory);
 
 /// @notice Get the gas spend limit for a session key on an account.
+/// Note that this spend limit is measured in wei, not units of gas.
 /// @param account The account to check.
 /// @param sessionKey The session key to check.
 /// @return info A struct with fields describing the state of gas spending limits on this session key.


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to clarify and update the gas spending limits for session keys. 

### Detailed summary
- Updated descriptions to specify gas spending in native token units (wei)
- Clarified the difference between gas limit and gas usage
- Emphasized the importance of setting gas spend limits for account protection

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->