### PR TITLE
fix(dropAndReplace): use dummy signature in drop and replace

### DIFF
--- a/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
+++ b/packages/core/src/actions/smartAccount/dropAndReplaceUserOperation.ts
@@ -55,7 +55,7 @@ export async function dropAndReplaceUserOperation<
           sender: (uoToDrop as UserOperationRequest<"0.6.0">).sender,
           nonce: (uoToDrop as UserOperationRequest<"0.6.0">).nonce,
           callData: (uoToDrop as UserOperationRequest<"0.6.0">).callData,
-          signature: (uoToDrop as UserOperationRequest<"0.6.0">).signature,
+          signature: await account.getDummySignature(),
         }
       : {
           ...((uoToDrop as UserOperationRequest<"0.7.0">).factory &&
@@ -69,7 +69,7 @@ export async function dropAndReplaceUserOperation<
           sender: (uoToDrop as UserOperationRequest<"0.7.0">).sender,
           nonce: (uoToDrop as UserOperationRequest<"0.7.0">).nonce,
           callData: (uoToDrop as UserOperationRequest<"0.7.0">).callData,
-          signature: (uoToDrop as UserOperationRequest<"0.7.0">).signature,
+          signature: await account.getDummySignature(),
         }
   ) as UserOperationStruct<TEntryPointVersion>;
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the signature handling in the `dropAndReplaceUserOperation` function by replacing it with `account.getDummySignature()`.

### Detailed summary
- Updated signature handling in `dropAndReplaceUserOperation` function
- Replaced signature with `await account.getDummySignature()`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->