### PR TITLE
feat: add support for passing in your own storage to session key signer

### DIFF
--- a/packages/accounts/src/msca/plugins/session-key/signer.ts
+++ b/packages/accounts/src/msca/plugins/session-key/signer.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 export const SessionKeySignerSchema = z.object({
   storageType: z
     .union([z.literal("local-storage"), z.literal("session-storage")])
+    .or(z.custom<Storage>())
     .default("local-storage"),
   storageKey: z.string().default("session-key-signer:session-key"),
 });
@@ -30,7 +31,7 @@ export class SessionKeySigner
 {
   signerType: string;
   inner: LocalAccountSigner<PrivateKeyAccount>;
-  private storageType: "local-storage" | "session-storage";
+  private storageType: "local-storage" | "session-storage" | Storage;
   private storageKey: string;
 
   constructor(config_: SessionKeySignerConfig = {}) {
@@ -41,7 +42,9 @@ export class SessionKeySigner
 
     const sessionKey = (() => {
       const storage =
-        config.storageType === "session-storage"
+        typeof this.storageType !== "string"
+          ? this.storageType
+          : this.storageType === "session-storage"
           ? sessionStorage
           : localStorage;
       const key = storage.getItem(this.storageKey);


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `SessionKeySigner` class by allowing a custom storage type in addition to "local-storage" and "session-storage".

### Detailed summary
- Added support for custom storage type in `SessionKeySigner`
- Updated `storageType` to allow custom type in addition to strings
- Modified session key retrieval logic to handle custom storage types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->