### PR TITLE
fix: update the version of the store so that we don't have clashes

### DIFF
--- a/packages/alchemy/e2e-tests/multisig-account.e2e.test.ts
+++ b/packages/alchemy/e2e-tests/multisig-account.e2e.test.ts
@@ -207,7 +207,7 @@ describe("Multisig Modular Account Alchemy Client Tests", async () => {
         signatures: [signature1],
         userOperationRequest: request,
       });
- 
+
     const result = await provider3.sendUserOperation({
       uo: request.callData,
       context: {
@@ -272,7 +272,7 @@ describe("Multisig Modular Account Alchemy Client Tests", async () => {
         signatures: [signature1],
         userOperationRequest: request,
       });
- 
+
     const result = await provider3.sendUserOperation({
       uo: request.callData,
       overrides: {
@@ -297,7 +297,6 @@ describe("Multisig Modular Account Alchemy Client Tests", async () => {
     await expect(txnHash).resolves.not.toThrowError();
   }, 100000);
 });
-
 
 const givenConnectedProvider = async ({
   signer,

--- a/packages/alchemy/src/config/store/client.ts
+++ b/packages/alchemy/src/config/store/client.ts
@@ -45,6 +45,7 @@ export const createClientStore = (config: CreateClientStoreParams) => {
             skipHydration: ssr,
             partialize: ({ signer, accounts, ...writeableState }) =>
               writeableState,
+            version: 1,
           })
         : () => createInitialClientState(config)
     )

--- a/packages/alchemy/src/config/store/core.ts
+++ b/packages/alchemy/src/config/store/core.ts
@@ -72,6 +72,7 @@ export const createCoreStore = (params: CreateCoreStoreParams): CoreStore => {
                 return bigintMapReviver(key, value);
               },
             }),
+            version: 1,
             skipHydration: ssr,
           })
         : () => createInitialCoreState(connections, chain)


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `version` property to core and client store configurations and refactors the `givenConnectedProvider` function in `multisig-account.e2e.test.ts`.

### Detailed summary
- Added `version` property to core and client store configurations
- Refactored `givenConnectedProvider` function in `multisig-account.e2e.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->