### PR TITLE
feat: change email validation rule

### DIFF
--- a/packages/alchemy/src/react/components/auth/sections/EmailAuth.tsx
+++ b/packages/alchemy/src/react/components/auth/sections/EmailAuth.tsx
@@ -22,7 +22,7 @@ export const EmailAuth = ({
 }: EmailAuthProps) => {
   const { setAuthStep } = useAuthContext();
   const signer = useSigner();
-  const { authenticateAsync, error, isPending } = useAuthenticate({
+  const { authenticateAsync, isPending } = useAuthenticate({
     onMutate: async (params) => {
       if ("email" in params) {
         setAuthStep({ type: "email_verify", email: params.email });
@@ -67,7 +67,7 @@ export const EmailAuth = ({
         <form.Field
           name="email"
           validators={{
-            onBlur: z.string().email("Must provide a valid email."),
+            onChange: z.string().email("Must provide a valid email."),
           }}
         >
           {(field) => (
@@ -77,11 +77,6 @@ export const EmailAuth = ({
               onChange={(e) => field.handleChange(e.target.value)}
               onBlur={field.handleBlur}
               placeholder={placeholder}
-              error={
-                field.state.meta.touchedErrors.length
-                  ? field.state.meta.touchedErrors[0]?.toString()
-                  : error?.message
-              }
               iconLeft={<MailIcon />}
               iconRight={
                 hideButton ? (
@@ -98,14 +93,20 @@ export const EmailAuth = ({
           )}
         </form.Field>
         <form.Subscribe
-          selector={(state) => [state.canSubmit, state.isSubmitting]}
+          selector={(state) => [
+            state.canSubmit,
+            state.isSubmitting,
+            state.values.email,
+          ]}
         >
-          {([canSubmit, isSubmitting]) =>
+          {([canSubmit, isSubmitting, email]) =>
             !hideButton ? (
               <Button
                 type="submit"
                 variant="primary"
-                disabled={isPending || !canSubmit || isSubmitting}
+                disabled={Boolean(
+                  isPending || !canSubmit || isSubmitting || !email
+                )}
               >
                 {buttonLabel}
               </Button>


### PR DESCRIPTION
We should only enable the "Submit" button if the email is valid - therefore we don't need the error state anymore 🤔 
https://www.figma.com/design/5n3ACN3Z6PJjULtfXux5ay?node-id=19-2593#829800061

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `EmailAuth` component in the `EmailAuth.tsx` file to improve email validation and button disabling logic.

### Detailed summary
- Updated validation trigger from onBlur to onChange for email input
- Removed error display logic
- Modified button disabled condition to also check for email presence

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->