### PR TITLE
feat: fix state override parameter type

### DIFF
--- a/packages/core/src/actions/bundler/estimateUserOperationGas.ts
+++ b/packages/core/src/actions/bundler/estimateUserOperationGas.ts
@@ -5,6 +5,7 @@ import type {
   UserOperationEstimateGasResponse,
   UserOperationRequest,
 } from "../../types";
+import { serializeStateOverride } from "../../utils/stateOverride.js";
 
 export const estimateUserOperationGas = async <
   TClient extends Client<Transport, Chain | undefined, any, BundlerRpcSchema>,
@@ -21,7 +22,11 @@ export const estimateUserOperationGas = async <
     method: "eth_estimateUserOperationGas",
     params:
       args.stateOverride != null
-        ? [args.request, args.entryPoint, args.stateOverride]
+        ? [
+            args.request,
+            args.entryPoint,
+            serializeStateOverride(args.stateOverride),
+          ]
         : [args.request, args.entryPoint],
   });
 };

--- a/packages/core/src/client/decorators/bundlerClient.ts
+++ b/packages/core/src/client/decorators/bundlerClient.ts
@@ -4,6 +4,7 @@ import type {
   Client,
   Hash,
   PublicRpcSchema,
+  RpcStateOverride,
   StateOverride,
   Transport,
 } from "viem";
@@ -29,7 +30,7 @@ export type BundlerRpcSchema = [
   },
   {
     Method: "eth_estimateUserOperationGas";
-    Parameters: [UserOperationRequest, Address, StateOverride?];
+    Parameters: [UserOperationRequest, Address, RpcStateOverride?];
     ReturnType: UserOperationEstimateGasResponse;
   },
   {

--- a/packages/core/src/utils/stateOverride.ts
+++ b/packages/core/src/utils/stateOverride.ts
@@ -1,0 +1,80 @@
+import type { Address } from "abitype";
+import {
+  AccountStateConflictError,
+  InvalidAddressError,
+  StateAssignmentConflictError,
+  isAddress,
+  numberToHex,
+  type RpcAccountStateOverride,
+  type RpcStateMapping,
+  type RpcStateOverride,
+  type StateMapping,
+  type StateOverride,
+} from "viem";
+
+// Copied from Viem's utils/stateOverride.ts, which does not expose these
+// functions.
+
+type SerializeStateMappingParameters = StateMapping | undefined;
+
+function serializeStateMapping(
+  stateMapping: SerializeStateMappingParameters
+): RpcStateMapping | undefined {
+  if (!stateMapping || stateMapping.length === 0) return undefined;
+  return stateMapping.reduce((acc, { slot, value }) => {
+    validateBytes32HexLength(slot);
+    validateBytes32HexLength(value);
+    acc[slot] = value;
+    return acc;
+  }, {} as RpcStateMapping);
+}
+
+function validateBytes32HexLength(value: Address): void {
+  if (value.length !== 66) {
+    // This is the error message from Viem's non-exported InvalidBytesLengthError.
+    throw new Error(
+      `Hex is expected to be 66 hex long, but is ${value.length} hex long.`
+    );
+  }
+}
+
+type SerializeAccountStateOverrideParameters = Omit<
+  StateOverride[number],
+  "address"
+>;
+
+function serializeAccountStateOverride(
+  parameters: SerializeAccountStateOverrideParameters
+): RpcAccountStateOverride {
+  const { balance, nonce, state, stateDiff, code } = parameters;
+  const rpcAccountStateOverride: RpcAccountStateOverride = {};
+  if (code !== undefined) rpcAccountStateOverride.code = code;
+  if (balance !== undefined)
+    rpcAccountStateOverride.balance = numberToHex(balance);
+  if (nonce !== undefined) rpcAccountStateOverride.nonce = numberToHex(nonce);
+  if (state !== undefined)
+    rpcAccountStateOverride.state = serializeStateMapping(state);
+  if (stateDiff !== undefined) {
+    if (rpcAccountStateOverride.state) throw new StateAssignmentConflictError();
+    rpcAccountStateOverride.stateDiff = serializeStateMapping(stateDiff);
+  }
+  return rpcAccountStateOverride;
+}
+
+type SerializeStateOverrideParameters = StateOverride | undefined;
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function serializeStateOverride(
+  parameters?: SerializeStateOverrideParameters
+): RpcStateOverride | undefined {
+  if (!parameters) return undefined;
+  const rpcStateOverride: RpcStateOverride = {};
+  for (const { address, ...accountState } of parameters) {
+    if (!isAddress(address, { strict: false }))
+      throw new InvalidAddressError({ address });
+    if (rpcStateOverride[address])
+      throw new AccountStateConflictError({ address: address });
+    rpcStateOverride[address] = serializeAccountStateOverride(accountState);
+  }
+  return rpcStateOverride;
+}


### PR DESCRIPTION
Viem uses different types for state overrides in the SDK vs what actually gets sent to RPC. We were incorrectly sending the SDK type to the RPC. Convert the SDK type just like Viem does instead.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add serialization functions for state overrides in the bundler client.

### Detailed summary
- Added `serializeStateOverride` function in `stateOverride.ts`
- Added `serializeStateMapping` and `serializeAccountStateOverride` functions
- Updated `estimateUserOperationGas` to use `serializeStateOverride` for `RpcStateOverride`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->