### PR TITLE
fix: use updated package path in prettier config

### DIFF
--- a/account-kit/react/src/tailwind/plugin.ts
+++ b/account-kit/react/src/tailwind/plugin.ts
@@ -13,13 +13,13 @@ import { apply, getColorVariableName } from "./utils.js";
 type TailWindPlugin = ReturnType<typeof plugin>;
 
 /**
- * Get the path to the aa-alchemy package and the tailwind content.
- * This is used within the tailwind.config.js to include the aa-alchemy content.
+ * Get the path to the @account-kit/react package and the tailwind content.
+ * This is used within the tailwind.config.js to include the @account-kit content.
  *
  * @example
  * ```ts
  *
- * import accountKitUi, { getAccountKitContentPath } from "@alchemy/aa-alchemy/tailwind";
+ * import accountKitUi, { getAccountKitContentPath } from "@account-kit/react/tailwind";
  * import type { Config } from "tailwindcss";
  *
  * const config: Config = {
@@ -33,10 +33,10 @@ type TailWindPlugin = ReturnType<typeof plugin>;
  *
  * export default config;
  * ```
- * @returns The resolved path to the aa-alchemy package and the tailwind content
+ * @returns The resolved path to the @account-kit/react package and the tailwind content
  */
 export const getAccountKitContentPath = () => {
-  const pathToMe = require.resolve("@alchemy/aa-alchemy");
+  const pathToMe = require.resolve("@account-kit/react");
   const contentPath = `${pathToMe.replace(
     "index.js",
     ""
@@ -52,7 +52,7 @@ export const getAccountKitContentPath = () => {
  * @example
  * ```ts
  *
- * import accountKitUi, { getAccountKitContentPath } from "@alchemy/aa-alchemy/tailwind";
+ * import accountKitUi, { getAccountKitContentPath } from "@account-kit/react/tailwind";
  * import type { Config } from "tailwindcss";
  *
  * const config: Config = {


### PR DESCRIPTION
Tiny fix to change the plugin location now that the package file structure has been changed

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates references from `@alchemy/aa-alchemy` to `@account-kit/react` in the `tailwind` plugin for better clarity and consistency.

### Detailed summary
- Updated package references from `@alchemy/aa-alchemy` to `@account-kit/react`
- Improved clarity in import paths and function names

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->