### PR TITLE
feat: new and improved auth modal

### DIFF
--- a/account-kit/react/src/components/auth/card/index.tsx
+++ b/account-kit/react/src/components/auth/card/index.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useLayoutEffect, useMemo, type ReactNode } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
 import { useSignerStatus } from "../../../hooks/useSignerStatus.js";
 import { IS_SIGNUP_QP } from "../../constants.js";
 import { useAuthContext } from "../context.js";
@@ -8,6 +14,7 @@ import { Notification } from "../../notification.js";
 import { useAuthError } from "../../../hooks/useAuthError.js";
 import { Navigation } from "../../navigation.js";
 import { useAuthModal } from "../../../hooks/useAuthModal.js";
+import { useElementHeight } from "../../../hooks/useElementHeight.js";
 
 export type AuthCardProps = {
   hideError?: boolean;
@@ -37,6 +44,9 @@ export const AuthCard = (
   const { status, isAuthenticating } = useSignerStatus();
   const { authStep, setAuthStep } = useAuthContext();
   const error = useAuthError();
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { height } = useElementHeight(contentRef);
 
   // TODO: Finalize the steps that allow going back
   const canGoBack = useMemo(() => {
@@ -76,16 +86,26 @@ export const AuthCard = (
           <Notification message={error.message} type="error" />
         )}
       </div>
-      <div className="modal-box relative flex flex-col items-center gap-5 text-fg-primary">
-        {(canGoBack || showClose) && (
-          <Navigation
-            showClose={showClose}
-            showBack={canGoBack}
-            onBack={onBack}
-            onClose={closeAuthModal}
-          />
-        )}
-        <Step {...props} />
+
+      {/* Wrapper container that sizes its height dynamically */}
+      <div
+        className="transition-all duration-300 ease-out overflow-y-hidden"
+        style={{ height: height ? `${height}px` : "auto" }}
+      >
+        <div
+          ref={contentRef}
+          className="modal-box relative flex flex-col items-center gap-5 text-fg-primary"
+        >
+          {(canGoBack || showClose) && (
+            <Navigation
+              showClose={showClose}
+              showBack={canGoBack}
+              onBack={onBack}
+              onClose={closeAuthModal}
+            />
+          )}
+          <Step {...props} />
+        </div>
       </div>
     </div>
   );

--- a/account-kit/react/src/components/auth/modal.tsx
+++ b/account-kit/react/src/components/auth/modal.tsx
@@ -1,24 +1,21 @@
-import { forwardRef } from "react";
 import { AuthCard } from "./card/index.js";
 import { type AlchemyAccountsUIConfig } from "../../context.js";
 import { useAuthModal } from "../../hooks/useAuthModal.js";
+import { Dialog } from "../dialog/dialog.js";
 
 type AuthModalProps = {
+  open: boolean;
   hideError?: boolean;
   auth: NonNullable<AlchemyAccountsUIConfig["auth"]>;
 };
 
-export const AuthModal = forwardRef<HTMLDialogElement, AuthModalProps>(
-  function AuthModal({ hideError, auth }, ref) {
-    const { closeAuthModal } = useAuthModal();
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const AuthModal = ({ open, hideError, auth }: AuthModalProps) => {
+  const { closeAuthModal } = useAuthModal();
 
-    return (
-      <dialog
-        ref={ref}
-        className={`modal overflow-visible relative w-[368px] ${
-          auth.className ?? ""
-        }`}
-      >
+  return (
+    <Dialog isOpen={open} onClose={closeAuthModal}>
+      <div className="modal md:w-[368px]">
         <AuthCard
           hideError={hideError}
           header={auth.header}
@@ -26,8 +23,7 @@ export const AuthModal = forwardRef<HTMLDialogElement, AuthModalProps>(
           onAuthSuccess={() => closeAuthModal()}
           showClose
         />
-        <div className="modal-backdrop" onClick={() => closeAuthModal()} />
-      </dialog>
-    );
-  }
-);
+      </div>
+    </Dialog>
+  );
+};

--- a/account-kit/react/src/components/auth/modal.tsx
+++ b/account-kit/react/src/components/auth/modal.tsx
@@ -9,7 +9,6 @@ type AuthModalProps = {
   auth: NonNullable<AlchemyAccountsUIConfig["auth"]>;
 };
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 export const AuthModal = ({ open, hideError, auth }: AuthModalProps) => {
   const { closeAuthModal } = useAuthModal();
 

--- a/account-kit/react/src/components/dialog/dialog.tsx
+++ b/account-kit/react/src/components/dialog/dialog.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { RemoveScroll } from "react-remove-scroll";
+import { FocusTrap } from "./focustrap.js";
+
+type DialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const Dialog = ({ isOpen, onClose, children }: DialogProps) => {
+  const [isScrollLocked, setScrollLocked] = useState(false);
+
+  const handleBackgroundClick = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    // Has to run in the browser
+    setScrollLocked(getComputedStyle(document.body).overflow !== "hidden");
+  }, []);
+
+  return isOpen
+    ? createPortal(
+        <RemoveScroll enabled={isScrollLocked}>
+          {/* Overlay */}
+          <div
+            aria-modal
+            role="dialog"
+            className="fixed inset-0 bg-black/80 flex items-end md:items-center justify-center z-[100000] animate-fade-in"
+            onClick={handleBackgroundClick}
+          >
+            <FocusTrap>
+              <div
+                className="animate-fade-in animate-slide-up max-md:w-screen md:max-w-sm"
+                onClick={(event) => event.stopPropagation()}
+              >
+                {children}
+              </div>
+            </FocusTrap>
+          </div>
+        </RemoveScroll>,
+        document.body
+      )
+    : null;
+};

--- a/account-kit/react/src/components/dialog/dialog.tsx
+++ b/account-kit/react/src/components/dialog/dialog.tsx
@@ -9,7 +9,6 @@ type DialogProps = {
   children: ReactNode;
 };
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 export const Dialog = ({ isOpen, onClose, children }: DialogProps) => {
   const [isScrollLocked, setScrollLocked] = useState(false);
 

--- a/account-kit/react/src/components/dialog/focustrap.tsx
+++ b/account-kit/react/src/components/dialog/focustrap.tsx
@@ -63,7 +63,6 @@ function useTrapFocus() {
   return { ref };
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 export const FocusTrap = ({ children }: PropsWithChildren<{}>) => {
   const { ref } = useTrapFocus();
 

--- a/account-kit/react/src/components/dialog/focustrap.tsx
+++ b/account-kit/react/src/components/dialog/focustrap.tsx
@@ -1,0 +1,81 @@
+// Adapted from: https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element
+
+import { useRef, useEffect, type PropsWithChildren } from "react";
+
+function useTrapFocus() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!ref.current) {
+      return;
+    }
+
+    // Elements that can receive focus
+    const focusableElements = ref.current.querySelectorAll<HTMLElement>(`
+      a[href]:not([disabled]),
+      button:not([disabled]),
+      textarea:not([disabled]),
+      input[type="text"]:not([disabled]),
+      input[type="radio"]:not([disabled]),
+      input[type="checkbox"]:not([disabled]),
+      select:not([disabled])
+    `);
+
+    const firstFocusableElement = focusableElements[0];
+    const lastFocusableElement =
+      focusableElements[focusableElements.length - 1];
+
+    const isPressingTab = event.key === "Tab";
+
+    if (!isPressingTab) {
+      return;
+    }
+
+    if (event.shiftKey) {
+      // Shift + tab
+      if (document.activeElement === firstFocusableElement) {
+        lastFocusableElement.focus();
+        event.preventDefault();
+      }
+    } else {
+      // Just tab
+      if (document.activeElement === lastFocusableElement) {
+        firstFocusableElement.focus();
+        event.preventDefault();
+      }
+    }
+  };
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    el.addEventListener("keydown", handleKeyDown);
+    el.focus({ preventScroll: true });
+
+    return () => {
+      el.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  return { ref };
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const FocusTrap = ({ children }: PropsWithChildren<{}>) => {
+  const { ref } = useTrapFocus();
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.focus({ preventScroll: true });
+    }
+  }, [ref]);
+
+  return (
+    <div ref={ref} tabIndex={0}>
+      {children}
+    </div>
+  );
+};

--- a/account-kit/react/src/context.tsx
+++ b/account-kit/react/src/context.tsx
@@ -8,10 +8,10 @@ import type { NoUndefined } from "@aa-sdk/core";
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import type { AuthCardProps } from "./components/auth/card/index.js";
@@ -93,9 +93,10 @@ export const AlchemyAccountProvider = (
 ) => {
   const { config, queryClient, children, uiConfig } = props;
 
-  const ref = useRef<HTMLDialogElement>(null);
-  const openAuthModal = () => ref.current?.showModal();
-  const closeAuthModal = () => ref.current?.close();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openAuthModal = useCallback(() => setIsModalOpen(true), []);
+  const closeAuthModal = useCallback(() => setIsModalOpen(false), []);
 
   const initialContext = useMemo(
     () => ({
@@ -108,7 +109,7 @@ export const AlchemyAccountProvider = (
           }
         : undefined,
     }),
-    [config, queryClient, uiConfig]
+    [config, queryClient, uiConfig, openAuthModal, closeAuthModal]
   );
 
   const { status, isAuthenticating } = useSignerStatus(initialContext);
@@ -126,7 +127,7 @@ export const AlchemyAccountProvider = (
 
       openAuthModal();
     }
-  }, [status, uiConfig?.auth]);
+  }, [status, uiConfig?.auth, openAuthModal]);
 
   return (
     <Hydrate {...props}>
@@ -141,9 +142,9 @@ export const AlchemyAccountProvider = (
             {children}
             {uiConfig?.auth && (
               <AuthModal
+                open={isModalOpen}
                 auth={uiConfig.auth}
                 hideError={uiConfig.hideError}
-                ref={ref}
               />
             )}
           </AuthModalContext.Provider>

--- a/account-kit/react/src/hooks/useElementHeight.ts
+++ b/account-kit/react/src/hooks/useElementHeight.ts
@@ -1,0 +1,25 @@
+import { type MutableRefObject, useLayoutEffect, useState } from "react";
+import { useResizeObserver } from "./useResizeObserver.js";
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function useElementHeight(
+  target: MutableRefObject<HTMLDivElement | null>
+) {
+  const [height, setHeight] = useState<number>();
+
+  useLayoutEffect(() => {
+    if (target.current) {
+      setHeight(target.current.getBoundingClientRect().height);
+    }
+  }, [target]);
+
+  useResizeObserver({
+    ref: target,
+    box: "border-box",
+    onResize: (size) => {
+      setHeight(size.height);
+    },
+  });
+
+  return { height };
+}

--- a/account-kit/react/src/hooks/useResizeObserver.ts
+++ b/account-kit/react/src/hooks/useResizeObserver.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+type Size = {
+  width: number | undefined;
+  height: number | undefined;
+};
+
+type UseResizeObserverOptions<T extends HTMLElement = HTMLElement> = {
+  ref: RefObject<T>;
+  onResize?: (size: Size) => void;
+  box?: "border-box" | "content-box" | "device-pixel-content-box";
+};
+
+const initialSize: Size = {
+  width: undefined,
+  height: undefined,
+};
+
+// See: https://usehooks-ts.com/react-hook/use-resize-observer
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function useResizeObserver<T extends HTMLElement = HTMLElement>(
+  options: UseResizeObserverOptions<T>
+): Size {
+  const { ref, box = "content-box" } = options;
+  const [{ width, height }, setSize] = useState<Size>(initialSize);
+  const previousSize = useRef<Size>({ ...initialSize });
+  const onResize = useRef<((size: Size) => void) | undefined>(undefined);
+  onResize.current = options.onResize;
+
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    return () => setIsMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    if (typeof window === "undefined" || !("ResizeObserver" in window)) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      const boxProp =
+        box === "border-box"
+          ? "borderBoxSize"
+          : box === "device-pixel-content-box"
+          ? "devicePixelContentBoxSize"
+          : "contentBoxSize";
+
+      const newWidth = extractSize(entry, boxProp, "inlineSize");
+      const newHeight = extractSize(entry, boxProp, "blockSize");
+
+      const hasChanged =
+        previousSize.current.width !== newWidth ||
+        previousSize.current.height !== newHeight;
+
+      if (hasChanged) {
+        const newSize: Size = { width: newWidth, height: newHeight };
+        previousSize.current.width = newWidth;
+        previousSize.current.height = newHeight;
+
+        if (onResize.current) {
+          onResize.current(newSize);
+        } else {
+          if (isMounted) {
+            setSize(newSize);
+          }
+        }
+      }
+    });
+
+    observer.observe(ref.current, { box });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [box, ref, isMounted]);
+
+  return { width, height };
+}
+
+type BoxSizesKey = keyof Pick<
+  ResizeObserverEntry,
+  "borderBoxSize" | "contentBoxSize" | "devicePixelContentBoxSize"
+>;
+
+function extractSize(
+  entry: ResizeObserverEntry,
+  box: BoxSizesKey,
+  sizeType: keyof ResizeObserverSize
+): number | undefined {
+  if (!entry[box]) {
+    if (box === "contentBoxSize") {
+      return entry.contentRect[sizeType === "inlineSize" ? "width" : "height"];
+    }
+    return undefined;
+  }
+
+  return Array.isArray(entry[box])
+    ? entry[box][0][sizeType]
+    : // @ts-ignore Support Firefox's non-standard behavior
+      (entry[box][sizeType] as number);
+}

--- a/account-kit/react/src/tailwind/components/modal.ts
+++ b/account-kit/react/src/tailwind/components/modal.ts
@@ -2,22 +2,10 @@ import type { ComponentDef } from "../types";
 
 export const modalComponents: ComponentDef = {
   ".modal": {
-    "@apply rounded-2xl": {},
+    "@apply rounded-t-2xl md:rounded-2xl": {},
     "@apply bg-bg-surface-default": {},
-    "&::backdrop": {
-      "@apply bg-black bg-opacity-[0.8]": {},
-    },
     ".modal-box": {
       "@apply z-[1] px-6 py-4": {},
-    },
-    ".modal-backdrop": {
-      "@apply fixed w-screen h-screen top-0 left-0": {},
-      "@apply -z-[1] col-start-1 row-start-1 grid self-stretch justify-self-stretch text-transparent":
-        {},
-      button: {
-        opacity: "0",
-        "@apply h-screen w-screen cursor-default": {},
-      },
     },
   },
 };

--- a/account-kit/react/src/tailwind/plugin.ts
+++ b/account-kit/react/src/tailwind/plugin.ts
@@ -101,6 +101,20 @@ export const accountKitUi: (
             }),
             {} as Record<AccountKitThemeColor, string>
           ),
+          keyframes: {
+            "fade-in": {
+              "0%": { opacity: "0" },
+              "100%": { opacity: "1" },
+            },
+            "slide-up": {
+              "0%": { transform: "translateY(100%)", opacity: "0" },
+              "100%": { transform: "translateY(0%))", opacity: "1" },
+            },
+          },
+          animation: {
+            "fade-in": "fade-in 150ms ease",
+            "slide-up": "slide-up 350ms cubic-bezier(.15,1.15,0.6,1.00)",
+          },
         },
       },
     }


### PR DESCRIPTION
New auth modal with the following features:
- Properly locks the document scroll
- Capture focus within the modal to improve a11y
- Animate the entrance of the modal
- Mobile responsiveness (card is pinned to the bottom of small screens)
- Dynamically resize the height of the modal when the content changes (with animation ✨ )

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new animations and refactors modal components in the `account-kit/react` project.

### Detailed summary
- Added keyframes and animations for fade-in and slide-up effects.
- Refactored modal styles with rounded corners and backdrop changes.
- Updated `useElementHeight` hook for dynamic height calculation.
- Implemented a new `Dialog` component for modals with focus trap.
- Added `useResizeObserver` for observing element size changes.

> The following files were skipped due to too many changes: `account-kit/react/src/hooks/useResizeObserver.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->