### PR TITLE
fix: lowercase some copy in the sign in step

### DIFF
--- a/account-kit/react/src/components/divider.tsx
+++ b/account-kit/react/src/components/divider.tsx
@@ -1,10 +1,12 @@
+import { ls } from "../strings.js";
+
 // this isn't used externally
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Divider = () => {
   return (
     <div className={`flex flex-row gap-3 w-full items-center text-fg-tertiary`}>
       <div className={`h-[1px] bg-static basis-full shrink grow`} />
-      <p>Or</p>
+      <p>{ls.login.or}</p>
       <div className={`h-[1px] bg-static basis-full shrink grow`} />
     </div>
   );

--- a/account-kit/react/src/strings.ts
+++ b/account-kit/react/src/strings.ts
@@ -2,7 +2,7 @@ const STRINGS = {
   "en-US": {
     login: {
       tosPrefix: "By signing in, you agree to the",
-      tosLink: "Terms of Service",
+      tosLink: "terms of service",
       email: {
         placeholder: "Email",
         button: "Continue",
@@ -10,6 +10,7 @@ const STRINGS = {
       passkey: {
         button: "I have a passkey",
       },
+      or: "or",
     },
     addPasskey: {
       title: "Add a passkey",


### PR DESCRIPTION
Clean up some old titlecasing in the first step of the auth UI

<img width="399" alt="Screenshot 2024-06-25 at 7 34 47 PM" src="https://github.com/alchemyplatform/aa-sdk/assets/2329357/746b977f-bd24-4c3e-aea9-1a3e5efbd5de">

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?
