### PR TITLE
fix(core): initial state parsing and disconnect logic

### DIFF
--- a/account-kit/core/src/actions/disconnect.ts
+++ b/account-kit/core/src/actions/disconnect.ts
@@ -1,4 +1,6 @@
+import { AlchemySignerStatus } from "@account-kit/signer";
 import { disconnect as wagmi_disconnect } from "@wagmi/core";
+import { convertSignerStatusToState } from "../store/store.js";
 import type { AlchemyAccountsConfig } from "../types";
 import { getSigner } from "./getSigner.js";
 
@@ -25,5 +27,10 @@ export async function disconnect(config: AlchemyAccountsConfig): Promise<void> {
   await wagmi_disconnect(config._internal.wagmiConfig);
   await signer?.disconnect();
   config.store.setState(() => config.store.getInitialState());
+
+  config.store.setState({
+    signerStatus: convertSignerStatusToState(AlchemySignerStatus.DISCONNECTED),
+  });
+
   config.store.persist.clearStorage();
 }

--- a/account-kit/core/src/hydrate.ts
+++ b/account-kit/core/src/hydrate.ts
@@ -2,13 +2,13 @@ import type { Address } from "@aa-sdk/core";
 import { AlchemySignerStatus } from "@account-kit/signer";
 import { hydrate as wagmi_hydrate } from "@wagmi/core";
 import { reconnect } from "./actions/reconnect.js";
-import type { AccountState, StoreState, StoredState } from "./store/types.js";
-import type { AlchemyAccountsConfig, SupportedAccountTypes } from "./types.js";
 import {
   convertSignerStatusToState,
   createDefaultAccountState,
   defaultAccountState,
 } from "./store/store.js";
+import type { AccountState, StoreState, StoredState } from "./store/types.js";
+import type { AlchemyAccountsConfig, SupportedAccountTypes } from "./types.js";
 
 export type HydrateResult = {
   onMount: () => Promise<void>;
@@ -41,7 +41,8 @@ export function hydrate(
       : initialState;
 
   if (initialAlchemyState && !config.store.persist.hasHydrated()) {
-    const { accountConfigs, signerStatus, ...rest } = initialAlchemyState;
+    const { accountConfigs, signerStatus, bundlerClient, ...rest } =
+      initialAlchemyState;
     const shouldReconnectAccounts =
       signerStatus.isConnected || signerStatus.isAuthenticating;
 

--- a/account-kit/core/src/store/store.ts
+++ b/account-kit/core/src/store/store.ts
@@ -52,7 +52,7 @@ export const createAccountKitStore = (
               },
               reviver: (key, value) => {
                 if (key === "bundlerClient") {
-                  const connection = value as Connection;
+                  const { connection } = value as { connection: Connection };
                   return createAlchemyPublicRpcClient({
                     chain: connection.chain,
                     connectionConfig: connection,
@@ -65,7 +65,7 @@ export const createAccountKitStore = (
             skipHydration: ssr,
             partialize: ({ signer, accounts, ...writeableState }) =>
               writeableState,
-            version: 2,
+            version: 3,
           })
         : () => createInitialStoreState(params)
     )

--- a/account-kit/core/src/store/types.ts
+++ b/account-kit/core/src/store/types.ts
@@ -54,7 +54,9 @@ export type SignerStatus = {
 };
 
 export type StoredState = {
-  alchemy: Omit<StoreState, "signer" | "accounts">;
+  alchemy: Omit<StoreState, "signer" | "accounts" | "bundlerClient"> & {
+    bundlerClient: { connection: Connection };
+  };
   wagmi?: WagmiState;
 };
 
@@ -72,7 +74,6 @@ export type CreateAccountKitStoreParams = ClientStoreConfig & {
 
 export type StoreState = {
   // non-serializable
-  // getting this state should throw an error if not on the client
   signer?: AlchemyWebSigner;
   accounts?: {
     [chain: number]: {
@@ -82,6 +83,7 @@ export type StoreState = {
   // serializable state
   // NOTE: in some cases this can be serialized to cookie storage
   // be mindful of how big this gets. cookie limit 4KB
+  bundlerClient: ClientWithAlchemyMethods;
   config: ClientStoreConfig;
   accountConfigs: {
     [chain: number]: Partial<{
@@ -90,7 +92,6 @@ export type StoreState = {
   };
   user?: User;
   signerStatus: SignerStatus;
-  bundlerClient: ClientWithAlchemyMethods;
   chain: Chain;
   connections: Map<number, Connection>;
 };

--- a/account-kit/core/src/utils/cookies.ts
+++ b/account-kit/core/src/utils/cookies.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_SESSION_MS } from "@account-kit/signer";
 import { cookieToInitialState as wagmiCookieToInitialState } from "@wagmi/core";
 import Cookies from "js-cookie";
-import type { StoreState, StoredState } from "../store/types.js";
+import type { StoredState } from "../store/types.js";
 import type { AlchemyAccountsConfig } from "../types.js";
 import { deserialize } from "./deserialize.js";
 
@@ -69,7 +69,7 @@ export function cookieToInitialState(
   if (!state) return;
 
   const alchemyClientState = deserialize<{
-    state: Omit<StoreState, "signer" | "accounts">;
+    state: StoredState["alchemy"];
   }>(state).state;
 
   const wagmiClientState = wagmiCookieToInitialState(


### PR DESCRIPTION
# Pull Request Checklist

Fixes a bug where initial state was not being parsed correctly. We can just ignore the bundler client because the zustand state will rehydrate it correctly.

Disconnect was causing an infinite load because the signer state was stuck in an initializing state after disconnect. So we manually set signer state to disconnected

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `store.ts`, `cookies.ts`, `disconnect.ts`, `types.ts`, and `hydrate.ts` files in the `account-kit` core module.

### Detailed summary
- Updated the `reviver` function in `store.ts` to destructure `connection`
- Incremented the `version` to 3 in `store.ts`
- Removed `StoreState` import in `cookies.ts`
- Added `convertSignerStatusToState` import in `disconnect.ts`
- Modified the `StoredState` type in `types.ts` to include `bundlerClient`
- Updated the `hydrate` function in `hydrate.ts` to destructure `bundlerClient`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->