### PR TITLE
fix(react): fix sign in header hiding itself

### DIFF
--- a/account-kit/react/src/components/auth/card/main.tsx
+++ b/account-kit/react/src/components/auth/card/main.tsx
@@ -8,13 +8,13 @@ import { AuthSection } from "../sections/AuthSection.js";
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const MainAuthContent = () => {
   const {
-    auth: { header, sections, showSignInText },
+    auth: { header, sections, hideSignInText },
   } = useUiConfig();
 
   return (
     <>
       {header}
-      {showSignInText && <h3 className="font-semibold text-lg">Sign in</h3>}
+      {!hideSignInText && <h3 className="font-semibold text-lg">Sign in</h3>}
       {sections?.map((section, idx) => {
         return (
           <Fragment key={`auth-section-fragment-${idx}`}>

--- a/account-kit/react/src/hooks/useUiConfig.ts
+++ b/account-kit/react/src/hooks/useUiConfig.ts
@@ -27,7 +27,7 @@ export const DEFAULT_UI_CONFIG: AlchemyAccountsUIConfigWithDefaults = {
     header: null,
     hideError: false,
     sections: [[{ type: "email" }], [{ type: "passkey" }]],
-    showSignInText: true,
+    hideSignInText: false,
     onAuthSuccess: () => {},
   },
   modalBaseClassName: "",

--- a/account-kit/react/src/types.ts
+++ b/account-kit/react/src/types.ts
@@ -24,7 +24,7 @@ export type AlchemyAccountsUIConfig = {
     /**
      * Whether to show the "Sign in" header text in the first auth step
      */
-    showSignInText?: boolean;
+    hideSignInText?: boolean;
   };
   illustrationStyle?: "outline" | "linear" | "filled" | "flat";
   /**


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the UI configuration to allow hiding the "Sign in" header text in the authentication step.

### Detailed summary
- Added `hideSignInText` property to UI configuration
- Updated logic to show/hide "Sign in" header text based on the new property

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->