### PR TITLE
test(smart-contracts): migrate one test suite to use prool instance

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: "yarn"
 
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: "yarn"
 
       - name: Install dependencies
@@ -72,11 +72,14 @@ jobs:
         with:
           fetch-depth: "0"
           submodules: "recursive"
+          
+      - name: Set up foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: "yarn"
 
       - name: Install dependencies

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -46,10 +46,13 @@ jobs:
           fetch-depth: "0"
           submodules: "recursive"
 
-      - name: Set Node.js 18.x
+      - name: Set up foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Set Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: "yarn"
 
       - name: Set Github User Details

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ site/**/*.js
 **/userop.json
 
 vocs.config.tsx.timestamp-*.mjs
+
+bin

--- a/.vitest/globalSetup.ts
+++ b/.vitest/globalSetup.ts
@@ -1,0 +1,22 @@
+import { rundlerBinaryPath } from "./src/constants";
+import * as instances from "./src/instances";
+import {
+  cleanupRundler,
+  downloadLatestRundlerRelease,
+  isRundlerInstalled,
+} from "./src/rundler";
+
+export default async function () {
+  if (!(await isRundlerInstalled(rundlerBinaryPath))) {
+    await downloadLatestRundlerRelease(rundlerBinaryPath);
+  }
+
+  const shutdown = await Promise.all(
+    Object.values(instances).map((instance) => instance.start())
+  );
+
+  return async () => {
+    await Promise.all(shutdown.map((stop) => stop()));
+    await cleanupRundler(rundlerBinaryPath);
+  };
+}

--- a/.vitest/package.json
+++ b/.vitest/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "local-vitest",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "prool": "^0.0.15",
+    "typescript-template": "*"
+  }
+}

--- a/.vitest/setupTests.ts
+++ b/.vitest/setupTests.ts
@@ -13,6 +13,6 @@ global.fetch = fetch;
 
 beforeAll(async () => {
   await setIntervalMining(client, { interval: 0 });
-}, 20_000);
+}, 60_000);
 
 afterAll(async () => {});

--- a/.vitest/setupTests.ts
+++ b/.vitest/setupTests.ts
@@ -1,6 +1,18 @@
 import dotenv from "dotenv";
 import fetch from "node-fetch";
+import { setIntervalMining } from "viem/actions";
+import { afterAll, beforeAll } from "vitest";
+import * as instances from "./src/instances.js";
+
+const client = instances.anvilArbSepolia.getClient();
+
 dotenv.config();
 
-// @ts-expect-error wut
+// @ts-expect-error this does exist but ts is not liking it
 global.fetch = fetch;
+
+beforeAll(async () => {
+  await setIntervalMining(client, { interval: 0 });
+}, 20_000);
+
+afterAll(async () => {});

--- a/.vitest/src/constants.ts
+++ b/.vitest/src/constants.ts
@@ -1,0 +1,5 @@
+import { join } from "path";
+
+export const rundlerBinaryPath = join(__dirname, "../bin/rundler");
+
+export const poolId = Number(process.env.VITEST_POOL_ID ?? 1);

--- a/.vitest/src/instances.ts
+++ b/.vitest/src/instances.ts
@@ -1,0 +1,131 @@
+import getPort from "get-port";
+import { createServer } from "prool";
+import { anvil, rundler } from "prool/instances";
+import { createClient, http, type Chain, type ClientConfig } from "viem";
+import { arbitrumSepolia } from "viem/chains";
+import { split } from "../../aa-sdk/core/src/transport/split";
+import { poolId, rundlerBinaryPath } from "./constants";
+
+export const anvilArbSepolia = defineInstance({
+  chain: arbitrumSepolia,
+  forkUrl: "https://arbitrum-sepolia-rpc.publicnode.com",
+  anvilPort: 8545,
+  bundlerPort: 8645,
+});
+
+type DefineInstanceParams = {
+  chain: Chain;
+  forkUrl: string;
+  anvilPort: number;
+  bundlerPort: number;
+};
+
+const bundlerMethods = [
+  "eth_sendUserOperation",
+  "eth_estimateUserOperationGas",
+  "eth_getUserOperationReceipt",
+  "eth_getUserOperationByHash",
+  "eth_supportedEntryPoints",
+];
+
+function defineInstance(params: DefineInstanceParams) {
+  const { anvilPort, bundlerPort, forkUrl, chain: chain_ } = params;
+  const rpcUrls = {
+    bundler: `http://127.0.0.1:${bundlerPort}`,
+    anvil: `http://127.0.0.1:${anvilPort}`,
+  };
+
+  const chain = {
+    ...chain_,
+    name: `${chain_.name} (Local)`,
+    rpcUrls: {
+      default: {
+        http: [rpcUrls.anvil],
+      },
+    },
+  } as const satisfies Chain;
+
+  const clientConfig = {
+    chain,
+    transport(args) {
+      const {
+        config,
+        request: request_,
+        value,
+      } = split({
+        overrides: [
+          {
+            methods: bundlerMethods,
+            transport: http(rpcUrls.bundler + `/${poolId}`),
+          },
+        ],
+        fallback: http(rpcUrls.anvil + `/${poolId}`),
+      })(args);
+
+      return {
+        config,
+        request(params) {
+          // Here we can add further custom handling for certain methods, or we can do it above in the split transport config
+          return request_(params);
+        },
+        value,
+      };
+    },
+  } as const satisfies ClientConfig;
+
+  const anvilServer = createServer({
+    instance: anvil({
+      forkUrl: forkUrl,
+      noMining: true,
+    }),
+    port: anvilPort,
+  });
+
+  const bundlerServer = createServer({
+    instance: (key) =>
+      rundler({
+        binary: rundlerBinaryPath,
+        nodeHttp: rpcUrls.anvil + `/${key}`,
+      }),
+    port: bundlerPort,
+  });
+
+  return {
+    chain,
+    clientConfig,
+    anvilServer,
+    bundlerServer,
+    getClient() {
+      return createClient({
+        ...clientConfig,
+        chain,
+        transport: clientConfig.transport,
+      }).extend(() => ({ mode: "anvil" }));
+    },
+    async restart() {
+      await fetch(`${rpcUrls.anvil}/${poolId}/restart`);
+      await bundlerServer.stop();
+      await bundlerServer.start();
+    },
+    async start() {
+      // We do this because it's possible we're running all workspaces at the same time
+      // and we don't want to start the servers multiple times
+      // This still gives us isolation because each workspace should have its own pool id
+      if ((await getPort({ port: anvilPort })) === anvilPort) {
+        await anvilServer.start();
+      }
+      if ((await getPort({ port: bundlerPort })) === bundlerPort) {
+        await bundlerServer.start();
+      }
+
+      return async () => {
+        await bundlerServer.stop();
+        await anvilServer.stop();
+      };
+    },
+    async stop() {
+      await anvilServer.stop();
+      await bundlerServer.stop();
+    },
+  };
+}

--- a/.vitest/src/rundler.ts
+++ b/.vitest/src/rundler.ts
@@ -1,0 +1,93 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pipeline } from "node:stream";
+import { promisify } from "node:util";
+import * as zlib from "node:zlib";
+import * as tar from "tar";
+
+const streamPipeline = promisify(pipeline);
+
+export async function isRundlerInstalled(rundlerPath: string) {
+  try {
+    await fs.promises.access(rundlerPath, fs.constants.F_OK);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export async function cleanupRundler(rundlerPath: string) {
+  await fs.promises.rm(rundlerPath, { force: true });
+}
+
+export async function downloadLatestRundlerRelease(
+  filePath: string,
+  version = "v0.2.2"
+) {
+  const repoUrl =
+    "https://api.github.com/repos/alchemyplatform/rundler/releases";
+  const { arch, platform } = process;
+
+  try {
+    // Get the list of releases from GitHub API
+    const releasesResponse = await fetch(repoUrl);
+    if (!releasesResponse.ok) {
+      throw new Error(
+        `Failed to fetch releases: ${releasesResponse.statusText}`
+      );
+    }
+    const releases: any = await releasesResponse.json();
+
+    if (releases.length === 0) {
+      return;
+    }
+
+    // Get the latest release
+    const latestRelease = releases.find((x: any) => x.tag_name === version);
+    if (!latestRelease) {
+      throw new Error(`Failed to find release with tag ${version}`);
+    }
+
+    const asset = latestRelease.assets
+      .filter((x: any) => (x.name as string).endsWith(".gz"))
+      .find((x: any) => {
+        return (
+          x.name.includes(platform) &&
+          (x.name.includes(arch) ||
+            (arch === "arm64" &&
+              platform === "darwin" &&
+              x.name.includes("aarch64")))
+        );
+      });
+
+    if (!asset) {
+      return;
+    }
+
+    const assetUrl = asset.browser_download_url;
+
+    // Download the asset
+    const assetResponse = await fetch(assetUrl);
+    if (!assetResponse.ok) {
+      throw new Error(`Failed to download asset: ${assetResponse.statusText}`);
+    }
+
+    if (!assetResponse.body) {
+      throw new Error("Github request returned an empty body");
+    }
+
+    // Save the downloaded file
+    const extractPath = path.resolve(filePath, "..");
+    if (!(await isRundlerInstalled(extractPath))) {
+      await fs.promises.mkdir(extractPath, { recursive: true });
+    }
+
+    const gunzipStream = zlib.createGunzip();
+    const tarStream = tar.extract({
+      cwd: extractPath,
+    });
+    await streamPipeline(assetResponse.body, gunzipStream, tarStream);
+  } catch (error) {
+    throw new Error(`Failed to download the latest release. ${error}`);
+  }
+}

--- a/.vitest/tsconfig.json
+++ b/.vitest/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "typescript-template/base.json"
+}

--- a/.vitest/vitest.shared.ts
+++ b/.vitest/vitest.shared.ts
@@ -4,11 +4,12 @@ import { configDefaults, defineConfig } from "vitest/config";
 export const sharedConfig = defineConfig({
   test: {
     alias: {
-      "~test": join(__dirname, "."),
+      "~test": join(__dirname, "./src"),
     },
     singleThread: true,
     globals: true,
     setupFiles: [join(__dirname, "setupTests.ts")],
+    globalSetup: join(__dirname, "globalSetup.ts"),
     exclude: [
       ...configDefaults.exclude,
       "**/e2e-tests/**/*.test.ts",

--- a/account-kit/smart-contracts/tsconfig.json
+++ b/account-kit/smart-contracts/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "typescript-template/base.json",
   "compilerOptions": {
     "paths": {
-      "@account-kit/smart-contracts": ["./src/index.ts"]
+      "@account-kit/smart-contracts": ["./src/index.ts"],
+      "~test/*": ["../../.vitest/src/*"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=18.16"
+    "node": ">=20"
   },
   "workspaces": [
     "aa-sdk/*",
@@ -16,6 +16,7 @@
   "scripts": {
     "generate": "lerna run generate",
     "postgenerate": "yarn lint:write",
+    "preinstall": "yarn config set ignore-engines true",
     "postinstall": "git submodule update --init --recursive",
     "build": "is-ci && yarn build:ci || yarn build:dev",
     "build:base": "lerna run build --verbose --ignore=alchemy-daapp --ignore=embedded-accounts-quickstart --ignore=aa-simple-dapp --ignore=ui-demo",
@@ -52,6 +53,7 @@
     "node-fetch": "^3.3.1",
     "nx": "^17.3.0",
     "prettier": "^2.8.8",
+    "prool": "^0.0.15",
     "vitest": "^0.31.0"
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=20"
+    "node": ">=18.16"
   },
   "workspaces": [
     "aa-sdk/*",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "templates/*",
     "examples/*",
     "site",
-    "doc-gen"
+    "doc-gen",
+    ".vitest"
   ],
   "scripts": {
     "generate": "lerna run generate",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,6 +4543,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz"
@@ -7130,6 +7137,11 @@
     "@noble/hashes" "~1.3.0"
     "@scure/base" "~1.1.0"
 
+"@sec-ant/readable-stream@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
+  integrity sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==
+
 "@shikijs/core@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.5.2.tgz#e3917551ffadf6acbdae495c08065c3d3fd9e381"
@@ -7239,6 +7251,11 @@
   version "0.27.8"
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
+"@sindresorhus/merge-streams@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
+  integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.0"
@@ -11311,6 +11328,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+change-case@5.4.4, change-case@^5.4.4:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.4.4.tgz#0d52b507d8fb8f204343432381d1a6d7bff97a02"
+  integrity sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==
+
 change-case@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz"
@@ -11338,11 +11360,6 @@ change-case@^5.4.3:
   version "5.4.3"
   resolved "https://registry.npmjs.org/change-case/-/change-case-5.4.3.tgz"
   integrity sha512-4cdyvorTy/lViZlVzw2O8/hHCLUuHqp4KpSSP3DlauhFCf3LdnfF+p5s0EAhjKsU7bqrMzu7iQArYfoPiHO2nw==
-
-change-case@^5.4.4:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.4.4.tgz#0d52b507d8fb8f204343432381d1a6d7bff97a02"
-  integrity sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==
 
 character-entities-html4@^2.0.0:
   version "2.1.0"
@@ -11445,6 +11462,11 @@ chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chroma-js@^2.4.2:
   version "2.4.2"
@@ -13952,7 +13974,7 @@ eventemitter3@5.0.1, eventemitter3@^5.0.1:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
-eventemitter3@^4.0.4, eventemitter3@^4.0.7:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -14093,6 +14115,24 @@ execa@^8.0.1:
     onetime "^6.0.0"
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
+
+execa@^9.1.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-9.3.0.tgz#b10b70f52c1a978985e8492cc1fa74795c59963c"
+  integrity sha512-l6JFbqnHEadBoVAVpN5dl2yCyfX28WoBAGaoQcNmLLSedOxTxcn2Qa83s8I/PA5i56vWru2OHOtrwF7Om2vqlg==
+  dependencies:
+    "@sindresorhus/merge-streams" "^4.0.0"
+    cross-spawn "^7.0.3"
+    figures "^6.1.0"
+    get-stream "^9.0.0"
+    human-signals "^7.0.0"
+    is-plain-obj "^4.1.0"
+    is-stream "^4.0.1"
+    npm-run-path "^5.2.0"
+    pretty-ms "^9.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^4.0.0"
+    yoctocolors "^2.0.0"
 
 exponential-backoff@^3.1.1:
   version "3.1.1"
@@ -14247,6 +14287,13 @@ figures@3.2.0, figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+figures@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-6.1.0.tgz#935479f51865fa7479f6fa94fc6fc7ac14e62c4a"
+  integrity sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==
+  dependencies:
+    is-unicode-supported "^2.0.0"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
@@ -14374,6 +14421,11 @@ focus-lock@^1.0.0:
   integrity sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==
   dependencies:
     tslib "^2.0.3"
+
+follow-redirects@^1.0.0:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 follow-redirects@^1.14.0, follow-redirects@^1.14.8, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.3"
@@ -14668,6 +14720,11 @@ get-port@5.1.1:
   resolved "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
+get-port@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-7.1.0.tgz#d5a500ebfc7aa705294ec2b83cc38c5d0e364fec"
+  integrity sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==
+
 get-size@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/get-size/-/get-size-3.0.0.tgz"
@@ -14701,6 +14758,14 @@ get-stream@^8.0.1:
   version "8.0.1"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz"
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
+
+get-stream@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-9.0.1.tgz#95157d21df8eb90d1647102b63039b1df60ebd27"
+  integrity sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==
+  dependencies:
+    "@sec-ant/readable-stream" "^0.4.1"
+    is-stream "^4.0.1"
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -14838,6 +14903,18 @@ glob@^10.0.0:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.2.tgz#bed6b95dade5c1f80b4434daced233aee76160e5"
   integrity sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
+glob@^10.3.7:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"
@@ -15338,6 +15415,15 @@ http-proxy-agent@^7.0.0:
     agent-base "^7.1.0"
     debug "^4.3.4"
 
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
 http-shutdown@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz"
@@ -15383,6 +15469,11 @@ human-signals@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
+human-signals@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-7.0.0.tgz#93e58e0c19cfec1dded4af10cd4969f5ab75f6c8"
+  integrity sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -16066,7 +16157,7 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
-is-plain-obj@^4.0.0:
+is-plain-obj@^4.0.0, is-plain-obj@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
@@ -16136,6 +16227,11 @@ is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz"
   integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
+
+is-stream@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
+  integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -18357,7 +18453,7 @@ minipass@^5.0.0:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
-minipass@^7.1.2:
+minipass@^7.0.4, minipass@^7.1.0, minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
@@ -18382,6 +18478,14 @@ minizlib@^2.1.1, minizlib@^2.1.2:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
+minizlib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.0.1.tgz#46d5329d1eb3c83924eff1d3b858ca0a31581012"
+  integrity sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==
+  dependencies:
+    minipass "^7.0.4"
+    rimraf "^5.0.5"
+
 mipd@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mipd/-/mipd-0.0.5.tgz#367ee796531c23f0631f129038700b1406663aec"
@@ -18400,6 +18504,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mkdirp@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
+  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
 mlly@^1.2.0, mlly@^1.4.2:
   version "1.4.2"
@@ -18994,6 +19103,13 @@ npm-run-path@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz"
   integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
+  dependencies:
+    path-key "^4.0.0"
+
+npm-run-path@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
   dependencies:
     path-key "^4.0.0"
 
@@ -19640,6 +19756,11 @@ parse-ms@^2.1.0:
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
   integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
 
+parse-ms@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
+  integrity sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==
+
 parse-path@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz"
@@ -20064,6 +20185,13 @@ pretty-ms@7.0.1:
   dependencies:
     parse-ms "^2.1.0"
 
+pretty-ms@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-9.0.0.tgz#53c57f81171c53be7ce3fd20bdd4265422bc5929"
+  integrity sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==
+  dependencies:
+    parse-ms "^4.0.0"
+
 prismjs@^1.27.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
@@ -20123,6 +20251,18 @@ promzard@^1.0.0:
   integrity sha512-KQVDEubSUHGSt5xLakaToDFrSoZhStB8dXLzk2xvwR67gJktrHFvpR63oZgHyK19WKbHFLXJqCPXdVR3aBP8Ig==
   dependencies:
     read "^2.0.0"
+
+prool@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/prool/-/prool-0.0.15.tgz#050eb57c56121f0f80ddec70be8ed57aa83469f6"
+  integrity sha512-MSV8LTQtezz4+b6zEd1dmU29CpgChVVb8g/S0H4kXTzuJfzxxq3cJ6CLOX2bIsvjDjakuPaW160Ar08cWHrT2A==
+  dependencies:
+    change-case "5.4.4"
+    eventemitter3 "^5.0.1"
+    execa "^9.1.0"
+    get-port "^7.1.0"
+    http-proxy "^1.18.1"
+    tar "7.2.0"
 
 prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
@@ -21030,6 +21170,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz"
@@ -21131,6 +21276,13 @@ rimraf@^4.4.1:
   integrity sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==
   dependencies:
     glob "^9.2.0"
+
+rimraf@^5.0.5:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.9.tgz#c3baa1b886eadc2ec7981a06a593c3d01134ffe9"
+  integrity sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==
+  dependencies:
+    glob "^10.3.7"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -22085,6 +22237,11 @@ strip-final-newline@^3.0.0:
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
+strip-final-newline@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-4.0.0.tgz#35a369ec2ac43df356e3edd5dcebb6429aa1fa5c"
+  integrity sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==
+
 strip-hex-prefix@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz"
@@ -22342,6 +22499,18 @@ tar@6.1.11:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tar@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.2.0.tgz#f03ae6ecd2e2bab880f2ef33450f502e761d7548"
+  integrity sha512-hctwP0Nb4AB60bj8WQgRYaMOuJYRAPMGiQUAotms5igN8ppfQM+IvjQ5HcKu1MaZh2Wy2KWVTe563Yj8dfc14w==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.0"
+    minizlib "^3.0.1"
+    mkdirp "^3.0.1"
+    yallist "^5.0.0"
 
 tar@^6.1.11, tar@^6.1.2:
   version "6.2.0"
@@ -24212,6 +24381,11 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
+
 yaml@2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz"
@@ -24330,6 +24504,11 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+yoctocolors@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.1.tgz#e0167474e9fbb9e8b3ecca738deaa61dd12e56fc"
+  integrity sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==
 
 zod@^3.0.0:
   version "3.23.8"


### PR DESCRIPTION
# Pull Request Checklist

This begins the migration of tests to using the prool instance. This test doesn't send UOs but does use the on-chain account impl addresses for checking signature schemes. I update the expected return types because they're different now that the chain is `arbSepolia`. However, I first verified that this worked when using polygonMumbai and it worked! So this should be a safe change to make

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Node.js versions, adds vitest configurations, enhances smart contracts testing, and improves rundler installation logic.

### Detailed summary
- Updated Node.js versions to 22.x in workflows
- Added vitest configurations in `.vitest` directory
- Enhanced smart contracts testing setup
- Improved rundler installation logic

> The following files were skipped due to too many changes: `account-kit/smart-contracts/src/light-account/accounts/account.test.ts`, `yarn.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->