### PR TITLE
fix: update CSS overrides doc link

### DIFF
--- a/examples/ui-demo/src/components/configuration/Styling.tsx
+++ b/examples/ui-demo/src/components/configuration/Styling.tsx
@@ -199,7 +199,7 @@ function LearnMore() {
     <div className="flex items-center gap-1 text-xs text-center self-center mt-8">
       <FileCode className="stroke-secondary stroke-1" size={18} />
       <div className="text-secondary">Want to fully configure the CSS?</div>
-      <ExternalLink className="font-semibold text-blue-600" href="#">
+      <ExternalLink className="font-semibold text-blue-600" href="https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/account-kit/react/src/tailwind/types.ts#L6">
         Click to learn how
       </ExternalLink>
     </div>


### PR DESCRIPTION
in demo app, update css overrides link to point to https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/account-kit/react/src/tailwind/types.ts#L6

will be helpful for alpha testers

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the link in the `ExternalLink` component to point to the specific line in a GitHub repository for configuring CSS.

### Detailed summary
- Updated the `href` attribute of the `ExternalLink` component to point to a specific GitHub repository line for CSS configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->