### PR TITLE
test: 6900 RI fork tests

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -66,7 +66,9 @@ jobs:
       # so we don't need a fork url
       - name: Conditionally set fork url
         if: ${{ env.API_KEY != '' }}
-        run: echo "VITEST_SEPOLIA_FORK_URL=https://eth-sepolia.g.alchemy.com/v2/${{ env.API_KEY }}" >> $GITHUB_ENV
+        run: |
+         echo "VITEST_SEPOLIA_FORK_URL=https://eth-sepolia.g.alchemy.com/v2/${{ env.API_KEY }}" >> $GITHUB_ENV
+         echo "VITEST_ARB_SEPOLIA_FORK_URL=https://arb-sepolia.g.alchemy.com/v2/${{ env.API_KEY }}" >> $GITHUB_ENV
           
       - name: Set up foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.vitest/setupTests.ts
+++ b/.vitest/setupTests.ts
@@ -5,7 +5,11 @@ import fetch from "node-fetch";
 import { setAutomine } from "viem/actions";
 import { beforeAll } from "vitest";
 import { poolId } from "./src/constants.js";
-import { local060Instance, local070Instance, local070InstanceArbSep } from "./src/instances.js";
+import {
+  local060Instance,
+  local070Instance,
+  local070InstanceArbSep,
+} from "./src/instances.js";
 import { paymaster060 } from "./src/paymaster/paymaster060.js";
 import { paymaster070 } from "./src/paymaster/paymaster070.js";
 

--- a/.vitest/setupTests.ts
+++ b/.vitest/setupTests.ts
@@ -5,7 +5,7 @@ import fetch from "node-fetch";
 import { setAutomine } from "viem/actions";
 import { beforeAll } from "vitest";
 import { poolId } from "./src/constants.js";
-import { local060Instance, local070Instance } from "./src/instances.js";
+import { local060Instance, local070Instance, local070InstanceArbSep } from "./src/instances.js";
 import { paymaster060 } from "./src/paymaster/paymaster060.js";
 import { paymaster070 } from "./src/paymaster/paymaster070.js";
 
@@ -15,8 +15,11 @@ global.fetch = fetch;
 beforeAll(async () => {
   const client060 = local060Instance.getClient();
   const client070 = local070Instance.getClient();
+  const client070ArbSep = local070InstanceArbSep.getClient();
+
   await setAutomine(client060, true);
   await setAutomine(client070, true);
+  await setAutomine(client070ArbSep, true);
 
   await paymaster060.deployPaymasterContract(client060);
   await paymaster070.deployPaymasterContract(client070);
@@ -30,10 +33,14 @@ afterEach(() => {
 
     console.log(await local070Instance.getLogs("anvil"));
     console.log(await local070Instance.getLogs("bundler"));
+
+    console.log(await local070InstanceArbSep.getLogs("anvil"));
+    console.log(await local070InstanceArbSep.getLogs("bundler"));
   });
 });
 
 afterAll(async () => {
   local060Instance.restart();
   local070Instance.restart();
+  local070InstanceArbSep.restart();
 });

--- a/.vitest/src/instances.ts
+++ b/.vitest/src/instances.ts
@@ -32,6 +32,21 @@ export const local070Instance = defineInstance({
   bundlerPort: 8445,
 });
 
+export const local070InstanceArbSep = defineInstance({
+  chain: {
+    ...localhost,
+    // Manually override the chain id because localhost defaults to 1337
+    id: 421_614,
+  },
+  forkBlockNumber: 67815074,
+  forkUrl:
+    process.env.VITEST_ARB_SEPOLIA_FORK_URL ??
+    "https://arbitrum-sepolia-rpc.publicnode.com",
+  entryPointVersion: "0.7.0",
+  anvilPort: 8345,
+  bundlerPort: 8445,
+});
+
 type DefineInstanceParams = {
   chain: Chain;
   forkUrl: string;

--- a/.vitest/src/instances.ts
+++ b/.vitest/src/instances.ts
@@ -33,18 +33,14 @@ export const local070Instance = defineInstance({
 });
 
 export const local070InstanceArbSep = defineInstance({
-  chain: {
-    ...localhost,
-    // Manually override the chain id because localhost defaults to 1337
-    id: 421_614,
-  },
+  chain: localhost,
   forkBlockNumber: 67815074,
   forkUrl:
     process.env.VITEST_ARB_SEPOLIA_FORK_URL ??
     "https://arbitrum-sepolia-rpc.publicnode.com",
   entryPointVersion: "0.7.0",
-  anvilPort: 8345,
-  bundlerPort: 8445,
+  anvilPort: 8347,
+  bundlerPort: 8447,
 });
 
 type DefineInstanceParams = {

--- a/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
@@ -1,4 +1,4 @@
-import { custom, parseEther, type Address } from "viem";
+import { custom, parseEther, publicActions, type Address } from "viem";
 
 import { LocalAccountSigner, type SmartAccountSigner } from "@aa-sdk/core";
 
@@ -8,6 +8,7 @@ import { local070InstanceArbSep } from "~test/instances.js";
 import { setBalance } from "viem/actions";
 import { resetBalance } from "~test/accounts.js";
 import { accounts } from "~test/constants.js";
+import { parse } from "dotenv";
 
 describe("6900 RI Account Tests", async () => {
   const instance = local070InstanceArbSep;
@@ -26,7 +27,99 @@ describe("6900 RI Account Tests", async () => {
     });
 
     expect(address).toMatchInlineSnapshot(
-      '"0x16D3b5139De103C46EFce3Cbf5B582edF4a75710"'
+      '"0xb32077A16FBfA16333dC37483b1eeB546bcBCc1d"'
+    );
+  });
+
+  it("should execute successfully", async () => {
+    const provider = await givenConnectedProvider({ signer });
+    const targetAddress = "0x000000000000000000000000000000000000dEaD";
+
+    const client = instance.getClient().extend(publicActions);
+
+    await setBalance(instance.getClient(), {
+      address: provider.getAddress(),
+      value: parseEther("1"),
+    });
+
+    const startingAddressBalance = await client.getBalance({
+      address: targetAddress,
+    });
+
+    const result = await provider.sendUserOperation({
+      uo: {
+        target: targetAddress,
+        value: parseEther("0.5"),
+        data: "0x",
+      },
+    });
+
+    const txnHash = provider.waitForUserOperationTransaction(result);
+
+    await expect(txnHash).resolves.not.toThrowError();
+
+    const newAddressBalance = await client.getBalance({
+      address: targetAddress,
+    });
+
+    await expect(newAddressBalance).toEqual(
+      startingAddressBalance + parseEther("0.5")
+    );
+  });
+
+  it("shoud execute batch successfully", async () => {
+    const provider = await givenConnectedProvider({ signer });
+    const targetAddress1 = "0x000000000000000000000000000000000000dEaD";
+    const targetAddress2 = "0x00000000000000000000000000000000dEadDEaD";
+
+    const client = instance.getClient().extend(publicActions);
+
+    await setBalance(instance.getClient(), {
+      address: provider.getAddress(),
+      value: parseEther("2"),
+    });
+
+    const startingAddressBalance1 = await client.getBalance({
+      address: targetAddress1,
+    });
+
+    const startingAddressBalance2 = await client.getBalance({
+      address: targetAddress2,
+    });
+
+    const result = await provider.sendUserOperation({
+      uo: [
+        {
+          target: targetAddress1,
+          value: parseEther("0.5"),
+          data: "0x",
+        },
+        {
+          target: targetAddress2,
+          value: parseEther("1"),
+          data: "0x",
+        },
+      ],
+    });
+
+    const txnHash = provider.waitForUserOperationTransaction(result);
+
+    await expect(txnHash).resolves.not.toThrowError();
+
+    const newAddressBalance1 = await client.getBalance({
+      address: targetAddress1,
+    });
+
+    const newAddressBalance2 = await client.getBalance({
+      address: targetAddress2,
+    });
+
+    await expect(newAddressBalance1).toEqual(
+      startingAddressBalance1 + parseEther("0.5")
+    );
+
+    await expect(newAddressBalance2).toEqual(
+      startingAddressBalance2 + parseEther("1")
     );
   });
 

--- a/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
@@ -6,9 +6,7 @@ import { createSingleSignerRIAccountClient } from "@account-kit/smart-contracts"
 
 import { local070InstanceArbSep } from "~test/instances.js";
 import { setBalance } from "viem/actions";
-import { resetBalance } from "~test/accounts.js";
 import { accounts } from "~test/constants.js";
-import { parse } from "dotenv";
 
 describe("6900 RI Account Tests", async () => {
   const instance = local070InstanceArbSep;

--- a/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
@@ -16,8 +16,6 @@ describe("6900 RI Account Tests", async () => {
   );
 
   it("should successfully get counterfactual address", async () => {
-    // console.log("instance.chain", instance.chain);
-
     const {
       account: { address },
     } = await givenConnectedProvider({

--- a/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/account.test.ts
@@ -1,0 +1,46 @@
+import { custom, parseEther, type Address } from "viem";
+
+import { LocalAccountSigner, type SmartAccountSigner } from "@aa-sdk/core";
+
+import { createSingleSignerRIAccountClient } from "@account-kit/smart-contracts";
+
+import { local070InstanceArbSep } from "~test/instances.js";
+import { setBalance } from "viem/actions";
+import { resetBalance } from "~test/accounts.js";
+import { accounts } from "~test/constants.js";
+
+describe("6900 RI Account Tests", async () => {
+  const instance = local070InstanceArbSep;
+
+  const signer: SmartAccountSigner = new LocalAccountSigner(
+    accounts.fundedAccountOwner
+  );
+
+  it("should successfully get counterfactual address", async () => {
+    // console.log("instance.chain", instance.chain);
+
+    const {
+      account: { address },
+    } = await givenConnectedProvider({
+      signer,
+    });
+
+    expect(address).toMatchInlineSnapshot(
+      '"0x16D3b5139De103C46EFce3Cbf5B582edF4a75710"'
+    );
+  });
+
+  const givenConnectedProvider = async ({
+    signer,
+    accountAddress,
+  }: {
+    signer: SmartAccountSigner;
+    accountAddress?: Address;
+  }) =>
+    createSingleSignerRIAccountClient({
+      chain: instance.chain,
+      signer,
+      accountAddress,
+      transport: custom(instance.getClient()),
+    });
+});

--- a/account-kit/smart-contracts/src/6900-v08-RI/modules/single-signer-validation/module.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/modules/single-signer-validation/module.ts
@@ -1,6 +1,7 @@
 import type { Address } from "viem";
 
 const addresses = {
+  1337: "0x9DA8c098A483E257dd96022831DF308cB24fCBE6",
   421614: "0x9DA8c098A483E257dd96022831DF308cB24fCBE6",
 } as Record<number, Address>;
 

--- a/account-kit/smart-contracts/src/6900-v08-RI/modules/single-signer-validation/module.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/modules/single-signer-validation/module.ts
@@ -1,9 +1,8 @@
 import type { Address } from "viem";
 
 const addresses = {
-  1337: "0x9DA8c098A483E257dd96022831DF308cB24fCBE6",
-  421614: "0x9DA8c098A483E257dd96022831DF308cB24fCBE6",
-} as Record<number, Address>;
+  default: "0x9DA8c098A483E257dd96022831DF308cB24fCBE6",
+} as Record<number | "default", Address>;
 
 export const meta = {
   name: "SingleSignerValidation",

--- a/account-kit/smart-contracts/src/6900-v08-RI/modules/single-signer-validation/signer.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/modules/single-signer-validation/signer.ts
@@ -41,7 +41,7 @@ export const singleSignerMessageSigner = <TSigner extends SmartAccountSigner>(
         "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
 
       return packSignature({
-        validationModule: meta.addresses[chain.id],
+        validationModule: meta.addresses[chain.id] ?? meta.addresses.default,
         entityID: DEFAULT_OWNER_ENTITY_ID,
         isGlobal: true, // todo: make this user-configurable
         orderedHookData: [],
@@ -52,7 +52,7 @@ export const singleSignerMessageSigner = <TSigner extends SmartAccountSigner>(
     signUserOperationHash: (uoHash: `0x${string}`): Promise<`0x${string}`> => {
       return signer.signMessage({ raw: uoHash }).then((signature: Hex) =>
         packSignature({
-          validationModule: meta.addresses[chain.id],
+          validationModule: meta.addresses[chain.id] ?? meta.addresses.default,
           entityID: DEFAULT_OWNER_ENTITY_ID,
           isGlobal: true, // todo: make this user-configurable
           orderedHookData: [],

--- a/account-kit/smart-contracts/src/6900-v08-RI/utils.ts
+++ b/account-kit/smart-contracts/src/6900-v08-RI/utils.ts
@@ -15,6 +15,7 @@ export const DEFAULT_OWNER_ENTITY_ID = 0;
   chain: Chain
 ): Address => {
   switch (chain.id) {
+    case 1337: // localhost
     case arbitrumSepolia.id:
       return "0x1c7EF41AA9896b74223a3956c7dDE28F206E8b24";
     default:

--- a/account-kit/smart-contracts/src/light-account/accounts/multiOwner.test.ts
+++ b/account-kit/smart-contracts/src/light-account/accounts/multiOwner.test.ts
@@ -106,10 +106,6 @@ describe("MultiOwner Light Account Tests", () => {
       },
       transport: custom(client),
       chain: instance.chain,
-      customMiddleware: async (uo) => {
-        console.log(uo);
-        return uo;
-      },
       ...(usePaymaster ? erc7677Middleware() : {}),
     });
 });


### PR DESCRIPTION
Adds an E2E fork test of the 6900 RI account. Required adding a new anvil + rundler instance for arbitrum sepolia.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the codebase with changes related to single signer validation modules and test setups.

### Detailed summary
- Added a default case in a switch statement for chain id 1337
- Updated the handling of middleware in a test file
- Modified the `addresses` object to include a default key
- Defined a new instance `local070InstanceArbSep`
- Updated workflow to set fork URLs
- Adjusted the `signer.ts` file to handle default validation module
- Modified test setup to include a new instance `local070InstanceArbSep`
- Added new imports and tests in `account.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->