### PR TITLE
feat(react): enable multi-owner la usage in core and react

### DIFF
--- a/account-kit/core/src/actions/createAccount.ts
+++ b/account-kit/core/src/actions/createAccount.ts
@@ -1,8 +1,10 @@
 import { type SmartAccountSigner } from "@aa-sdk/core";
 import {
   createLightAccount,
+  createMultiOwnerLightAccount,
   createMultiOwnerModularAccount,
   type CreateLightAccountParams,
+  type CreateMultiOwnerLightAccountParams,
   type CreateMultiOwnerModularAccountParams,
   type LightAccountVersion,
 } from "@account-kit/smart-contracts";
@@ -24,6 +26,15 @@ export type AccountConfig<TAccount extends SupportedAccountTypes> =
           Transport,
           SmartAccountSigner,
           LightAccountVersion<"LightAccount">
+        >,
+        "signer" | "transport" | "chain"
+      >
+    : TAccount extends "MultiOwnerLightAccount"
+    ? Omit<
+        CreateMultiOwnerLightAccountParams<
+          Transport,
+          SmartAccountSigner,
+          LightAccountVersion<"MultiOwnerLightAccount">
         >,
         "signer" | "transport" | "chain"
       >
@@ -87,6 +98,17 @@ export async function createAccount<TAccount extends SupportedAccountTypes>(
         return createLightAccount({
           ...params,
           ...cachedConfig,
+          signer,
+          transport: (opts) => transport({ ...opts, retryCount: 0 }),
+          chain,
+        });
+      case "MultiOwnerLightAccount":
+        return createMultiOwnerLightAccount({
+          ...(params as AccountConfig<"MultiOwnerLightAccount">),
+          ...(cachedConfig as Omit<
+            CreateMultiOwnerLightAccountParams,
+            "transport" | "chain" | "signer"
+          >),
           signer,
           transport: (opts) => transport({ ...opts, retryCount: 0 }),
           chain,

--- a/account-kit/core/src/hydrate.ts
+++ b/account-kit/core/src/hydrate.ts
@@ -115,6 +115,10 @@ const hydrateAccountState = (
         config.MultiOwnerModularAccount && shouldReconnectAccounts
           ? reconnectingState(config.MultiOwnerModularAccount.accountAddress!)
           : defaultAccountState(),
+      MultiOwnerLightAccount:
+        config.MultiOwnerLightAccount && shouldReconnectAccounts
+          ? reconnectingState(config.MultiOwnerLightAccount.accountAddress!)
+          : defaultAccountState(),
     };
 
     return acc;

--- a/account-kit/core/src/store/store.ts
+++ b/account-kit/core/src/store/store.ts
@@ -65,7 +65,7 @@ export const createAccountKitStore = (
             skipHydration: ssr,
             partialize: ({ signer, accounts, ...writeableState }) =>
               writeableState,
-            version: 3,
+            version: 4,
           })
         : () => createInitialStoreState(params)
     )
@@ -243,6 +243,7 @@ export const createDefaultAccountState = (chains: Chain[]) => {
       LightAccount: defaultAccountState<"LightAccount">(),
       MultiOwnerModularAccount:
         defaultAccountState<"MultiOwnerModularAccount">(),
+      MultiOwnerLightAccount: defaultAccountState<"MultiOwnerLightAccount">(),
     };
     return acc;
   }, {} as NoUndefined<StoreState["accounts"]>);

--- a/account-kit/core/src/types.ts
+++ b/account-kit/core/src/types.ts
@@ -6,6 +6,8 @@ import type {
 } from "@account-kit/signer";
 import type {
   LightAccount,
+  LightAccountVersion,
+  MultiOwnerLightAccount,
   MultiOwnerModularAccount,
 } from "@account-kit/smart-contracts";
 import type { CreateConnectorFn } from "@wagmi/core";
@@ -14,17 +16,26 @@ import type { Chain } from "viem";
 import type { PartialBy } from "viem/chains";
 import type { Store, StoredState } from "./store/types";
 
-export type SupportedAccountTypes = "LightAccount" | "MultiOwnerModularAccount";
+export type SupportedAccountTypes =
+  | "MultiOwnerLightAccount"
+  | "LightAccount"
+  | "MultiOwnerModularAccount";
 
 export type SupportedAccounts =
-  | LightAccount<AlchemyWebSigner>
-  | MultiOwnerModularAccount<AlchemyWebSigner>;
+  | LightAccount<AlchemyWebSigner, LightAccountVersion<"LightAccount">>
+  | MultiOwnerModularAccount<AlchemyWebSigner>
+  | MultiOwnerLightAccount<
+      AlchemyWebSigner,
+      LightAccountVersion<"MultiOwnerLightAccount">
+    >;
 
 export type SupportedAccount<T extends SupportedAccountTypes> =
   T extends "LightAccount"
     ? LightAccount<AlchemyWebSigner>
     : T extends "MultiOwnerModularAccount"
     ? MultiOwnerModularAccount<AlchemyWebSigner>
+    : T extends "MultiOwnerLightAccount"
+    ? MultiOwnerLightAccount<AlchemyWebSigner>
     : never;
 
 export type AlchemyAccountsConfig = {

--- a/account-kit/react/src/hooks/useAccount.ts
+++ b/account-kit/react/src/hooks/useAccount.ts
@@ -32,6 +32,7 @@ export type UseAccountProps<TAccount extends SupportedAccountTypes> =
 
 /**
  * Hook to subscribe to account state and interactions, including creation, connection, and status monitoring. It synchronizes with external store updates and provides status-dependent results.
+ * The supported account types are: LightAccount, MultiOwnerLightAccount, and MultiOwnerModularAccount.
  *
  * @example
  * ```ts

--- a/account-kit/react/src/hooks/useSmartAccountClient.ts
+++ b/account-kit/react/src/hooks/useSmartAccountClient.ts
@@ -2,6 +2,8 @@
 
 import type {
   GetAccountParams,
+  MultiOwnerLightAccount,
+  MultiOwnerLightAccountClientActions,
   SupportedAccount,
   SupportedAccounts,
   SupportedAccountTypes,
@@ -10,6 +12,7 @@ import {
   accountLoupeActions,
   createAlchemySmartAccountClientFromExisting,
   lightAccountClientActions,
+  multiOwnerLightAccountClientActions,
   multiOwnerPluginActions,
   pluginManagerActions,
   type AccountLoupeActions,
@@ -52,6 +55,8 @@ export type ClientActions<
   ? MultiOwnerPluginActions<MultiOwnerModularAccount<AlchemyWebSigner>> &
       PluginManagerActions<MultiOwnerModularAccount<AlchemyWebSigner>> &
       AccountLoupeActions<MultiOwnerModularAccount<AlchemyWebSigner>>
+  : TAccount extends MultiOwnerLightAccount
+  ? MultiOwnerLightAccountClientActions<AlchemyWebSigner>
   : never;
 
 export type UseSmartAccountClientResult<
@@ -78,7 +83,7 @@ export function useSmartAccountClient<
 ): UseSmartAccountClientResult<TTransport, TChain, SupportedAccount<TAccount>>;
 
 /**
- * Uses the provided smart account client parameters to create or retrieve an existing smart account client, handling different types of accounts including LightAccount and MultiOwnerModularAccount.
+ * Uses the provided smart account client parameters to create or retrieve an existing smart account client, handling different types of accounts including LightAccount, MultiOwnerLightAccount, and MultiOwnerModularAccount.
  *
  * @example
  * ```ts
@@ -148,6 +153,17 @@ export function useSmartAccountClient({
           policyId: connection.policyId,
           ...clientParams,
         }).extend(lightAccountClientActions),
+        address: account.address,
+        isLoadingClient: false,
+      };
+    case "MultiOwnerLightAccount":
+      return {
+        client: createAlchemySmartAccountClientFromExisting({
+          client: bundlerClient,
+          account,
+          policyId: connection.policyId,
+          ...clientParams,
+        }).extend(multiOwnerLightAccountClientActions),
         address: account.address,
         isLoadingClient: false,
       };

--- a/site/pages/react/send-user-operations.mdx
+++ b/site/pages/react/send-user-operations.mdx
@@ -8,12 +8,13 @@ description: Learn how to send user operations using Account Kit in a React appl
 Once your users have been [authenticated](/react/authenticate-users), you can start sending user operations! Account Kit makes it really easy to send user operations using React hooks.
 
 Sending user operations is really easy, since all you have to do is use the [`useSendUserOperation`](/reference/account-kit/react/hooks/useSendUserOperation) hook.
-If you want to sponsor the gas for a user, see our [guide](#TODO/react/sponsor-gas).
+If you want to sponsor the gas for a user, see our [guide](/react/sponsor-gas).
 
 ## Single user operation
 
 :::tip
-In the below example, we use `LightAccount` as the underlying Smart Contract type. You can also use `MultiOwnerModularAccount` if you want to provide your users with an ERC-6900 compliant modular account.
+In the below example, we use `LightAccount` as the underlying Smart Contract type. You can also use `MultiOwnerModularAccount` if you want to provide your users with an ERC-6900 compliant modular account,
+or you can use `MultiOwnerLightAccount` if you want to support an account with multiple owners.
 :::
 
 ```tsx twoslash

--- a/site/pages/reference/account-kit/react/hooks/useAccount.mdx
+++ b/site/pages/reference/account-kit/react/hooks/useAccount.mdx
@@ -8,6 +8,7 @@ description: Overview of the useAccount method
 # useAccount
 
 Hook to subscribe to account state and interactions, including creation, connection, and status monitoring. It synchronizes with external store updates and provides status-dependent results.
+The supported account types are: LightAccount, MultiOwnerLightAccount, and MultiOwnerModularAccount.
 
 ## Import
 

--- a/site/pages/reference/account-kit/react/hooks/useSmartAccountClient.mdx
+++ b/site/pages/reference/account-kit/react/hooks/useSmartAccountClient.mdx
@@ -7,7 +7,7 @@ description: Overview of the useSmartAccountClient method
 
 # useSmartAccountClient
 
-Uses the provided smart account client parameters to create or retrieve an existing smart account client, handling different types of accounts including LightAccount and MultiOwnerModularAccount.
+Uses the provided smart account client parameters to create or retrieve an existing smart account client, handling different types of accounts including LightAccount, MultiOwnerLightAccount, and MultiOwnerModularAccount.
 
 ## Import
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for `MultiOwnerLightAccount` in account-related functionalities.

### Detailed summary
- Added support for `MultiOwnerLightAccount` in account types and actions
- Updated account creation and client handling functions to include `MultiOwnerLightAccount`
- Updated documentation to reflect the addition of `MultiOwnerLightAccount`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->