### PR TITLE
fix: await instance reset

### DIFF
--- a/.vitest/setupTests.ts
+++ b/.vitest/setupTests.ts
@@ -34,6 +34,6 @@ afterEach(() => {
 });
 
 afterAll(async () => {
-  local060Instance.restart();
-  local070Instance.restart();
+  await local060Instance.restart();
+  await local070Instance.restart();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,14 +138,6 @@
     "@alchemy/aa-core" "^3.18.2"
     viem "2.8.6"
 
-"@alchemy/aa-accounts@^3.19.0":
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/@alchemy/aa-accounts/-/aa-accounts-3.19.0.tgz#ad433eaecf53dcb0ebd5c793c44f217fccc60d72"
-  integrity sha512-cdR8H9LveeUyBWFkmoqU7hZnFoqmdyPQDYZRtFr9aF+3zWAQYYJ/13Vz7aoVQ4lZ57+JQj7fN5vSVn2gFI47yA==
-  dependencies:
-    "@alchemy/aa-core" "^3.18.2"
-    viem "2.8.6"
-
 "@alchemy/aa-alchemy@3.14.1":
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/@alchemy/aa-alchemy/-/aa-alchemy-3.14.1.tgz#66a12acd95eddbffe69d15330de1f30dc092d28b"


### PR DESCRIPTION
The anvil + rundler fork tests were having issues shutting down, and it seems to be caused by non-awaited promises.
![Screenshot 2024-07-30 at 3 55 02 PM](https://github.com/user-attachments/assets/4e8a606e-1d1e-4d9c-bc63-70054e86e466)

There's also a diff in `yarn.lock` after running `yarn install` - not totally sure why, but including it here due to it being auto-generated.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the code to use `await` keyword for restarting instances and removes unnecessary dependencies from `yarn.lock`.

### Detailed summary
- Changed `local060Instance.restart();` to `await local060Instance.restart();`
- Changed `local070Instance.restart();` to `await local070Instance.restart();`
- Removed unnecessary dependencies from `yarn.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->