### PR TITLE
fix(ui-modal): don't render ui modal if no ui config is passed in

### DIFF
--- a/account-kit/core/src/actions/getSmartAccountClient.ts
+++ b/account-kit/core/src/actions/getSmartAccountClient.ts
@@ -150,11 +150,7 @@ export function getSmartAccountClient(
     signerStatus.isAuthenticating ||
     signerStatus.isInitializing
   ) {
-    if (
-      !account &&
-      !signerStatus.isDisconnected &&
-      !signerStatus.isInitializing
-    )
+    if (!account && signerStatus.isConnected)
       createAccount({ type, accountParams }, config);
 
     if (clientState && clientState.isLoadingClient) {

--- a/account-kit/core/src/actions/reconnect.ts
+++ b/account-kit/core/src/actions/reconnect.ts
@@ -52,13 +52,13 @@ export async function reconnect(config: AlchemyAccountsConfig) {
       );
     }
 
-    unsubConnected();
+    setTimeout(() => unsubConnected(), 1);
   });
 
   const unsubDisconnected = signer.on("disconnected", () => {
     store.setState({
       accountConfigs: {},
     });
-    unsubDisconnected();
+    setTimeout(() => unsubDisconnected(), 1);
   });
 }

--- a/account-kit/react/src/context.tsx
+++ b/account-kit/react/src/context.tsx
@@ -165,16 +165,20 @@ export const AlchemyAccountProvider = (
     <Hydrate {...props}>
       <AlchemyAccountContext.Provider value={initialContext}>
         <QueryClientProvider client={queryClient}>
-          <AuthModalContext.Provider
-            value={{
-              authStep,
-              setAuthStep,
-              resetAuthStep,
-            }}
-          >
-            {children}
-            <AuthModal />
-          </AuthModalContext.Provider>
+          {initialContext.ui ? (
+            <AuthModalContext.Provider
+              value={{
+                authStep,
+                setAuthStep,
+                resetAuthStep,
+              }}
+            >
+              {children}
+              <AuthModal />
+            </AuthModalContext.Provider>
+          ) : (
+            children
+          )}
         </QueryClientProvider>
       </AlchemyAccountContext.Provider>
     </Hydrate>


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances account connection handling, improves UI rendering, and adds a slight delay to disconnection actions for stability.

### Detailed summary
- Added a 1ms delay to `unsubConnected` and `unsubDisconnected` calls in `reconnect.ts`
- Updated condition in `getSmartAccountClient.ts` to create account only when `account` is falsy and `signerStatus` is connected
- Modified UI rendering logic in `context.tsx` to conditionally render `AuthModalContext.Provider` based on `initialContext.ui` value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->