### PR TITLE
chore: make viem a peer dependency

### DIFF
--- a/aa-sdk/core/package.json
+++ b/aa-sdk/core/package.json
@@ -52,11 +52,10 @@
   "dependencies": {
     "abitype": "^0.8.3",
     "eventemitter3": "^5.0.1",
-    "viem": "2.20.0",
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0"
   },
   "repository": {
     "type": "git",

--- a/aa-sdk/ethers/package.json
+++ b/aa-sdk/ethers/package.json
@@ -58,11 +58,10 @@
     "@ethersproject/hash": "^5.7.0",
     "@ethersproject/keccak256": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@ethersproject/wallet": "^5.7.0",
-    "viem": "2.20.0"
+    "@ethersproject/wallet": "^5.7.0"
   },
   "peerDependencies": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0"
   },
   "repository": {
     "type": "git",

--- a/account-kit/core/package.json
+++ b/account-kit/core/package.json
@@ -50,17 +50,12 @@
     "@account-kit/signer": "^4.0.0-beta.0",
     "@account-kit/smart-contracts": "^4.0.0-beta.0",
     "js-cookie": "^3.0.5",
-    "viem": "2.20.0",
-    "wagmi": "2.12.7",
     "zod": "^3.22.4",
     "zustand": "^4.5.2"
   },
   "peerDependencies": {
-    "viem": "2.20.0",
-    "wagmi": "2.12.7"
-  },
-  "resolutions": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0",
+    "wagmi": "^2.12.7"
   },
   "publishConfig": {
     "access": "public",

--- a/account-kit/core/src/actions/createAccount.ts
+++ b/account-kit/core/src/actions/createAccount.ts
@@ -1,4 +1,4 @@
-import { type SmartAccountSigner } from "@aa-sdk/core";
+import type { AlchemyWebSigner } from "@account-kit/signer";
 import {
   createLightAccount,
   createMultiOwnerLightAccount,
@@ -24,7 +24,7 @@ export type AccountConfig<TAccount extends SupportedAccountTypes> =
     ? Omit<
         CreateLightAccountParams<
           Transport,
-          SmartAccountSigner,
+          AlchemyWebSigner,
           LightAccountVersion<"LightAccount">
         >,
         "signer" | "transport" | "chain"
@@ -33,13 +33,13 @@ export type AccountConfig<TAccount extends SupportedAccountTypes> =
     ? Omit<
         CreateMultiOwnerLightAccountParams<
           Transport,
-          SmartAccountSigner,
+          AlchemyWebSigner,
           LightAccountVersion<"MultiOwnerLightAccount">
         >,
         "signer" | "transport" | "chain"
       >
     : Omit<
-        CreateMultiOwnerModularAccountParams,
+        CreateMultiOwnerModularAccountParams<Transport, AlchemyWebSigner>,
         "signer" | "transport" | "chain"
       >;
 

--- a/account-kit/infra/package.json
+++ b/account-kit/infra/package.json
@@ -47,14 +47,10 @@
   "dependencies": {
     "@aa-sdk/core": "^4.0.0-beta.0",
     "eventemitter3": "^5.0.1",
-    "viem": "2.20.0",
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "viem": "2.20.0"
-  },
-  "resolutions": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0"
   },
   "publishConfig": {
     "access": "public",

--- a/account-kit/plugingen/package.json
+++ b/account-kit/plugingen/package.json
@@ -73,10 +73,9 @@
     "pathe": "^1.1.2",
     "picocolors": "^1.0.0",
     "prettier": "^3.2.5",
-    "viem": "2.20.0",
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0"
   }
 }

--- a/account-kit/react/package.json
+++ b/account-kit/react/package.json
@@ -70,8 +70,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.4.3",
-    "viem": "2.20.0",
-    "wagmi": "2.12.7"
+    "viem": "^2.20.0",
+    "wagmi": "^2.12.7"
   },
   "resolutions": {
     "viem": "2.20.0"

--- a/account-kit/signer/package.json
+++ b/account-kit/signer/package.json
@@ -54,14 +54,10 @@
     "@turnkey/iframe-stamper": "^1.0.0",
     "@turnkey/viem": "^0.4.8",
     "@turnkey/webauthn-stamper": "^0.4.3",
-    "viem": "2.20.0",
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "viem": "2.20.0"
-  },
-  "resolutions": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0"
   },
   "publishConfig": {
     "access": "public",

--- a/account-kit/signer/src/base.ts
+++ b/account-kit/signer/src/base.ts
@@ -313,7 +313,7 @@ export abstract class BaseAlchemySigner<TClient extends BaseSignerClient>
    * @returns {Promise<any>} A promise that resolves to the signed message
    */
   signTypedData: <
-    const TTypedData extends TypedData | { [key: string]: unknown },
+    const TTypedData extends TypedData | Record<string, unknown>,
     TPrimaryType extends keyof TTypedData | "EIP712Domain" = keyof TTypedData
   >(
     params: TypedDataDefinition<TTypedData, TPrimaryType>

--- a/account-kit/smart-contracts/package.json
+++ b/account-kit/smart-contracts/package.json
@@ -69,10 +69,9 @@
   "gitHead": "ee46e8bb857de3b631044fa70714ea706d9e317d",
   "dependencies": {
     "@aa-sdk/core": "^4.0.0-beta.0",
-    "@account-kit/infra": "^4.0.0-beta.0",
-    "viem": "2.20.0"
+    "@account-kit/infra": "^4.0.0-beta.0"
   },
   "peerDependencies": {
-    "viem": "2.20.0"
+    "viem": "^2.20.0"
   }
 }

--- a/examples/ui-demo/package.json
+++ b/examples/ui-demo/package.json
@@ -30,6 +30,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "tailwind-merge": "^2.3.0",
     "wagmi": "^2.12.7",
+    "viem": "^2.20.0",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
       "site",
       "doc-gen",
       ".vitest"
-    ],
-    "nohoist": [
-      "**/viem",
-      "**/viem/**"
     ]
   },
   "resolutions": {

--- a/site/pages/core/quickstart.mdx
+++ b/site/pages/core/quickstart.mdx
@@ -13,6 +13,14 @@ In this guide, we'll walk you through how to use this package to send a user ope
 
 ## Install packages
 
+**Prerequisites**
+
+- minimum Typescript version of 5
+- pin viem to 2.20.0 (`yarn add viem@2.20.0`)
+- pin wagmi to 2.12.7 (`yarn add wagmi@2.12.7`)
+
+**Installation**
+
 To get started, you'll need to install the required packages. We also install the `infra` package because it contains the necessary `Chain` definitions that makes it easier to setup
 your a Bundler client.
 

--- a/site/pages/infra/quickstart.mdx
+++ b/site/pages/infra/quickstart.mdx
@@ -15,6 +15,13 @@ but you're free to use any smart contract you'd like.
 
 ## Installation
 
+**Prerequisites**
+
+- minimum Typescript version of 5
+- pin viem to 2.20.0 (`yarn add viem@2.20.0`)
+
+**Installation**
+
 :::code-group
 
 ```bash [yarn]

--- a/site/pages/signer/quickstart.mdx
+++ b/site/pages/signer/quickstart.mdx
@@ -15,6 +15,13 @@ Getting started with the Signer is very similar to [getting started with React](
 
 ## Install the Signer package
 
+**Prerequisites**
+
+- minimum Typescript version of 5
+- pin viem to 2.20.0 (`yarn add viem@2.20.0`)
+
+**Installation**
+
 :::code-group
 
 ```bash [yarn]

--- a/site/pages/smart-contracts/light-account/getting-started.mdx
+++ b/site/pages/smart-contracts/light-account/getting-started.mdx
@@ -9,6 +9,13 @@ It is easy to get started with Light Account! We will show you how to create and
 
 ### Install packages
 
+**Prerequisites**
+
+- minimum Typescript version of 5
+- pin viem to 2.20.0 (`yarn add viem@2.20.0`)
+
+**Installation**
+
 :::code-group
 
 ```bash [npm]

--- a/site/pages/smart-contracts/modular-account/getting-started.mdx
+++ b/site/pages/smart-contracts/modular-account/getting-started.mdx
@@ -9,6 +9,13 @@ It is easy to get started with Modular Account! We will show you two different w
 
 ## Install packages
 
+**Prerequisites**
+
+- minimum Typescript version of 5
+- pin viem to 2.20.0 (`yarn add viem@2.20.0`)
+
+**Installation**
+
 First, install the the `@account-kit/smart-contracts` package.
 
 :::code-group

--- a/yarn.lock
+++ b/yarn.lock
@@ -17500,7 +17500,7 @@ vfile@^6.0.0, vfile@^6.0.1:
     unist-util-stringify-position "^4.0.0"
     vfile-message "^4.0.0"
 
-viem@2.20.0, viem@^1.0.0, viem@^2.1.1:
+viem@2.20.0, viem@^1.0.0, viem@^2.1.1, viem@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.20.0.tgz#abff4c2cf733bcc20978e662ea17db117a2881ef"
   integrity sha512-cM4vs81HnSNbfceI1MLkx4pCVzbVjl9xiNSv5SCutYjUyFFOVSPDlEyhpg2iHinxx1NM4Qne3END5eLT8rvUdg==


### PR DESCRIPTION
# This PR

This updates the viem dependencies and wagmi dependencies to be peer dependencies. This should make it more compatible with apps that are already using viem

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `viem` package version to `^2.20.0` and changes the peer dependency to match. It also adds installation instructions for pinning `viem` to `2.20.0` in multiple files.

### Detailed summary
- Updated `viem` package version to `^2.20.0`
- Changed peer dependency for `viem` to `^2.20.0`
- Added installation instructions for pinning `viem` to `2.20.0` in various files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->