### PR TITLE
fix: allow useLogout without authModalContext

### DIFF
--- a/account-kit/react/src/components/auth/context.ts
+++ b/account-kit/react/src/components/auth/context.ts
@@ -27,7 +27,7 @@ export const AuthModalContext = createContext<AuthContextType | undefined>(
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const useAuthContext = (): AuthContextType => {
-  const context = useContext(AuthModalContext);
+  const context = useOptionalAuthContext();
 
   if (!context) {
     throw new Error(
@@ -37,3 +37,7 @@ export const useAuthContext = (): AuthContextType => {
 
   return context;
 };
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const useOptionalAuthContext = (): AuthContextType | undefined =>
+  useContext(AuthModalContext);

--- a/account-kit/react/src/hooks/useLogout.ts
+++ b/account-kit/react/src/hooks/useLogout.ts
@@ -2,7 +2,7 @@
 
 import { disconnect } from "@account-kit/core";
 import { useMutation, type UseMutateFunction } from "@tanstack/react-query";
-import { useAuthContext } from "../components/auth/context.js";
+import { useOptionalAuthContext } from "../components/auth/context.js";
 import { useAlchemyAccountContext } from "../context.js";
 import type { BaseHookMutationArgs } from "../types.js";
 
@@ -37,7 +37,7 @@ export function useLogout(
   mutationArgs?: UseLogoutMutationArgs
 ): UseLogoutResult {
   const { queryClient, config } = useAlchemyAccountContext();
-  const { resetAuthStep } = useAuthContext();
+  const authContext = useOptionalAuthContext();
 
   const {
     mutate: logout,
@@ -47,7 +47,7 @@ export function useLogout(
     {
       mutationFn: async () => {
         await disconnect(config);
-        resetAuthStep();
+        authContext?.resetAuthStep();
       },
       ...mutationArgs,
     },


### PR DESCRIPTION
`useLogout` does not depend on UI components and now will no longer throw an error when used outside an `AuthModalProvider`.`

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the authentication context handling by introducing an optional context hook for better flexibility.

### Detailed summary
- Introduces `useOptionalAuthContext` hook for optional authentication context handling
- Updates `useLogout` hook to use `useOptionalAuthContext` instead of `useAuthContext`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->