### PR TITLE
fix: close OAuth popup from parent

### DIFF
--- a/account-kit/signer/src/client/index.ts
+++ b/account-kit/signer/src/client/index.ts
@@ -454,6 +454,7 @@ export class AlchemySignerWebClient extends BaseSignerClient<ExportWalletParams>
         const { alchemyBundle: bundle, alchemyOrgId: orgId } = event.data;
         if (bundle && orgId) {
           cleanup();
+          popup?.close();
           this.completeAuthWithBundle({
             bundle,
             orgId,


### PR DESCRIPTION
On iOS, a browser window can't close itself via `window.close()`: instead, it must be closed by the same context that called `window.open` to open it. This means that for iOS we cannot rely on the OAuth callback window to close itself in the popup-based flow. Instead, we'll have the parent close it upon receiving a message.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a line of code to close a popup window when `bundle` and `orgId` are present. 

### Detailed summary
- Added `popup?.close()` to close the popup window when `bundle` and `orgId` are present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->