### PR TITLE
fix: make both icons on add passkey modal the same color

### DIFF
--- a/account-kit/react/src/icons/illustrations/passkeys.tsx
+++ b/account-kit/react/src/icons/illustrations/passkeys.tsx
@@ -314,7 +314,7 @@ const PasskeyShieldOutlineLight = ({
     width="20"
     height="20"
     viewBox="0 0 20 20"
-    fill="#363FF9"
+    color="#363FF9"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -354,7 +354,7 @@ const PasskeyShieldFilledLight = ({
     width="21"
     height="20"
     viewBox="0 0 21 20"
-    fill="#363FF9"
+    color="#363FF9"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -374,7 +374,7 @@ const PasskeyShieldFlatLight = ({
     width="20"
     height="20"
     viewBox="0 0 20 20"
-    fill="#363FF9"
+    color="#363FF9"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -404,7 +404,7 @@ const PasskeyShieldOutlineDark = ({
     width="20"
     height="20"
     viewBox="0 0 20 20"
-    fill="#9AB7FF"
+    color="#9AB7FF"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -444,7 +444,7 @@ const PasskeyShieldFilledDark = ({
     width="21"
     height="20"
     viewBox="0 0 21 20"
-    fill="#9AB7FF"
+    color="#9AB7FF"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
@@ -464,7 +464,7 @@ const PasskeyShieldFlatDark = ({
     width="20"
     height="20"
     viewBox="0 0 20 20"
-    fill="#9AB7FF"
+    color="#9AB7FF"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

## Test Plan
### Before: mismatched colors
![Screenshot 2024-09-19 at 12 43 38 PM](https://github.com/user-attachments/assets/4d4b3377-5298-4736-87b3-0c813bfb7815)

### After: icons are both blue
![Screenshot 2024-09-19 at 12 37 57 PM](https://github.com/user-attachments/assets/35b72c0e-9765-4186-9773-2ae2b2092806)
![Screenshot 2024-09-19 at 12 38 26 PM](https://github.com/user-attachments/assets/61c13a5d-13ed-48a2-a722-59a183d2b0cd)
![Screenshot 2024-09-19 at 12 38 53 PM](https://github.com/user-attachments/assets/1649c66e-f001-462e-8336-5b83d459f133)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the SVG elements in the `passkeys.tsx` file to replace the `fill` attribute with the `color` attribute for various passkey shield components.

### Detailed summary
- Changed `fill` to `color` for the following components:
  - `PasskeyShieldFilledLight`
  - `PasskeyShieldFlatLight`
  - `PasskeyShieldOutlineDark`
  - `PasskeyShieldFilledDark`
  - `PasskeyShieldFlatDark`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->