### PR TITLE
fix: prevent passkey modal from re-opening on blur

### DIFF
--- a/account-kit/react/src/components/auth/card/index.tsx
+++ b/account-kit/react/src/components/auth/card/index.tsx
@@ -98,6 +98,13 @@ export const AuthCardContent = ({
     }
   }, [authStep, setAuthStep, signer]);
 
+  const onClose = useCallback(() => {
+    if (authStep.type === "passkey_create") {
+      setAuthStep({ type: "complete" });
+    }
+    closeAuthModal();
+  }, [authStep.type, closeAuthModal, setAuthStep]);
+
   useLayoutEffect(() => {
     if (authStep.type === "complete") {
       didGoBack.current = false;
@@ -141,7 +148,7 @@ export const AuthCardContent = ({
                 showClose={showClose}
                 showBack={canGoBack}
                 onBack={onBack}
-                onClose={closeAuthModal}
+                onClose={onClose}
               />
             )}
             <Step />


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

# Bug description:

When you login to the demo app via email and close the setup passkey modal via the top right x, the modal will reappear if you click off window and then back into the window.  The X was not capturing setting the authStep correctly to 'complete' as it does when you click the skip button.

# Testing steps

Sign into the demo app with a new account using email.  
When you click the email and are re-routed back to the app close the passkey modal using the X in the top right corner.
Click off window and back into the demo app.  The passkey modal should not reappear.

![Screenshot 2024-09-26 at 10 20 24 AM](https://github.com/user-attachments/assets/c0faaf5f-5c4d-46b9-a83c-38a7ed0933e1)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `onClose` function in the `AuthCardContent` component, which modifies the behavior when closing the authentication modal based on the current `authStep`. 

### Detailed summary
- Added `onClose` function using `useCallback` to handle closing the modal.
- Checks if `authStep.type` is `"passkey_create"` and sets `authStep` to `{ type: "complete" }`.
- Replaced the `onClose` prop passed to the component from `closeAuthModal` to the new `onClose` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->