### PR TITLE
feat: toast

### DIFF
--- a/examples/ui-demo/package.json
+++ b/examples/ui-demo/package.json
@@ -16,6 +16,7 @@
     "@phun-ky/moebius": "^1.0.6",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-switch": "^1.0.3",
+    "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@t3-oss/env-core": "^0.7.1",
     "@t3-oss/env-nextjs": "^0.7.1",

--- a/examples/ui-demo/src/app/globals.css
+++ b/examples/ui-demo/src/app/globals.css
@@ -97,7 +97,7 @@
 
 /* Radix Toast Animations */
 @keyframes slideInToast {
-  from { 
+  from {
     transform: translateY(100%);
     opacity: 0;
   }

--- a/examples/ui-demo/src/app/globals.css
+++ b/examples/ui-demo/src/app/globals.css
@@ -96,8 +96,8 @@
 }
 
 /* Radix Toast Animations */
-@keyframes slideIn {
-  from {
+@keyframes slideInToast {
+  from { 
     transform: translateY(100%);
     opacity: 0;
   }
@@ -107,7 +107,7 @@
   }
 }
 
-@keyframes hide {
+@keyframes hideToast {
   from {
     transform: translateY(0%);
     opacity: 1;
@@ -118,10 +118,10 @@
   }
 }
 
-[data-state="open"] {
-  animation: slideIn 200ms cubic-bezier(0.16, 1, 0.3, 1);
+#toast[data-state="open"] {
+  animation: slideInToast 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-[data-state="closed"] {
-  animation: hide 100ms ease-in forwards;
+#toast[data-state="closed"] {
+  animation: hideToast 100ms ease-in forwards;
 }

--- a/examples/ui-demo/src/app/globals.css
+++ b/examples/ui-demo/src/app/globals.css
@@ -94,3 +94,34 @@
     --alpha-pointer-box-shadow: rgb(0 0 0 / 37%) 0px 1px 4px 0px !important;
   }
 }
+
+/* Radix Toast Animations */
+@keyframes slideIn {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+}
+
+@keyframes hide {
+  from {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+}
+
+[data-state="open"] {
+  animation: slideIn 200ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-state="closed"] {
+  animation: hide 100ms ease-in forwards;
+}

--- a/examples/ui-demo/src/app/page.tsx
+++ b/examples/ui-demo/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { Authentication } from "@/components/configuration/Authentication";
 import { Styling } from "@/components/configuration/Styling";
 import { Inter, Public_Sans } from "next/font/google";
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { AuthCardWrapper } from "../components/preview/AuthCardWrapper";
 import { CodePreview } from "../components/preview/CodePreview";
 import { CodePreviewSwitch } from "../components/shared/CodePreviewSwitch";

--- a/examples/ui-demo/src/app/providers.tsx
+++ b/examples/ui-demo/src/app/providers.tsx
@@ -6,7 +6,7 @@ import { AlchemyAccountProvider, createConfig } from "@account-kit/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense } from "react";
 import { ConfigContextProvider, DEFAULT_CONFIG } from "./state";
-import { Provider as ToastProvider } from "@radix-ui/react-toast";
+import { ToastProvider } from "@/contexts/ToastProvider";
 
 const queryClient = new QueryClient();
 
@@ -41,9 +41,9 @@ export const Providers = (props: PropsWithChildren<{}>) => {
           config={alchemyConfig}
           queryClient={queryClient}
         >
-        <ToastProvider>
-          <ConfigContextProvider>{props.children}</ConfigContextProvider>
-        </ToastProvider>
+          <ToastProvider>
+            <ConfigContextProvider>{props.children}</ConfigContextProvider>
+          </ToastProvider>
         </AlchemyAccountProvider>
       </QueryClientProvider>
     </Suspense>

--- a/examples/ui-demo/src/app/providers.tsx
+++ b/examples/ui-demo/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { AlchemyAccountProvider, createConfig } from "@account-kit/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense } from "react";
 import { ConfigContextProvider, DEFAULT_CONFIG } from "./state";
+import { Provider as ToastProvider } from "@radix-ui/react-toast";
 
 const queryClient = new QueryClient();
 
@@ -40,7 +41,9 @@ export const Providers = (props: PropsWithChildren<{}>) => {
           config={alchemyConfig}
           queryClient={queryClient}
         >
+        <ToastProvider>
           <ConfigContextProvider>{props.children}</ConfigContextProvider>
+        </ToastProvider>
         </AlchemyAccountProvider>
       </QueryClientProvider>
     </Suspense>

--- a/examples/ui-demo/src/components/icons/x.tsx
+++ b/examples/ui-demo/src/components/icons/x.tsx
@@ -1,0 +1,23 @@
+export const XIcon = ({
+  stroke = "currentColor",
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <g>
+      <path
+        id="Icon"
+        d="M12.6668 3.33301L3.3335 12.6663M12.6668 12.6663L3.3335 3.33301"
+        stroke={stroke}
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </g>
+  </svg>
+);

--- a/examples/ui-demo/src/components/shared/MintCard.tsx
+++ b/examples/ui-demo/src/components/shared/MintCard.tsx
@@ -15,6 +15,7 @@ import { AccountKitNftMinterABI, nftContractAddress } from "@/utils/config";
 import { encodeFunctionData } from "viem";
 import { useConfig } from "@/app/state";
 import { useQuery } from "@tanstack/react-query";
+import { Toast } from "./Toast";
 
 type NFTLoadingState = "loading" | "success";
 
@@ -32,8 +33,11 @@ type MintStatus = {
 
 export const MintCard = () => {
   const [status, setStatus] = useState<MintStatus>(initialState);
-  // To be wired into the toast pr
-  const [hasError, setHasError] = useState(false);
+  const [toastContent, setToastContent] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
   const { nftTransfered, setNFTTransfered } = useConfig();
 
   const handleSuccess = () => {
@@ -42,11 +46,18 @@ export const MintCard = () => {
       gas: "success",
       signing: "success",
     }));
+    setToastContent({
+      type: "success",
+      text: "You've successfully collected your NFT! Refresh to mint again.",
+    });
     setNFTTransfered(true);
   };
   const handleError = () => {
     setStatus(initialState);
-    setHasError(true);
+    setToastContent({
+      type: "error",
+      text: "There was a problem with that action",
+    });
   };
 
   const { client } = useSmartAccountClient({ type: "LightAccount" });
@@ -102,6 +113,13 @@ export const MintCard = () => {
 
   return (
     <div className="flex bg-bg-surface-default radius-1 border-btn-secondary border-2 overflow-hidden h-[532px]">
+      <Toast
+        text={toastContent?.text || ""}
+        type={toastContent?.type || "success"}
+        open={!!toastContent}
+        // For auto close of toast
+        setOpen={() => setToastContent(null)}
+      />
       <div className="px-10 py-12 h-full w-[428px]">
         <h1 className="text-3xl font-semibold  leading-10 mb-8 text-fg-primary">
           {!nftTransfered ? "One-click checkout" : "You collected your NFT!"}

--- a/examples/ui-demo/src/components/shared/MintCard.tsx
+++ b/examples/ui-demo/src/components/shared/MintCard.tsx
@@ -47,6 +47,7 @@ export const MintCard = () => {
     setToast({
       type: "success",
       text: "You've successfully collected your NFT! Refresh to mint again.",
+      open: true,
     });
     setNFTTransfered(true);
   };
@@ -55,6 +56,7 @@ export const MintCard = () => {
     setToast({
       type: "error",
       text: "There was a problem with that action",
+      open: true,
     });
   };
 

--- a/examples/ui-demo/src/components/shared/MintCard.tsx
+++ b/examples/ui-demo/src/components/shared/MintCard.tsx
@@ -15,7 +15,7 @@ import { AccountKitNftMinterABI, nftContractAddress } from "@/utils/config";
 import { encodeFunctionData } from "viem";
 import { useConfig } from "@/app/state";
 import { useQuery } from "@tanstack/react-query";
-import { Toast } from "./Toast";
+import { useToast } from "@/hooks/useToast";
 
 type NFTLoadingState = "loading" | "success";
 
@@ -33,10 +33,8 @@ type MintStatus = {
 
 export const MintCard = () => {
   const [status, setStatus] = useState<MintStatus>(initialState);
-  const [toastContent, setToastContent] = useState<{
-    type: "success" | "error";
-    text: string;
-  } | null>(null);
+
+  const { setToast } = useToast();
 
   const { nftTransfered, setNFTTransfered } = useConfig();
 
@@ -46,7 +44,7 @@ export const MintCard = () => {
       gas: "success",
       signing: "success",
     }));
-    setToastContent({
+    setToast({
       type: "success",
       text: "You've successfully collected your NFT! Refresh to mint again.",
     });
@@ -54,7 +52,7 @@ export const MintCard = () => {
   };
   const handleError = () => {
     setStatus(initialState);
-    setToastContent({
+    setToast({
       type: "error",
       text: "There was a problem with that action",
     });
@@ -113,13 +111,6 @@ export const MintCard = () => {
 
   return (
     <div className="flex bg-bg-surface-default radius-1 border-btn-secondary border-2 overflow-hidden h-[532px]">
-      <Toast
-        text={toastContent?.text || ""}
-        type={toastContent?.type || "success"}
-        open={!!toastContent}
-        // For auto close of toast
-        setOpen={() => setToastContent(null)}
-      />
       <div className="px-10 py-12 h-full w-[428px]">
         <h1 className="text-3xl font-semibold  leading-10 mb-8 text-fg-primary">
           {!nftTransfered ? "One-click checkout" : "You collected your NFT!"}

--- a/examples/ui-demo/src/components/shared/Toast.tsx
+++ b/examples/ui-demo/src/components/shared/Toast.tsx
@@ -9,7 +9,7 @@ import { useToast } from "@/hooks/useToast";
 
 export const Toast = () => {
   const { closeToast, toast } = useToast();
-
+  const { type, text, open } = toast;
   const getBGColor = () => {
     switch (toast?.type) {
       case "error":
@@ -47,17 +47,19 @@ export const Toast = () => {
     <>
       <Root
         id="toast"
-        open={!!toast}
+        open={open}
         onOpenChange={closeToast}
         className={`${getBGColor()} align-middle rounded-lg shadow-lg px-3 py-2 flex justify-center items-center`}
       >
         <p className={`${getTextColor()} text-center pr-2 align-middle`}>
           <span
-            className={`bg-[${getButtonColor()}] align-middle px-2 py-1 text-fg-invert text-xs font-semibold rounded mr-2`}
+            className={`${
+              type === "success" ? "bg-[#16A34A]" : "bg-[#DC2626]"
+            } align-middle px-2 py-1 text-fg-invert text-xs font-semibold rounded mr-2`}
           >
-            {toast?.type === "success" ? "Success" : "Error"}
+            {type === "success" ? "Success" : "Error"}
           </span>
-          {toast?.text}
+          {text}
         </p>
         <Close>
           <XIcon stroke={getButtonColor()} />

--- a/examples/ui-demo/src/components/shared/Toast.tsx
+++ b/examples/ui-demo/src/components/shared/Toast.tsx
@@ -5,7 +5,7 @@ import { Root, Viewport, Close } from "@radix-ui/react-toast";
 import { XIcon } from "../icons/x";
 import { useToast } from "@/hooks/useToast";
 
-// Toast is not themed due to its positioning over the perma-white nav bar.
+// Toast is not themed due to its positioning over the perma-white nav bar
 
 export const Toast = () => {
   const { closeToast, toast } = useToast();

--- a/examples/ui-demo/src/components/shared/Toast.tsx
+++ b/examples/ui-demo/src/components/shared/Toast.tsx
@@ -49,7 +49,8 @@ export const Toast = ({ text, open, setOpen, type }: ToastProps) => {
 
   return (
     <>
-      <Root
+      <Root 
+        id="toast"
         open={open}
         onOpenChange={setOpen}
         className={`${getBGColor()} align-middle rounded-lg shadow-lg px-3 py-2 flex justify-center items-center`}

--- a/examples/ui-demo/src/components/shared/Toast.tsx
+++ b/examples/ui-demo/src/components/shared/Toast.tsx
@@ -55,7 +55,7 @@ export const Toast = () => {
           <span
             className={`${
               type === "success" ? "bg-[#16A34A]" : "bg-[#DC2626]"
-            } align-middle px-2 py-1 text-fg-invert text-xs font-semibold rounded mr-2`}
+            } align-middle px-2 py-1 text-[#FFFFF] text-xs font-semibold rounded mr-2`}
           >
             {type === "success" ? "Success" : "Error"}
           </span>

--- a/examples/ui-demo/src/components/shared/Toast.tsx
+++ b/examples/ui-demo/src/components/shared/Toast.tsx
@@ -1,0 +1,72 @@
+"use client";
+import React from "react";
+
+import { Root, Viewport, Close } from "@radix-ui/react-toast";
+import { XIcon } from "../icons/x";
+
+type ToastProps = {
+  text: string;
+  type: "success" | "error";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+// Toast is not themed due to its positioning over the perma-white nav bar.
+
+export const Toast = ({ text, open, setOpen, type }: ToastProps) => {
+  const getBGColor = () => {
+    switch (type) {
+      case "error":
+        // "bg-bg-surface-critical"
+        return "bg-[#FEF2F2]";
+      case "success":
+        // bg-bg-surface-success-subtle
+        return "bg-[#F0FdF4]";
+    }
+  };
+
+  const getTextColor = () => {
+    switch (type) {
+      case "error":
+        //  "text-fg-critical";
+        return "text-[#B91C1C]";
+      case "success":
+        //  "text-bg-surface-success";
+        return "text-[#15803D]";
+    }
+  };
+
+  const getButtonColor = () => {
+    switch (type) {
+      case "error":
+        // "bg-surface-error";
+        return "#DC2626";
+      case "success":
+        // "bg-surface-success";
+        return "#16A34A";
+    }
+  };
+
+  return (
+    <>
+      <Root
+        open={open}
+        onOpenChange={setOpen}
+        className={`${getBGColor()} align-middle rounded-lg shadow-lg px-3 py-2 flex justify-center items-center`}
+      >
+        <p className={`${getTextColor()} text-center pr-2 align-middle`}>
+          <span
+            className={`bg-[${getButtonColor()}] align-middle px-2 py-1 text-fg-invert text-xs font-semibold rounded mr-2`}
+          >
+            {type === "success" ? "Success" : "Error"}
+          </span>
+          {text}
+        </p>
+        <Close>
+          <XIcon stroke={getButtonColor()} />
+        </Close>
+      </Root>
+      <Viewport className="fixed top-2 right-1/2 translate-x-1/2 z-50 outline-none" />
+    </>
+  );
+};

--- a/examples/ui-demo/src/components/shared/Toast.tsx
+++ b/examples/ui-demo/src/components/shared/Toast.tsx
@@ -3,19 +3,15 @@ import React from "react";
 
 import { Root, Viewport, Close } from "@radix-ui/react-toast";
 import { XIcon } from "../icons/x";
-
-type ToastProps = {
-  text: string;
-  type: "success" | "error";
-  open: boolean;
-  setOpen: (open: boolean) => void;
-};
+import { useToast } from "@/hooks/useToast";
 
 // Toast is not themed due to its positioning over the perma-white nav bar.
 
-export const Toast = ({ text, open, setOpen, type }: ToastProps) => {
+export const Toast = () => {
+  const { closeToast, toast } = useToast();
+
   const getBGColor = () => {
-    switch (type) {
+    switch (toast?.type) {
       case "error":
         // "bg-bg-surface-critical"
         return "bg-[#FEF2F2]";
@@ -26,7 +22,7 @@ export const Toast = ({ text, open, setOpen, type }: ToastProps) => {
   };
 
   const getTextColor = () => {
-    switch (type) {
+    switch (toast?.type) {
       case "error":
         //  "text-fg-critical";
         return "text-[#B91C1C]";
@@ -37,7 +33,7 @@ export const Toast = ({ text, open, setOpen, type }: ToastProps) => {
   };
 
   const getButtonColor = () => {
-    switch (type) {
+    switch (toast?.type) {
       case "error":
         // "bg-surface-error";
         return "#DC2626";
@@ -49,19 +45,19 @@ export const Toast = ({ text, open, setOpen, type }: ToastProps) => {
 
   return (
     <>
-      <Root 
+      <Root
         id="toast"
-        open={open}
-        onOpenChange={setOpen}
+        open={!!toast}
+        onOpenChange={closeToast}
         className={`${getBGColor()} align-middle rounded-lg shadow-lg px-3 py-2 flex justify-center items-center`}
       >
         <p className={`${getTextColor()} text-center pr-2 align-middle`}>
           <span
             className={`bg-[${getButtonColor()}] align-middle px-2 py-1 text-fg-invert text-xs font-semibold rounded mr-2`}
           >
-            {type === "success" ? "Success" : "Error"}
+            {toast?.type === "success" ? "Success" : "Error"}
           </span>
-          {text}
+          {toast?.text}
         </p>
         <Close>
           <XIcon stroke={getButtonColor()} />

--- a/examples/ui-demo/src/contexts/ToastProvider.tsx
+++ b/examples/ui-demo/src/contexts/ToastProvider.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Toast } from "@/components/shared/Toast";
+import { Provider } from "@radix-ui/react-toast";
+import { createContext, PropsWithChildren, useState } from "react";
+
+export type ToastType = { text: string; type: "success" | "error" };
+export const ToastContext = createContext<{
+  toast: ToastType | null;
+  setToast: (toast: ToastType | null) => void;
+  closeToast: () => void;
+}>({
+  toast: null,
+  setToast: (toast: ToastType | null) => {},
+  closeToast: () => {},
+});
+export const ToastProvider = ({ children }: PropsWithChildren) => {
+  const [toast, setToast] = useState<ToastType | null>(null);
+  const closeToast = () => setToast(null);
+  return (
+    <ToastContext.Provider value={{ toast, setToast, closeToast }}>
+      <Provider>
+        <>
+          {children}
+          <Toast />
+        </>
+      </Provider>
+    </ToastContext.Provider>
+  );
+};

--- a/examples/ui-demo/src/contexts/ToastProvider.tsx
+++ b/examples/ui-demo/src/contexts/ToastProvider.tsx
@@ -4,19 +4,31 @@ import { Toast } from "@/components/shared/Toast";
 import { Provider } from "@radix-ui/react-toast";
 import { createContext, PropsWithChildren, useState } from "react";
 
-export type ToastType = { text: string; type: "success" | "error" };
+export type ToastType = {
+  text: string;
+  type: "success" | "error";
+  open: boolean;
+};
 export const ToastContext = createContext<{
-  toast: ToastType | null;
-  setToast: (toast: ToastType | null) => void;
+  toast: ToastType;
+  setToast: (toast: ToastType) => void;
   closeToast: () => void;
 }>({
-  toast: null,
-  setToast: (toast: ToastType | null) => {},
+  toast: {
+    text: "",
+    type: "success",
+    open: false,
+  },
+  setToast: (toast: ToastType) => {},
   closeToast: () => {},
 });
 export const ToastProvider = ({ children }: PropsWithChildren) => {
-  const [toast, setToast] = useState<ToastType | null>(null);
-  const closeToast = () => setToast(null);
+  const [toast, setToast] = useState<ToastType>({
+    text: "",
+    type: "success",
+    open: false,
+  });
+  const closeToast = () => setToast((prev) => ({ ...prev, open: false }));
   return (
     <ToastContext.Provider value={{ toast, setToast, closeToast }}>
       <Provider>

--- a/examples/ui-demo/src/hooks/useToast.tsx
+++ b/examples/ui-demo/src/hooks/useToast.tsx
@@ -4,8 +4,10 @@ import { ToastContext } from "@/contexts/ToastProvider";
 import { useContext } from "react";
 
 export const useToast = () => {
-  if (!ToastContext) { 
-    throw Error("useToast can only be used by components that are descendants of the ToastProvider`");
+  if (!ToastContext) {
+    throw Error(
+      "useToast can only be used by components that are descendants of the ToastProvider`"
+    );
   }
   const toastContext = useContext(ToastContext);
   return toastContext;

--- a/examples/ui-demo/src/hooks/useToast.tsx
+++ b/examples/ui-demo/src/hooks/useToast.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { ToastContext } from "@/contexts/ToastProvider";
+import { useContext } from "react";
+
+export const useToast = () => {
+  const { toast, setToast, closeToast } = useContext(ToastContext);
+  return { toast, setToast, closeToast };
+};

--- a/examples/ui-demo/src/hooks/useToast.tsx
+++ b/examples/ui-demo/src/hooks/useToast.tsx
@@ -4,6 +4,9 @@ import { ToastContext } from "@/contexts/ToastProvider";
 import { useContext } from "react";
 
 export const useToast = () => {
-  const { toast, setToast, closeToast } = useContext(ToastContext);
-  return { toast, setToast, closeToast };
+  if (!ToastContext) { 
+    throw Error("useToast can only be used by components that are descendants of the ToastProvider`");
+  }
+  const toastContext = useContext(ToastContext);
+  return toastContext;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5167,6 +5167,16 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-slot" "1.0.2"
 
+"@radix-ui/react-collection@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.0.tgz#f18af78e46454a2360d103c2251773028b7724ed"
+  integrity sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -5470,6 +5480,24 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-roving-focus" "1.0.4"
     "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-toast@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.2.1.tgz#4bde231ed27d007dcd0455a446565ca619f92a2d"
+  integrity sha512-5trl7piMXcZiCq7MW6r8YYmu0bK5qDpTWz+FdEPdKyft2UixkspheYbjbrLXVN5NGKHFbOP7lm8eD0biiSqZqg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-collection" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-dismissable-layer" "1.1.0"
+    "@radix-ui/react-portal" "1.1.1"
+    "@radix-ui/react-presence" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.0"
 
 "@radix-ui/react-tooltip@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

# Description
Adds a toast component to display a success / error when transferring and NFT.
![Screenshot 2024-09-27 at 6 04 12 PM](https://github.com/user-attachments/assets/0ba4ec9a-0ecb-43e8-81a4-bdbedd640e75)

# Testing steps
Attempt to transfer an NFT, on success you should see a green toast appear on top of the white nav bar.
You can click the X next to the toast to dismiss it early.  It will naturally dismiss after 4 seconds.
This toast is not themeable as the nav bar is always white.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `Toast` notification system using `@radix-ui/react-toast`. It adds a `ToastProvider`, updates the UI components to utilize the toast functionality, and implements animations for toast visibility.

### Detailed summary
- Added `@radix-ui/react-toast` dependency.
- Created `ToastProvider` in `ToastProvider.tsx`.
- Implemented `useToast` hook in `useToast.tsx`.
- Added `Toast` component for displaying notifications.
- Integrated toast notifications in `MintCard` for success/error messages.
- Added toast animations in `globals.css`.
- Created `XIcon` component for closing the toast.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->