### PR TITLE
fix: ensure openid is included in custom scopes

### DIFF
--- a/account-kit/signer/src/client/index.ts
+++ b/account-kit/signer/src/client/index.ts
@@ -511,7 +511,7 @@ export class AlchemySignerWebClient extends BaseSignerClient<ExportWalletParams>
     let scope: string;
     let claims: string | undefined;
     if (providedScope) {
-      scope = providedScope;
+      scope = addOpenIdIfAbsent(providedScope);
       claims = providedClaims;
     } else {
       if (isCustomProvider) {
@@ -668,6 +668,17 @@ function resolveRelativeUrl(url: string): string {
   const a = document.createElement("a");
   a.href = url;
   return a.href;
+}
+
+/**
+ * "openid" is a required scope in the OIDC protocol. Insert it if the user
+ * forgot.
+ *
+ * @param {string} scope scope param which may be missing "openid"
+ * @returns {string} scope which most definitely contains "openid"
+ */
+function addOpenIdIfAbsent(scope: string): string {
+  return scope.match(/\bopenid\b/) ? scope : `openid ${scope}`;
 }
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new function to ensure the `openid` scope is included in the OAuth flow, enhancing compliance with the OIDC protocol.

### Detailed summary
- Added a new function `addOpenIdIfAbsent` to check and prepend `openid` to the provided scope if it is missing.
- Updated the assignment of `scope` to use the new `addOpenIdIfAbsent` function when `providedScope` is available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->