### PR TITLE
fix: prevent mintcard without client loaded

### DIFF
--- a/examples/ui-demo/src/components/preview/AuthCardWrapper.tsx
+++ b/examples/ui-demo/src/components/preview/AuthCardWrapper.tsx
@@ -1,11 +1,14 @@
 import { useConfig } from "@/app/state";
 import { cn } from "@/lib/utils";
-import { AuthCard, useUser } from "@account-kit/react";
+import { AuthCard, useSmartAccountClient, useUser } from "@account-kit/react";
 import { MintCard } from "../shared/MintCard";
+import { LoadingIcon } from "../icons/loading";
 
 export function AuthCardWrapper({ className }: { className?: string }) {
   const user = useUser();
   const { config } = useConfig();
+  const { client } = useSmartAccountClient({ type: "LightAccount" });
+
   return (
     <div
       className={cn(
@@ -14,15 +17,31 @@ export function AuthCardWrapper({ className }: { className?: string }) {
         className
       )}
     >
-      {!user ? (
-        <div className="flex flex-col gap-2 w-[368px]">
-          <div className="modal bg-surface-default shadow-md overflow-hidden">
-            <AuthCard />
-          </div>
-        </div>
-      ) : (
-        <MintCard />
-      )}
+      <RenderContent hasUser={!!user} hasClient={!!client} />
     </div>
   );
 }
+
+const RenderContent = ({
+  hasUser,
+  hasClient,
+}: {
+  hasUser: boolean;
+  hasClient: boolean;
+}) => {
+  if (!hasUser) {
+    return (
+      <div className="flex flex-col gap-2 w-[368px]">
+        <div className="modal bg-surface-default shadow-md overflow-hidden">
+          <AuthCard />
+        </div>
+      </div>
+    );
+  }
+
+  if (hasClient) {
+    return <MintCard />;
+  }
+
+  return <LoadingIcon />;
+};


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

# Description

Added some conditional logic to prevent the mintcard from loading before the client was loaded.  This will prevent a loading error causing the mintcard to render before dependencies are ready.

# Testing

Go through the typical login flow.  You should land on the mint nft screen without any errors.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `AuthCardWrapper` component to improve the rendering logic based on user and client states. It introduces a new `RenderContent` component that handles different scenarios for displaying content.

### Detailed summary
- Replaced `useUser` with `useSmartAccountClient` in `AuthCardWrapper`.
- Added `LoadingIcon` import.
- Removed conditional rendering in `AuthCardWrapper`.
- Introduced `RenderContent` component to manage rendering based on `hasUser` and `hasClient` states.
- Added logic to show `LoadingIcon` when no user and no client are present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->