### PR TITLE
chore(react): fix the storybook not starting after breaking changes

### DIFF
--- a/account-kit/react/.storybook/preview.tsx
+++ b/account-kit/react/.storybook/preview.tsx
@@ -1,11 +1,11 @@
 import "./tailwind.css";
 
+import { alchemy, sepolia } from "@account-kit/infra";
 import type { Preview } from "@storybook/react";
-import { initialize, mswLoader } from "msw-storybook-addon";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AlchemyAccountProvider, createConfig } from "../src";
+import { initialize, mswLoader } from "msw-storybook-addon";
 import React, { useEffect } from "react";
-import { sepolia } from "@account-kit/infra";
+import { AlchemyAccountProvider, createConfig } from "../src";
 
 const queryClient = new QueryClient();
 
@@ -13,7 +13,7 @@ initialize();
 
 const config = createConfig(
   {
-    rpcUrl: "/api/rpc",
+    transport: alchemy({ rpcUrl: "/api/rpc" }),
     chain: sepolia,
     ssr: true,
   },


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the configuration for the Storybook preview in the `account-kit/react` project, specifically enhancing the integration with the `alchemy` transport and modifying the `createConfig` parameters.

### Detailed summary
- Changed the `rpcUrl` parameter to use `transport: alchemy({ rpcUrl: "/api/rpc" })`.
- Confirmed the use of `chain: sepolia` in the configuration.
- Reorganized imports for clarity and consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->