### PR TITLE
feat: expose signer error messages

### DIFF
--- a/account-kit/core/src/actions/disconnect.ts
+++ b/account-kit/core/src/actions/disconnect.ts
@@ -31,7 +31,10 @@ export async function disconnect(config: AlchemyAccountsConfig): Promise<void> {
 
   config.store.setState(() => config.store.getInitialState());
 
-  config.store.setState({
-    signerStatus: convertSignerStatusToState(AlchemySignerStatus.DISCONNECTED),
-  });
+  config.store.setState((state) => ({
+    signerStatus: convertSignerStatusToState(
+      AlchemySignerStatus.DISCONNECTED,
+      state.signerStatus.error
+    ),
+  }));
 }

--- a/account-kit/core/src/actions/watchBundlerClient.test.ts
+++ b/account-kit/core/src/actions/watchBundlerClient.test.ts
@@ -17,7 +17,8 @@ describe("watchBundlerClient", () => {
 
     config.store.setState({
       signerStatus: convertSignerStatusToState(
-        AlchemySignerStatus.AWAITING_EMAIL_AUTH
+        AlchemySignerStatus.AWAITING_EMAIL_AUTH,
+        undefined
       ),
     });
 

--- a/account-kit/core/src/actions/watchSignerStatus.ts
+++ b/account-kit/core/src/actions/watchSignerStatus.ts
@@ -22,6 +22,6 @@ export const watchSignerStatus =
     return config.store.subscribe(
       ({ signerStatus }) => signerStatus,
       onChange,
-      { equalityFn: (a, b) => a.status === b.status }
+      { equalityFn: (a, b) => a.status === b.status && a.error === b.error }
     );
   };

--- a/account-kit/core/src/actions/watchSmartAccountClient.test.ts
+++ b/account-kit/core/src/actions/watchSmartAccountClient.test.ts
@@ -18,7 +18,8 @@ describe("watchSmartAccountClient", () => {
 
     config.store.setState({
       signerStatus: convertSignerStatusToState(
-        AlchemySignerStatus.DISCONNECTED
+        AlchemySignerStatus.DISCONNECTED,
+        undefined
       ),
     });
 

--- a/account-kit/core/src/hydrate.ts
+++ b/account-kit/core/src/hydrate.ts
@@ -49,7 +49,8 @@ export function hydrate(
       ...rest,
       accountConfigs,
       signerStatus: convertSignerStatusToState(
-        AlchemySignerStatus.INITIALIZING
+        AlchemySignerStatus.INITIALIZING,
+        undefined
       ),
       accounts: hydrateAccountState(
         accountConfigs,

--- a/account-kit/core/src/store/types.ts
+++ b/account-kit/core/src/store/types.ts
@@ -4,6 +4,7 @@ import type {
   AlchemySignerStatus,
   AlchemySignerWebClient,
   AlchemyWebSigner,
+  ErrorInfo,
   User,
 } from "@account-kit/signer";
 import type { State as WagmiState } from "@wagmi/core";
@@ -51,6 +52,7 @@ export type ClientStoreConfig = {
 
 export type SignerStatus = {
   status: AlchemySignerStatus;
+  error?: ErrorInfo;
   isInitializing: boolean;
   isAuthenticating: boolean;
   isConnected: boolean;

--- a/account-kit/react/src/context.tsx
+++ b/account-kit/react/src/context.tsx
@@ -115,12 +115,10 @@ export const AlchemyAccountProvider = (
   const openAuthModal = useCallback(() => setIsModalOpen(true), []);
   const closeAuthModal = useCallback(() => setIsModalOpen(false), []);
 
-  const clearAuthParams = () => {
+  const clearSignupParam = () => {
     const url = new URL(window.location.href);
-    url.searchParams.delete("orgId");
-    url.searchParams.delete("bundle");
     url.searchParams.delete(IS_SIGNUP_QP);
-    window.history.replaceState({}, "", url.toString());
+    window.history.replaceState(window.history.state, "", url.toString());
   };
 
   /**
@@ -129,7 +127,7 @@ export const AlchemyAccountProvider = (
   const resetAuthStep = useCallback(() => {
     setAuthStep({ type: "initial" });
 
-    clearAuthParams();
+    clearSignupParam();
   }, []);
 
   const initialContext = useMemo(
@@ -166,7 +164,7 @@ export const AlchemyAccountProvider = (
 
   useEffect(() => {
     if (authStep.type === "complete") {
-      clearAuthParams();
+      clearSignupParam();
     }
   }, [authStep]);
 

--- a/account-kit/signer/src/types.ts
+++ b/account-kit/signer/src/types.ts
@@ -4,6 +4,7 @@ export type AlchemySignerEvents = {
   connected(user: User): void;
   disconnected(): void;
   statusChanged(status: AlchemySignerStatus): void;
+  errorChanged(error: ErrorInfo | undefined): void;
 };
 
 export type AlchemySignerEvent = keyof AlchemySignerEvents;
@@ -14,4 +15,9 @@ export enum AlchemySignerStatus {
   DISCONNECTED = "DISCONNECTED",
   AUTHENTICATING = "AUTHENTICATING",
   AWAITING_EMAIL_AUTH = "AWAITING_EMAIL_AUTH",
+}
+
+export interface ErrorInfo {
+  name: string;
+  message: string;
 }

--- a/site/pages/reference/account-kit/signer/classes/BaseAlchemySigner/constructor.mdx
+++ b/site/pages/reference/account-kit/signer/classes/BaseAlchemySigner/constructor.mdx
@@ -32,3 +32,8 @@ The client instance to be used internally
 
 `SessionConfig`
 Configuration for managing sessions
+
+### param0.initialError
+
+`ErrorInfo | undefined`
+Error already present on the signer when initialized, if any


### PR DESCRIPTION
Adds a new field to the signer store state, `error`, containing error information, and populates it on errors thrown by `authenticate` as well as during signer creation if there are error query params in the URL. Adds a similar field to the `signerStatus` field of the main store state. Finally, removes SDK-related params from the URL after reading them, both the new error params as well as the existing bundle params.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling in the `AlchemySigner` implementation and updating several related components to accommodate the new error management features.

### Detailed summary
- Added `error` property to `SignerStatus` and `AlchemySignerStore`.
- Introduced `ErrorInfo` interface for structured error information.
- Updated `convertSignerStatusToState` to accept and handle errors.
- Modified state updates to retain error information during status changes.
- Enhanced error handling in the `authenticate` method.
- Updated tests and documentation to reflect error handling improvements.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->