### PR TITLE
fix: allow users to log back in after logout

### DIFF
--- a/account-kit/react/src/components/dialog/dialog.tsx
+++ b/account-kit/react/src/components/dialog/dialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { RemoveScroll } from "react-remove-scroll";

--- a/account-kit/signer/src/client/index.ts
+++ b/account-kit/signer/src/client/index.ts
@@ -3,6 +3,8 @@ import { getWebAuthnAttestation } from "@turnkey/http";
 import { IframeStamper } from "@turnkey/iframe-stamper";
 import { WebauthnStamper } from "@turnkey/webauthn-stamper";
 import { z } from "zod";
+import { getDefaultScopeAndClaims, getOauthNonce } from "../oauth.js";
+import type { AuthParams, OauthMode } from "../signer.js";
 import { base64UrlEncode } from "../utils/base64UrlEncode.js";
 import { generateRandomBuffer } from "../utils/generateRandomBuffer.js";
 import { BaseSignerClient } from "./base.js";
@@ -16,8 +18,6 @@ import type {
   OauthParams,
   User,
 } from "./types.js";
-import { getDefaultScopeAndClaims, getOauthNonce } from "../oauth.js";
-import type { AuthParams, OauthMode } from "../signer.js";
 
 const CHECK_CLOSE_INTERVAL = 500;
 
@@ -372,6 +372,7 @@ export class AlchemySignerWebClient extends BaseSignerClient<ExportWalletParams>
   public override disconnect = async () => {
     this.user = undefined;
     this.iframeStamper.clear();
+    await this.iframeStamper.init();
   };
 
   /**


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `AlchemySignerWebClient` by adding initialization for the `iframeStamper` during the `disconnect` method and reorganizing import statements for better clarity and structure.

### Detailed summary
- Added `await this.iframeStamper.init();` in the `disconnect` method of `AlchemySignerWebClient`.
- Moved import statements for `getDefaultScopeAndClaims` and `getOauthNonce` to a new position in `account-kit/signer/src/client/index.ts`.
- Removed redundant import statements for `getDefaultScopeAndClaims` and `getOauthNonce`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->