### PR TITLE
refactor: extend oauth authtype to support all providers

### DIFF
--- a/account-kit/react/src/components/auth/sections/OAuth.tsx
+++ b/account-kit/react/src/components/auth/sections/OAuth.tsx
@@ -1,23 +1,25 @@
 import { GoogleIcon } from "../../../icons/oauth.js";
 import { Button } from "../../button.js";
 import { useOAuthVerify } from "../hooks/useOAuthVerify.js";
+import type { AuthType } from "../types.js";
 
-type Props = {
-  googleAuth: boolean;
-};
+type Props = Extract<AuthType, { type: "social" }>;
 
 // Not used externally
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const OAuth = ({ googleAuth }: Props) => {
+export const OAuth = ({ authProviderId }: Props) => {
   const { authenticate } = useOAuthVerify();
 
-  return (
-    googleAuth && (
+  if (authProviderId === "google") {
+    return (
       <Button
         variant="social"
         icon={<GoogleIcon />}
         onClick={authenticate}
       ></Button>
-    )
-  );
+    );
+  }
+
+  // TODO: add the other social providers
+  return null;
 };

--- a/account-kit/react/src/components/auth/types.ts
+++ b/account-kit/react/src/components/auth/types.ts
@@ -1,3 +1,7 @@
+import type {
+  KnownAuthProvider,
+  OauthRedirectConfig,
+} from "@account-kit/signer";
 import type { WalletConnectParameters } from "wagmi/connectors";
 
 export type AuthType =
@@ -10,4 +14,17 @@ export type AuthType =
     }
   | { type: "passkey" }
   | { type: "external_wallets"; walletConnect?: WalletConnectParameters }
-  | { type: "social"; googleAuth: boolean };
+  | ({ type: "social"; scope?: string; claims?: string } & (
+      | {
+          authProviderId: "auth0";
+          isCustomProvider?: false;
+          auth0Connection?: string;
+          logoUrl: string;
+        }
+      | {
+          authProviderId: KnownAuthProvider;
+          isCustomProvider?: false;
+          auth0Connection?: never;
+        }
+    ) &
+      OauthRedirectConfig);

--- a/account-kit/react/src/createConfig.ts
+++ b/account-kit/react/src/createConfig.ts
@@ -45,6 +45,14 @@ export const createConfig = (
   props: CreateConfigProps,
   ui?: AlchemyAccountsUIConfig
 ): AlchemyAccountsConfigWithUI => {
+  if (
+    ui?.auth?.sections.some((x) =>
+      x.some((y) => y.type === "social" && y.mode === "popup")
+    )
+  ) {
+    props.enablePopupOauth = true;
+  }
+
   const config = createCoreConfig(props);
 
   return {

--- a/examples/ui-demo/src/app/providers.tsx
+++ b/examples/ui-demo/src/app/providers.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { AuthCardHeader } from "@/components/shared/AuthCardHeader";
+import { ToastProvider } from "@/contexts/ToastProvider";
 import { alchemy, arbitrumSepolia } from "@account-kit/infra";
 import { AlchemyAccountProvider, createConfig } from "@account-kit/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense } from "react";
 import { ConfigContextProvider, DEFAULT_CONFIG } from "./state";
-import { ToastProvider } from "@/contexts/ToastProvider";
 
 const queryClient = new QueryClient();
 
@@ -27,7 +27,8 @@ const alchemyConfig = createConfig(
         [
           {
             type: "social" as const,
-            googleAuth: true,
+            authProviderId: "google",
+            mode: "popup",
           },
         ],
       ],

--- a/examples/ui-demo/src/app/state.tsx
+++ b/examples/ui-demo/src/app/state.tsx
@@ -108,9 +108,9 @@ export function ConfigContextProvider(props: PropsWithChildren) {
       sections.push([{ type: "passkey" }]);
     }
 
-    if (config.auth.showSocial) {
+    if (config.auth.showSocial && config.auth.addGoogleAuth) {
       sections.push([
-        { type: "social", googleAuth: config.auth.addGoogleAuth },
+        { type: "social", authProviderId: "google", mode: "popup" },
       ]);
     }
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the social authentication feature by refining the configuration and type definitions for social logins, specifically integrating Google authentication with a popup mode. It also updates the component props and logic to support the new structure.

### Detailed summary
- Updated the condition for showing social authentication in `state.tsx`.
- Changed the structure of the social authentication object to include `authProviderId` and `mode` in `state.tsx`.
- Modified the `createConfig` function to enable popup OAuth based on the UI configuration.
- Expanded the `AuthType` type to include detailed configurations for social authentication.
- Refined `OAuth` component props to accept `authProviderId` instead of `googleAuth`.
- Updated rendering logic in `OAuth.tsx` to display the Google login button based on `authProviderId`. 
- Adjusted the example configuration in `providers.tsx` to align with the new authentication structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->