### PR TITLE
fix: try again button on passkey error screen

### DIFF
--- a/account-kit/react/src/components/auth/card/loading/passkey.tsx
+++ b/account-kit/react/src/components/auth/card/loading/passkey.tsx
@@ -2,6 +2,7 @@ import { ls } from "../../../../strings.js";
 import { LoadingPasskey } from "../../../../icons/passkey.js";
 import { useAuthContext, type AuthStep } from "../../context.js";
 import { ConnectionError } from "../error/connection-error.js";
+import { usePasskeyVerify } from "../../hooks/usePasskeyVerify.js";
 
 interface LoadingPasskeyAuthProps {
   authStep: Extract<AuthStep, { type: "passkey_verify" }>;
@@ -9,16 +10,13 @@ interface LoadingPasskeyAuthProps {
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const LoadingPasskeyAuth = ({ authStep }: LoadingPasskeyAuthProps) => {
   const { setAuthStep } = useAuthContext();
+  const { authenticate } = usePasskeyVerify();
 
   if (authStep.error) {
     return (
       <ConnectionError
         connectionType="passkey"
-        handleTryAgain={() =>
-          setAuthStep({
-            type: "initial",
-          })
-        }
+        handleTryAgain={authenticate}
         handleUseAnotherMethod={() => setAuthStep({ type: "initial" })}
       />
     );


### PR DESCRIPTION
# Context 

The try again button on passkey login errors wasn't working correctly as it would just send the user back to the beginning. This fixes that.

# Test Plan

Check vercel and try out the passkey error state works as expected.

https://github.com/user-attachments/assets/2fabadee-7839-4557-8836-c4801e5fe906

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new authentication method using passkeys in the `LoadingPasskeyAuth` component. It integrates a verification hook to streamline the error handling process.

### Detailed summary
- Added import for `usePasskeyVerify`.
- Introduced `authenticate` method from `usePasskeyVerify`.
- Replaced the `handleTryAgain` function with `authenticate` in the `ConnectionError` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->