### PR TITLE
refactor: cleanup the auth step usage

### DIFF
--- a/account-kit/react/src/components/auth/card/add-passkey.tsx
+++ b/account-kit/react/src/components/auth/card/add-passkey.tsx
@@ -6,7 +6,7 @@ import {
 } from "../../../icons/illustrations/passkeys.js";
 import { ls } from "../../../strings.js";
 import { Button } from "../../button.js";
-import { useAuthContext, type AuthStep } from "../context.js";
+import { useAuthContext } from "../context.js";
 import { ConnectionError } from "./error/connection-error.js";
 
 const BENEFITS = [
@@ -22,13 +22,8 @@ const BENEFITS = [
   },
 ];
 
-type AddPasskeyProps = {
-  authStep: Extract<AuthStep, { type: "passkey_create" }>;
-};
-
-// eslint-disable-next-line jsdoc/require-jsdoc
-export const AddPasskey = ({ authStep }: AddPasskeyProps) => {
-  const { setAuthStep } = useAuthContext();
+export const AddPasskey = () => {
+  const { setAuthStep, authStep } = useAuthContext("passkey_create");
   const { addPasskey, isAddingPasskey } = useAddPasskey({
     onSuccess: () => {
       setAuthStep({ type: "passkey_create_success" });

--- a/account-kit/react/src/components/auth/card/eoa.tsx
+++ b/account-kit/react/src/components/auth/card/eoa.tsx
@@ -3,22 +3,17 @@ import { walletConnect } from "wagmi/connectors";
 import { useChain } from "../../../hooks/useChain.js";
 import { useConnect } from "../../../hooks/useConnect.js";
 import { useUiConfig } from "../../../hooks/useUiConfig.js";
+import { Spinner } from "../../../icons/spinner.js";
 import { WalletConnectIcon } from "../../../icons/walletConnectIcon.js";
 import { Button } from "../../button.js";
-import { useAuthContext, type AuthStep } from "../context.js";
+import { useAuthContext } from "../context.js";
 import type { AuthType } from "../types.js";
 import { CardContent } from "./content.js";
-import { Spinner } from "../../../icons/spinner.js";
 import { ConnectionError } from "./error/connection-error.js";
 import { EOAWallets } from "./error/types.js";
 
-interface Props {
-  authStep: Extract<AuthStep, { type: "eoa_connect" }>;
-}
-
-// eslint-disable-next-line jsdoc/require-jsdoc
-export const EoaConnectCard = ({ authStep }: Props) => {
-  const { setAuthStep } = useAuthContext();
+export const EoaConnectCard = () => {
+  const { setAuthStep, authStep } = useAuthContext("eoa_connect");
 
   if (authStep.error) {
     return (
@@ -58,12 +53,8 @@ export const EoaConnectCard = ({ authStep }: Props) => {
   );
 };
 
-type WalletConnectCardProps = {
-  authStep: Extract<AuthStep, { type: "wallet_connect" }>;
-};
-
-export const WalletConnectCard = ({ authStep }: WalletConnectCardProps) => {
-  const { setAuthStep } = useAuthContext();
+export const WalletConnectCard = () => {
+  const { setAuthStep, authStep } = useAuthContext("wallet_connect");
 
   if (authStep.error) {
     return (

--- a/account-kit/react/src/components/auth/card/loading/email.tsx
+++ b/account-kit/react/src/components/auth/card/loading/email.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useState } from "react";
 import { useSignerStatus } from "../../../../hooks/useSignerStatus.js";
-import { useAuthContext, type AuthStep } from "../../context.js";
+import { EmailIllustration } from "../../../../icons/illustrations/email.js";
 import { Spinner } from "../../../../icons/spinner.js";
 import { ls } from "../../../../strings.js";
-import { EmailIllustration } from "../../../../icons/illustrations/email.js";
-
-interface LoadingEmailProps {
-  authStep: Extract<AuthStep, { type: "email_verify" }>;
-}
+import { useAuthContext } from "../../context.js";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const LoadingEmail = ({ authStep }: LoadingEmailProps) => {
+export const LoadingEmail = () => {
+  const { authStep } = useAuthContext("email_verify");
   // yup, re-sent and resent. I'm not fixing it
   const [emailResent, setEmailResent] = useState(false);
 
@@ -39,14 +36,10 @@ export const LoadingEmail = ({ authStep }: LoadingEmailProps) => {
   );
 };
 
-interface CompletingEmailAuthProps {
-  authStep: Extract<AuthStep, { type: "email_completing" }>;
-}
-
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const CompletingEmailAuth = ({ authStep }: CompletingEmailAuthProps) => {
+export const CompletingEmailAuth = () => {
   const { isConnected } = useSignerStatus();
-  const { setAuthStep } = useAuthContext();
+  const { setAuthStep, authStep } = useAuthContext("email_completing");
 
   useEffect(() => {
     if (isConnected && authStep.createPasskeyAfter) {

--- a/account-kit/react/src/components/auth/card/loading/oauth.tsx
+++ b/account-kit/react/src/components/auth/card/loading/oauth.tsx
@@ -2,17 +2,13 @@ import { useEffect } from "react";
 import { useSignerStatus } from "../../../../hooks/useSignerStatus.js";
 import { ContinueWithOAuth } from "../../../../icons/oauth.js";
 import { capitalize } from "../../../../utils.js";
-import { useAuthContext, type AuthStep } from "../../context.js";
+import { useAuthContext } from "../../context.js";
 import { useOAuthVerify } from "../../hooks/useOAuthVerify.js";
 import { ConnectionError } from "../error/connection-error.js";
 
-interface CompletingOAuthProps {
-  authStep: Extract<AuthStep, { type: "oauth_completing" }>;
-}
-
-export const CompletingOAuth = ({ authStep }: CompletingOAuthProps) => {
+export const CompletingOAuth = () => {
   const { isConnected } = useSignerStatus();
-  const { setAuthStep } = useAuthContext();
+  const { setAuthStep, authStep } = useAuthContext("oauth_completing");
   const { authenticate } = useOAuthVerify({ config: authStep.config });
 
   useEffect(() => {

--- a/account-kit/react/src/components/auth/card/loading/passkey.tsx
+++ b/account-kit/react/src/components/auth/card/loading/passkey.tsx
@@ -1,15 +1,11 @@
-import { ls } from "../../../../strings.js";
 import { LoadingPasskey } from "../../../../icons/passkey.js";
-import { useAuthContext, type AuthStep } from "../../context.js";
-import { ConnectionError } from "../error/connection-error.js";
+import { ls } from "../../../../strings.js";
+import { useAuthContext } from "../../context.js";
 import { usePasskeyVerify } from "../../hooks/usePasskeyVerify.js";
+import { ConnectionError } from "../error/connection-error.js";
 
-interface LoadingPasskeyAuthProps {
-  authStep: Extract<AuthStep, { type: "passkey_verify" }>;
-}
-// eslint-disable-next-line jsdoc/require-jsdoc
-export const LoadingPasskeyAuth = ({ authStep }: LoadingPasskeyAuthProps) => {
-  const { setAuthStep } = useAuthContext();
+export const LoadingPasskeyAuth = () => {
+  const { setAuthStep, authStep } = useAuthContext("passkey_verify");
   const { authenticate } = usePasskeyVerify();
 
   if (authStep.error) {

--- a/account-kit/react/src/components/auth/card/main.tsx
+++ b/account-kit/react/src/components/auth/card/main.tsx
@@ -1,16 +1,12 @@
 import { Fragment } from "react";
 import { useUiConfig } from "../../../hooks/useUiConfig.js";
 import { Divider } from "../../divider.js";
+import { useAuthContext } from "../context.js";
 import { AuthSection } from "../sections/AuthSection.js";
 import { GeneralError } from "./error/general-error.js";
-import { type AuthStep } from "../context.js";
 
-type MainAuthContentProps = {
-  authStep: AuthStep;
-};
-
-// eslint-disable-next-line jsdoc/require-jsdoc
-export const MainAuthContent = ({ authStep }: MainAuthContentProps) => {
+export const MainAuthContent = () => {
+  const { authStep } = useAuthContext();
   const isError = authStep.type === "initial" && authStep.error;
   const {
     auth: { header, sections, hideSignInText },

--- a/account-kit/react/src/components/auth/card/steps.tsx
+++ b/account-kit/react/src/components/auth/card/steps.tsx
@@ -1,37 +1,36 @@
 import { useAuthContext } from "../context.js";
 import { AddPasskey } from "./add-passkey.js";
 import { EoaConnectCard, EoaPickCard, WalletConnectCard } from "./eoa.js";
-import { LoadingEmail, CompletingEmailAuth } from "./loading/email.js";
+import { CompletingEmailAuth, LoadingEmail } from "./loading/email.js";
 import { CompletingOAuth } from "./loading/oauth.js";
 import { LoadingPasskeyAuth } from "./loading/passkey.js";
 import { MainAuthContent } from "./main.js";
 import { PasskeyAdded } from "./passkey-added.js";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 export const Step = () => {
   const { authStep } = useAuthContext();
   switch (authStep.type) {
     case "email_verify":
-      return <LoadingEmail authStep={authStep} />;
+      return <LoadingEmail />;
     case "passkey_verify":
-      return <LoadingPasskeyAuth authStep={authStep} />;
+      return <LoadingPasskeyAuth />;
     case "email_completing":
-      return <CompletingEmailAuth authStep={authStep} />;
+      return <CompletingEmailAuth />;
     case "oauth_completing":
-      return <CompletingOAuth authStep={authStep} />;
+      return <CompletingOAuth />;
     case "passkey_create":
-      return <AddPasskey authStep={authStep} />;
+      return <AddPasskey />;
     case "passkey_create_success":
       return <PasskeyAdded />;
     case "eoa_connect":
-      return <EoaConnectCard authStep={authStep} />;
+      return <EoaConnectCard />;
     case "pick_eoa":
       return <EoaPickCard />;
     case "wallet_connect":
-      return <WalletConnectCard authStep={authStep} />;
+      return <WalletConnectCard />;
     case "complete":
     case "initial":
     default:
-      return <MainAuthContent authStep={authStep} />;
+      return <MainAuthContent />;
   }
 };

--- a/account-kit/react/src/components/auth/hooks/useOAuthVerify.ts
+++ b/account-kit/react/src/components/auth/hooks/useOAuthVerify.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useCallback } from "react";
 import { useAuthenticate } from "../../../hooks/useAuthenticate.js";
-import { useAuthContext, type AuthStep } from "../context.js";
+import { useAuthContext } from "../context.js";
 import type { AuthType } from "../types.js";
 
 export type UseOAuthVerifyReturnType = {
@@ -14,8 +14,7 @@ export const useOAuthVerify = ({
 }: {
   config: Extract<AuthType, { type: "social" }>;
 }): UseOAuthVerifyReturnType => {
-  const { authStep: _authStep, setAuthStep } = useAuthContext();
-  const authStep = _authStep as Extract<AuthStep, { type: "oauth_completing" }>;
+  const { setAuthStep } = useAuthContext();
 
   const { authenticate: authenticate_, isPending } = useAuthenticate({
     onMutate: () => {
@@ -27,11 +26,8 @@ export const useOAuthVerify = ({
     onError: (err) => {
       setAuthStep({
         type: "oauth_completing",
-        config: authStep.config,
+        config,
         error: err,
-        ...(authStep.config.authProviderId === "auth0" && {
-          logoUrl: authStep.config.logoUrl,
-        }),
       });
     },
     onSuccess: () => {

--- a/account-kit/react/src/hooks/useUiConfig.ts
+++ b/account-kit/react/src/hooks/useUiConfig.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useLayoutEffect, useMemo } from "react";
 import { create } from "zustand";
 import { useAlchemyAccountContext } from "../context.js";
 import { MissingUiConfigError } from "../errors.js";
@@ -73,25 +73,25 @@ export const useUiConfig = () => {
   // so we don't want to render the modal.
   const { ui } = useAlchemyAccountContext();
 
-  useEffect(() => {
-    if (!ui || _initialized) return;
-
-    initialize(ui.config);
-  }, [config, initialize, _initialized, ui]);
-
   if (!ui) {
     throw new MissingUiConfigError("useUiConfig");
   }
 
+  useLayoutEffect(() => {
+    if (ui && !_initialized) {
+      initialize(ui.config);
+    }
+  }, [_initialized, initialize, ui]);
+
   const uiConfig = useMemo(
     () =>
       ({
-        ...config,
+        ...(_initialized ? config : ui.config),
         updateConfig,
       } as AlchemyAccountsUIConfigWithDefaults & {
         updateConfig: (partial: AlchemyAccountsUIConfig) => void;
       }),
-    [config, updateConfig]
+    [_initialized, config, ui, updateConfig]
   );
 
   return uiConfig;

--- a/examples/ui-demo/src/app/state.tsx
+++ b/examples/ui-demo/src/app/state.tsx
@@ -57,7 +57,7 @@ export function ConfigContextProvider(props: PropsWithChildren) {
 
     if (config.auth.showSocial && config.auth.addGoogleAuth) {
       if (config.auth.showPasskey) {
-        sections!
+        sections
           .at(-1)!
           .push({ type: "social", authProviderId: "google", mode: "popup" });
       } else {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on refactoring the authentication components by removing the `authStep` prop from various components and instead utilizing the `useAuthContext` hook to access the `authStep` directly. This simplifies the component interfaces and improves code consistency.

### Detailed summary
- Removed `authStep` prop from multiple components, including `MainAuthContent`, `AddPasskey`, `CompletingOAuth`, and others.
- Updated `useAuthContext` to accept a type parameter for better type safety.
- Changed `useEffect` to `useLayoutEffect` in `useUiConfig`.
- Adjusted how `authStep` is accessed in components, leading to cleaner code.
- Modified the return statements in the `Step` component to no longer pass `authStep` to child components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->