### PR TITLE
fix: set error state when authentication fails

### DIFF
--- a/account-kit/signer/src/base.ts
+++ b/account-kit/signer/src/base.ts
@@ -215,13 +215,13 @@ export abstract class BaseAlchemySigner<TClient extends BaseSignerClient>
     try {
       switch (type) {
         case "email":
-          return this.authenticateWithEmail(params);
+          return await this.authenticateWithEmail(params);
         case "passkey":
-          return this.authenticateWithPasskey(params);
+          return await this.authenticateWithPasskey(params);
         case "oauth":
-          return this.authenticateWithOauth(params);
+          return await this.authenticateWithOauth(params);
         case "oauthReturn":
-          return this.handleOauthReturn(params);
+          return await this.handleOauthReturn(params);
         default:
           assertNever(type, `Unknown auth type: ${type}`);
       }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the authentication methods in the `base.ts` file to ensure they are executed asynchronously by using `await`. This change enhances the handling of different authentication types.

### Detailed summary
- Changed `return this.authenticateWithEmail(params);` to `return await this.authenticateWithEmail(params);`
- Changed `return this.authenticateWithPasskey(params);` to `return await this.authenticateWithPasskey(params);`
- Changed `return this.authenticateWithOauth(params);` to `return await this.authenticateWithOauth(params);`
- Changed `return this.handleOauthReturn(params);` to `return await this.handleOauthReturn(params);`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->