### PR TITLE
fix(core): hydrate wasn't properly handling logged out users

### DIFF
--- a/account-kit/core/src/hydrate.ts
+++ b/account-kit/core/src/hydrate.ts
@@ -47,6 +47,7 @@ export function hydrate(
 
     config.store.setState({
       ...rest,
+      user: initialAlchemyState.user,
       accountConfigs,
       signerStatus: convertSignerStatusToState(
         AlchemySignerStatus.INITIALIZING,
@@ -57,6 +58,11 @@ export function hydrate(
         shouldReconnectAccounts,
         config
       ),
+    });
+  } else if (!config.store.persist.hasHydrated()) {
+    config.store.setState({
+      ...config.store.getInitialState(),
+      user: undefined,
     });
   }
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the state hydration process in the `hydrate` function by adding user state management and handling cases where the store has not yet hydrated.

### Detailed summary
- Added a new line to set the `user` in the state with `initialAlchemyState.user`.
- Introduced an `else if` condition to check if the store has not hydrated.
- If not hydrated, it sets the state to the initial state with `user` set to `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->