### PR TITLE
fix: fix mobile animation up bug

### DIFF
--- a/account-kit/react/src/tailwind/plugin.ts
+++ b/account-kit/react/src/tailwind/plugin.ts
@@ -117,7 +117,7 @@ export const accountKitUi: (
             },
             "slide-up": {
               "0%": { transform: "translateY(100%)", opacity: "0" },
-              "100%": { transform: "translateY(0%))", opacity: "1" },
+              "100%": { transform: "translateY(0%)", opacity: "1" },
             },
           },
           animation: {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


# Test Plan

Shows current failure and then the fix with these changes in a different self hosted url. Tested this on Safari as well.

https://github.com/user-attachments/assets/16beeab7-1426-4dd5-abef-f4c5efb31e26



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `slide-up` animation in the `tailwind/plugin.ts` file by removing unnecessary transformations and correcting a syntax error.

### Detailed summary
- Modified `slide-up` animation keyframes:
  - Changed `transform` from `"translateY(100%) translateZ(0)"` to `"translateY(100%)"`.
  - Changed `transform` from `"translateY(0%)) translateZ(0)"` to `"translateY(0%)"`.
  - Removed `translateZ(0)` from both keyframes.
- Removed extra comma in the `100%` keyframe.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->