### PR TITLE
fix: update default auth

### DIFF
--- a/account-kit/react/src/components/auth/card/index.tsx
+++ b/account-kit/react/src/components/auth/card/index.tsx
@@ -101,6 +101,8 @@ export const AuthCardContent = ({
   const onClose = useCallback(() => {
     if (authStep.type === "passkey_create") {
       setAuthStep({ type: "complete" });
+    } else {
+      setAuthStep({ type: "initial" });
     }
     closeAuthModal();
   }, [authStep.type, closeAuthModal, setAuthStep]);

--- a/account-kit/react/src/components/auth/card/index.tsx
+++ b/account-kit/react/src/components/auth/card/index.tsx
@@ -6,7 +6,6 @@ import { useElementHeight } from "../../../hooks/useElementHeight.js";
 import { useSigner } from "../../../hooks/useSigner.js";
 import { useSignerStatus } from "../../../hooks/useSignerStatus.js";
 import { useUiConfig } from "../../../hooks/useUiConfig.js";
-import { IS_SIGNUP_QP } from "../../constants.js";
 import { Navigation } from "../../navigation.js";
 import { useAuthContext } from "../context.js";
 import { Step } from "./steps.js";
@@ -63,7 +62,7 @@ export const AuthCardContent = ({
   const didGoBack = useRef(false);
 
   const {
-    auth: { onAuthSuccess },
+    auth: { onAuthSuccess, addPasskeyOnSignup },
   } = useUiConfig();
 
   const canGoBack = useMemo(() => {
@@ -115,12 +114,9 @@ export const AuthCardContent = ({
     } else if (authStep.type !== "initial") {
       didGoBack.current = false;
     } else if (!didGoBack.current && isAuthenticating) {
-      // Auth step must be initial
-      const urlParams = new URLSearchParams(window.location.search);
-
       setAuthStep({
         type: "email_completing",
-        createPasskeyAfter: urlParams.get(IS_SIGNUP_QP) === "true",
+        createPasskeyAfter: addPasskeyOnSignup,
       });
     }
   }, [
@@ -130,6 +126,7 @@ export const AuthCardContent = ({
     setAuthStep,
     onAuthSuccess,
     closeAuthModal,
+    addPasskeyOnSignup,
   ]);
 
   return (

--- a/examples/ui-demo/src/app/config.tsx
+++ b/examples/ui-demo/src/app/config.tsx
@@ -41,9 +41,9 @@ export type Config = {
 export const DEFAULT_CONFIG: Config = {
   auth: {
     showEmail: true,
-    showExternalWallets: false,
+    showExternalWallets: true,
     showPasskey: true,
-    addPasskey: true,
+    addPasskey: false,
     showOAuth: true,
     oAuthMethods: {
       google: true,


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


Default auth state should now have eoa wallets enabled and disable add passkey after signup.
It also resets the auth step to initial if you close the modal.  If you have passkey enabled and passkey after signup you should be prompted after the email flow.  If you have passkey after signup disabled you should not be prompted after the flow.

![Screenshot 2024-10-11 at 10 18 04 AM](https://github.com/user-attachments/assets/2633344a-c39f-4b04-83cb-0b2d4c306032)

# Testing steps:
On mobile when you begin login click a non-email method.  Close the modal before submitting.  When you re-open the modal you should be at the initial state.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating authentication configuration and logic in the UI, specifically regarding external wallets and passkey settings, as well as refining the authentication flow in the `AuthCardContent` component.

### Detailed summary
- Changed `showExternalWallets` from `false` to `true`.
- Changed `addPasskey` from `true` to `false`.
- Added `addPasskeyOnSignup` to the auth context.
- Modified the `onClose` callback to set the auth step to `initial`.
- Updated `createPasskeyAfter` to use `addPasskeyOnSignup`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->