### PR TITLE
feat: add loading screen to post email login on mobile

### DIFF
--- a/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
+++ b/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
@@ -1,7 +1,19 @@
-import { useAuthModal } from "@account-kit/react";
+import { useAuthModal, useSignerStatus } from "@account-kit/react";
+import { AlchemySignerStatus } from "@account-kit/signer";
+import { useLayoutEffect } from "react";
 
 export function MobileSplashPage() {
   const { openAuthModal } = useAuthModal();
+  const { status } = useSignerStatus();
+
+  // Open the auth modal to show the auth loading phase
+  // Using useLayoutEffect to ensure the modal is opened before the page is painted
+  useLayoutEffect(() => {
+    if (status === AlchemySignerStatus.AUTHENTICATING_EMAIL) {
+      openAuthModal();
+    }
+  }, [status, openAuthModal]);
+
   return (
     <div className="flex flex-col flex-1 pb-5 h-auto max-h-[calc(100svh-100px)] box-content p-4 pt-[78px]">
       {/* Header Text */}


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

# Screenshots
https://www.loom.com/share/aa7d93a92221473d979c6e9e1ae24ad1


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to the `MobileSplashPage` component, allowing it to open an authentication modal when the user is in the process of authenticating their email. This is achieved using `useLayoutEffect` to ensure the modal opens before the page renders.

### Detailed summary
- Added hooks `useAuthModal` and `useSignerStatus` for handling authentication and signer status.
- Implemented `useLayoutEffect` to trigger the `openAuthModal` function when the `status` is `AlchemySignerStatus.AUTHENTICATING_EMAIL`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->