### PR TITLE
refactor: use remote logger config

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.ALCHEMY_BOT_PAT }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANALYTICS_WRITE_KEY: "test-key" # todo set this to the analytics write key in secrets
     steps:
       - uses: actions/checkout@v3
         with:
@@ -56,7 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       API_KEY: ${{ secrets.API_KEY }}
-      ANALYTICS_WRITE_KEY: "test-key" # todo set this to the analytics write key in secrets
     steps:
       - uses: actions/checkout@v3
         with:

--- a/account-kit/logging/postbuild.ts
+++ b/account-kit/logging/postbuild.ts
@@ -1,6 +1,5 @@
 import dotenv from "dotenv";
 import { writeFileSync } from "fs";
-import isCi from "is-ci";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 dotenv.config();
@@ -8,20 +7,14 @@ dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const writeKey = process.env.ANALYTICS_WRITE_KEY;
 const writeInDev = process.env.WRITE_IN_DEV === "true";
 
-if (writeKey) {
+if (writeInDev) {
   const targetFilePath = "dist/esm/_writeKey.js";
   writeFileSync(
     resolve(__dirname, targetFilePath),
     `
-    export const WRITE_KEY = "${writeKey}";
     export const WRITE_IN_DEV = ${writeInDev};
     `
-  );
-} else if (isCi) {
-  console.warn(
-    "In CI, you should specify a write key to ensure that the library is built to log events"
   );
 }

--- a/account-kit/logging/src/_writeKey.ts
+++ b/account-kit/logging/src/_writeKey.ts
@@ -1,3 +1,2 @@
 // this gets replaced after the build completes if it's present in the Environment
-export const WRITE_KEY: string | undefined = undefined;
 export const WRITE_IN_DEV: boolean = false;

--- a/account-kit/logging/src/client.test.ts
+++ b/account-kit/logging/src/client.test.ts
@@ -1,61 +1,85 @@
 import { vi } from "vitest";
 import * as writeKeyConfig from "./_writeKey.js";
+import * as fetchKeyModule from "./fetchRemoteWriteKey.js";
 import { noopLogger } from "./noop.js";
+import type { LoggerContext } from "./types.js";
 
 const devSpy = vi.spyOn(writeKeyConfig, "WRITE_IN_DEV", "get");
-const keySpy = vi.spyOn(writeKeyConfig, "WRITE_KEY", "get");
+const keySpy = vi.spyOn(fetchKeyModule, "fetchRemoteWriteKey");
+
+type TestSchema = [
+  {
+    EventName: "test";
+    EventData: {
+      test: boolean;
+    };
+  }
+];
 
 describe("Client Logger", () => {
+  const loggerContext: LoggerContext = {
+    package: "test/signer",
+    version: "1.0.0",
+  };
+
   beforeEach(() => {
     vi.resetAllMocks();
     // @ts-ignore this does exist
     global.jsdom.reconfigure({ url: "http://localhost" });
+
+    keySpy.mockImplementation(async () => undefined);
   });
 
-  it("should create a no-op logger if no write key", async () => {
-    keySpy.mockImplementation(() => undefined);
-
+  it("should not log events if no write key", async () => {
+    // @ts-ignore this does exist
+    global.jsdom.reconfigure({ url: "https://test.com" });
+    const consoleSpy = vi.spyOn(console, "log");
+    consoleSpy.mockImplementation(() => {});
     const { createClientLogger } = await import("./client.js");
 
-    const logger = createClientLogger();
-    expect(logger).toBe(noopLogger);
+    const logger = createClientLogger<TestSchema>(loggerContext);
+    await logger._internal.ready;
+    await logger.trackEvent({ name: "test", data: { test: true } });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(0);
   });
 
   it("should create a no-op logger if not write in dev", async () => {
-    devSpy.mockImplementation(() => true);
+    devSpy.mockImplementation(() => false);
 
     const { createClientLogger } = await import("./client.js");
 
-    const logger = createClientLogger();
+    const logger = createClientLogger<TestSchema>(loggerContext);
     expect(logger).toBe(noopLogger);
   });
 
   it("should create a valid logger if not localhost", async () => {
-    keySpy.mockImplementation(() => "test-key");
+    keySpy.mockImplementation(() => Promise.resolve("test-key"));
     // @ts-ignore this does exist
     global.jsdom.reconfigure({ url: "https://test.com" });
 
     const { createClientLogger } = await import("./client.js");
 
-    const logger = createClientLogger();
+    const logger = createClientLogger<TestSchema>(loggerContext);
     expect(logger).not.toBe(noopLogger);
   });
 
   it("should create a console logger in dev", async () => {
     const fetchSpy = vi.spyOn(global, "fetch");
-    keySpy.mockImplementation(() => "test-key");
+    keySpy.mockImplementation(() => Promise.resolve("test-key"));
     devSpy.mockImplementation(() => true);
     const consoleSpy = vi.spyOn(console, "log");
     consoleSpy.mockImplementation(() => {});
 
     const { createClientLogger } = await import("./client.js");
 
-    const logger = createClientLogger();
+    const logger = createClientLogger<TestSchema>(loggerContext);
     expect(logger).not.toBe(noopLogger);
     await logger._internal.ready;
 
     await logger.trackEvent({ name: "test", data: { test: true } });
     expect(fetchSpy).toHaveBeenCalledTimes(0);
+
     expect(JSON.parse(consoleSpy.mock.calls[0][0])).toMatchInlineSnapshot(
       {
         timestamp: expect.any(String),
@@ -80,7 +104,9 @@ describe("Client Logger", () => {
         },
         "messageId": Any<String>,
         "properties": {
+          "package": "test/signer",
           "test": true,
+          "version": "1.0.0",
         },
         "timestamp": Any<String>,
         "type": "track",

--- a/account-kit/logging/src/fetchRemoteWriteKey.ts
+++ b/account-kit/logging/src/fetchRemoteWriteKey.ts
@@ -1,0 +1,17 @@
+export async function fetchRemoteWriteKey(): Promise<string | undefined> {
+  try {
+    const json = await fetch(
+      "https://static.alchemyapi.io/assets/accountkit/logger_config.json",
+      {
+        headers: {
+          ContentType: "application/json",
+        },
+      }
+    ).then((res) => res.json());
+
+    return json.writeKey as string | undefined;
+  } catch (e) {
+    console.warn("failed to fetch write key");
+    return undefined;
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `WRITE_KEY` for analytics by fetching it remotely, modifying logging behavior based on the environment, and updating tests accordingly.

### Detailed summary
- Added `fetchRemoteWriteKey` function to fetch the write key from a remote URL.
- Removed direct use of `WRITE_KEY` in favor of fetching it asynchronously.
- Updated logging behavior to depend on the fetched write key.
- Modified tests to accommodate the asynchronous fetching of the write key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->