### PR TITLE
fix: open the auth modal upon email return

### DIFF
--- a/account-kit/react/src/components/auth/card/index.tsx
+++ b/account-kit/react/src/components/auth/card/index.tsx
@@ -56,7 +56,7 @@ export const AuthCardContent = ({
   className?: string;
   showClose?: boolean;
 }) => {
-  const { closeAuthModal } = useAuthModal();
+  const { openAuthModal, closeAuthModal } = useAuthModal();
   const { status, isAuthenticating } = useSignerStatus();
   const { authStep, setAuthStep } = useAuthContext();
 
@@ -120,6 +120,7 @@ export const AuthCardContent = ({
     } else if (authStep.type !== "initial") {
       didGoBack.current = false;
     } else if (!didGoBack.current && isAuthenticating) {
+      openAuthModal();
       setAuthStep({
         type: "email_completing",
         createPasskeyAfter: addPasskeyOnSignup,
@@ -131,6 +132,7 @@ export const AuthCardContent = ({
     isAuthenticating,
     setAuthStep,
     onAuthSuccess,
+    openAuthModal,
     closeAuthModal,
     addPasskeyOnSignup,
   ]);

--- a/examples/ui-demo/src/app/api/rpc/[...routes]/route.ts
+++ b/examples/ui-demo/src/app/api/rpc/[...routes]/route.ts
@@ -18,7 +18,7 @@ export async function POST(
     method: "POST",
     headers: {
       Authorization: `Bearer ${env.API_KEY}`,
-      ...req.headers,
+      ...headers,
     },
     body: JSON.stringify(body),
   });

--- a/examples/ui-demo/src/app/api/rpc/route.ts
+++ b/examples/ui-demo/src/app/api/rpc/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
   const res = await fetch(env.ALCHEMY_RPC_URL, {
     method: "POST",
     headers: {
-      ...req.headers,
+      ...headers,
     },
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
On mobile, if the user clicks an email magic link, the modal should open immediately to display that they are completing email login.

This has the side effect of opening the modal for OAuth redirect login too, because at the moment email and OAuth share a loading state when returning.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the handling of headers in API routes and enhancing the authentication flow in the `AuthCardContent` component.

### Detailed summary
- In `route.ts`, replaced `...req.headers` with `...headers` for better header management.
- In `route.ts`, added `openAuthModal` to the destructured values from `useAuthModal`.
- In `AuthCardContent`, called `openAuthModal()` when the authentication step is not initial and the user is authenticating.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->