### PR TITLE
fix: include `enablePopupOauth` in code preview in demo

### DIFF
--- a/examples/ui-demo/src/components/preview/CodePreview.tsx
+++ b/examples/ui-demo/src/components/preview/CodePreview.tsx
@@ -113,6 +113,9 @@ function getTailwindCode(ui: Config["ui"]) {
 
 function getConfigCode(config: Config) {
   const sections = getSectionsForConfig(config, "your-project-id");
+  const socialIsEnabled = Object.values(config.auth.oAuthMethods).some(
+    (enabled) => enabled
+  );
 
   return dedent`
   import { AlchemyAccountsUIConfig, createConfig } from "@account-kit/react";
@@ -138,7 +141,9 @@ function getConfigCode(config: Config) {
     // get this from the app config you create at ${links.dashboard}
     transport: alchemy({ apiKey: "your-api-key" }),
     chain: sepolia,
-    ssr: true, // set to false if you're not using server-side rendering
+    ssr: true, // set to false if you're not using server-side rendering${
+      socialIsEnabled ? "\n  enablePopupOauth: true," : ""
+    }
   }, uiConfig);
 
   export const queryClient = new QueryClient();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a check for OAuth methods in the `getConfigCode` function to conditionally enable a popup for OAuth authentication in the configuration.

### Detailed summary
- Introduced a new constant `socialIsEnabled` to check if any OAuth methods are enabled.
- Conditionally added `enablePopupOauth: true` to the configuration if `socialIsEnabled` is true.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->