### PR TITLE
fix: passkey causes stuck loading state

### DIFF
--- a/account-kit/signer/src/base.ts
+++ b/account-kit/signer/src/base.ts
@@ -237,7 +237,18 @@ export abstract class BaseAlchemySigner<TClient extends BaseSignerClient>
       this.trackAuthenticateType(params);
 
       return result.catch((error) => {
-        this.store.setState({ error: toErrorInfo(error) });
+        /**
+         * 2 things going on here:
+         * 1. for oauth flows we expect the status to remain in authenticating
+         * 2. we do the ternary, because if we explicitly pass in `undefined` for the status, zustand will set the value of status to `undefined`.
+         * However, if we omit it, then it will not override the current value of status.
+         */
+        this.store.setState({
+          error: toErrorInfo(error),
+          ...(type === "oauthReturn" || type === "oauth"
+            ? {}
+            : { status: AlchemySignerStatus.DISCONNECTED }),
+        });
         throw error;
       });
     }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling in the `base.ts` file by adjusting the state management in the `catch` block of a promise. It ensures that the `status` is only updated under certain conditions related to OAuth flows.

### Detailed summary
- Added a comment explaining the changes in error handling.
- Modified the `this.store.setState` to conditionally set the `status` based on the `type`.
- If the `type` is "oauthReturn" or "oauth", the `status` remains unchanged; otherwise, it is set to `AlchemySignerStatus.DISCONNECTED`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->