### PR TITLE
fix: update z-indexes of wallet connect and our mobile modal

### DIFF
--- a/account-kit/react/src/components/auth/card/eoa.tsx
+++ b/account-kit/react/src/components/auth/card/eoa.tsx
@@ -1,4 +1,4 @@
-import { walletConnect } from "wagmi/connectors";
+import { walletConnect, type WalletConnectParameters } from "wagmi/connectors";
 import { useAuthConfig } from "../../../hooks/internal/useAuthConfig.js";
 import { useChain } from "../../../hooks/useChain.js";
 import { useConnect } from "../../../hooks/useConnect.js";
@@ -120,7 +120,7 @@ export const EoaPickCard = () => {
   });
   const { setAuthStep } = useAuthContext();
 
-  const walletConnectConfig = useAuthConfig((auth) => {
+  const walletConnectAuthConfig = useAuthConfig((auth) => {
     const externalWalletSection = auth.sections
       .find((x) => x.some((y) => y.type === "external_wallets"))
       ?.find((x) => x.type === "external_wallets") as
@@ -129,6 +129,20 @@ export const EoaPickCard = () => {
 
     return externalWalletSection?.walletConnect;
   });
+
+  // Add z-index to the wallet connect modal if not already set
+  const walletConnectParams = walletConnectAuthConfig
+    ? ({
+        ...walletConnectAuthConfig,
+        qrModalOptions: {
+          ...walletConnectAuthConfig.qrModalOptions,
+          themeVariables: {
+            "--wcm-z-index": "1000000",
+            ...walletConnectAuthConfig.qrModalOptions?.themeVariables,
+          },
+        },
+      } as WalletConnectParameters)
+    : undefined;
 
   const connectorButtons = connectors.map((connector) => {
     return (
@@ -155,8 +169,8 @@ export const EoaPickCard = () => {
     );
   });
 
-  const walletConnectConnector = walletConnectConfig
-    ? walletConnect(walletConnectConfig)
+  const walletConnectConnector = walletConnectParams
+    ? walletConnect(walletConnectParams)
     : null;
 
   return (
@@ -164,7 +178,7 @@ export const EoaPickCard = () => {
       className="w-full"
       header="Select your wallet"
       description={
-        walletConnectConfig != null || connectors.length ? (
+        walletConnectConnector != null || connectors.length ? (
           <div className="flex flex-col gap-3 w-full">
             {connectorButtons}
             {walletConnectConnector && (

--- a/account-kit/react/src/components/dialog/dialog.tsx
+++ b/account-kit/react/src/components/dialog/dialog.tsx
@@ -47,7 +47,7 @@ export const Dialog = ({ isOpen, onClose, children }: DialogProps) => {
           <div
             aria-modal
             role="dialog"
-            className="fixed inset-0 bg-black/80 flex items-end md:items-center justify-center z-[100000] animate-fade-in"
+            className="fixed inset-0 bg-black/80 flex items-end md:items-center justify-center z-[999999] animate-fade-in"
             onClick={handleBackgroundClick}
           >
             <FocusTrap>


### PR DESCRIPTION
https://github.com/user-attachments/assets/042a641a-3799-4fdc-b2a2-9a331011899b

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `EoaPickCard` component by updating the wallet connection configuration and enhancing the z-index for the wallet connect modal.

### Detailed summary
- Increased z-index from `100000` to `999999` in the `dialog.tsx` file.
- Renamed `walletConnectConfig` to `walletConnectAuthConfig` in `eoa.tsx`.
- Added z-index configuration for the wallet connect modal.
- Updated the wallet connect initialization to use `walletConnectParams`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->