### PR TITLE
refactor: remove the open modal check on mobile

### DIFF
--- a/account-kit/react/src/components/auth/card/index.tsx
+++ b/account-kit/react/src/components/auth/card/index.tsx
@@ -120,7 +120,6 @@ export const AuthCardContent = ({
     } else if (authStep.type !== "initial") {
       didGoBack.current = false;
     } else if (!didGoBack.current && isAuthenticating) {
-      openAuthModal();
       setAuthStep({
         type: "email_completing",
         createPasskeyAfter: addPasskeyOnSignup,

--- a/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
+++ b/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
@@ -1,7 +1,16 @@
-import { useAuthModal } from "@account-kit/react";
+import { useAuthModal, useSignerStatus } from "@account-kit/react";
+import { useEffect } from "react";
 
 export function MobileSplashPage() {
   const { openAuthModal } = useAuthModal();
+  const { isAuthenticating } = useSignerStatus();
+
+  useEffect(() => {
+    if (isAuthenticating) {
+      openAuthModal();
+    }
+  }, [openAuthModal, isAuthenticating]);
+
   return (
     <div className="flex flex-col flex-1 pb-5 h-auto max-h-[calc(100svh-100px)] box-content p-4 pt-[78px]">
       {/* Header Text */}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on integrating authentication modal functionality into the `MobileSplashPage` component by utilizing hooks from the `@account-kit/react` library to manage the authentication state.

### Detailed summary
- Added imports for `useAuthModal` and `useSignerStatus` from `@account-kit/react`.
- Introduced `isAuthenticating` state from `useSignerStatus`.
- Implemented `useEffect` to open the auth modal when `isAuthenticating` is true.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->