### PR TITLE
fix: modal was popping up in all auth state changes

### DIFF
--- a/examples/ui-demo/src/app/page.tsx
+++ b/examples/ui-demo/src/app/page.tsx
@@ -35,6 +35,7 @@ export default function Home() {
   const user = useUser();
   const theme = useTheme();
   const isEOAUser = user?.type === "eoa";
+
   return (
     <main
       className={`flex flex-col h-auto sm:bg-bg-main min-h-screen sm:min-h-0 sm:h-screen ${publicSans.className} bg-cover bg-center overflow-hidden`}

--- a/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
+++ b/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
@@ -1,15 +1,17 @@
+import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { useAuthModal, useSignerStatus } from "@account-kit/react";
 import { useEffect } from "react";
 
 export function MobileSplashPage() {
   const { openAuthModal } = useAuthModal();
   const { isAuthenticating } = useSignerStatus();
+  const breakpoint = useBreakpoint();
 
   useEffect(() => {
-    if (isAuthenticating) {
+    if (breakpoint === "sm" && isAuthenticating) {
       openAuthModal();
     }
-  }, [openAuthModal, isAuthenticating]);
+  }, [breakpoint, isAuthenticating, openAuthModal]);
 
   return (
     <div className="flex flex-col flex-1 pb-5 h-auto max-h-[calc(100svh-100px)] box-content p-4 pt-[78px]">


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `MobileSplashPage` component to include a new `breakpoint` variable that checks for screen size before triggering the authentication modal. This change enhances user experience by ensuring the modal only opens under certain conditions.

### Detailed summary
- Added `const breakpoint = useBreakpoint();` to determine the screen size.
- Modified the condition in `useEffect` to check if `breakpoint === "sm"` before opening the auth modal.
- Updated the dependency array of `useEffect` to include `breakpoint`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->