### PR TITLE
refactor(ui-demo): make the ui config per request

### DIFF
--- a/examples/ui-demo/package.json
+++ b/examples/ui-demo/package.json
@@ -28,6 +28,7 @@
     "dedent": "^1.5.3",
     "lucide-react": "^0.394.0",
     "next": "14.2.3",
+    "prettier": "^3.3.3",
     "react": "^18",
     "react-dom": "^18",
     "react-syntax-highlighter": "^15.5.0",

--- a/examples/ui-demo/src/app/config.tsx
+++ b/examples/ui-demo/src/app/config.tsx
@@ -68,34 +68,35 @@ export const DEFAULT_CONFIG: Config = {
 
 export const queryClient = new QueryClient();
 
-export const alchemyConfig = createConfig(
-  {
-    transport: alchemy({ rpcUrl: "/api/rpc" }),
-    chain: arbitrumSepolia,
-    ssr: true,
-    policyId: process.env.NEXT_PUBLIC_PAYMASTER_POLICY_ID,
-    storage: cookieStorage,
-    enablePopupOauth: true,
-  },
-  {
-    illustrationStyle: DEFAULT_CONFIG.ui.illustrationStyle,
-    auth: {
-      sections: [
-        [{ type: "email" }],
-        [
-          { type: "passkey" },
-          { type: "social", authProviderId: "google", mode: "popup" },
-          { type: "social", authProviderId: "facebook", mode: "popup" },
-        ],
-      ],
-      addPasskeyOnSignup: DEFAULT_CONFIG.auth.addPasskey,
-      header: (
-        <AuthCardHeader
-          theme={DEFAULT_CONFIG.ui.theme}
-          logoDark={DEFAULT_CONFIG.ui.logoDark}
-          logoLight={DEFAULT_CONFIG.ui.logoLight}
-        />
-      ),
+export const alchemyConfig = () =>
+  createConfig(
+    {
+      transport: alchemy({ rpcUrl: "/api/rpc" }),
+      chain: arbitrumSepolia,
+      ssr: true,
+      policyId: process.env.NEXT_PUBLIC_PAYMASTER_POLICY_ID,
+      storage: cookieStorage,
+      enablePopupOauth: true,
     },
-  }
-);
+    {
+      illustrationStyle: DEFAULT_CONFIG.ui.illustrationStyle,
+      auth: {
+        sections: [
+          [{ type: "email" }],
+          [
+            { type: "passkey" },
+            { type: "social", authProviderId: "google", mode: "popup" },
+            { type: "social", authProviderId: "facebook", mode: "popup" },
+          ],
+        ],
+        addPasskeyOnSignup: DEFAULT_CONFIG.auth.addPasskey,
+        header: (
+          <AuthCardHeader
+            theme={DEFAULT_CONFIG.ui.theme}
+            logoDark={DEFAULT_CONFIG.ui.logoDark}
+            logoLight={DEFAULT_CONFIG.ui.logoLight}
+          />
+        ),
+      },
+    }
+  );

--- a/examples/ui-demo/src/app/layout.tsx
+++ b/examples/ui-demo/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const initialState = cookieToInitialState(
-    alchemyConfig,
+    alchemyConfig(),
     headers().get("cookie") ?? undefined
   );
 

--- a/examples/ui-demo/src/app/providers.tsx
+++ b/examples/ui-demo/src/app/providers.tsx
@@ -3,9 +3,12 @@
 import { ToastProvider } from "@/contexts/ToastProvider";
 import { convertDemoConfigToUiConfig } from "@/state/store";
 import { AlchemyClientState } from "@account-kit/core";
-import { AlchemyAccountProvider } from "@account-kit/react";
+import {
+  AlchemyAccountProvider,
+  AlchemyAccountsConfigWithUI,
+} from "@account-kit/react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { PropsWithChildren, Suspense } from "react";
+import { PropsWithChildren, Suspense, useRef } from "react";
 import { ConfigContextProvider, ConfigSync } from "../state";
 import { alchemyConfig, Config, queryClient } from "./config";
 
@@ -15,18 +18,24 @@ export const Providers = (
     initialConfig?: Config;
   }>
 ) => {
-  const localAlchemyConfig = {
-    ...alchemyConfig,
-    ui: props.initialConfig
-      ? convertDemoConfigToUiConfig(props.initialConfig)
-      : alchemyConfig.ui,
-  };
+  const configRef = useRef<AlchemyAccountsConfigWithUI>();
+  if (!configRef.current) {
+    configRef.current = (() => {
+      const innerConfig = alchemyConfig();
+      return {
+        ...innerConfig,
+        ui: props.initialConfig
+          ? convertDemoConfigToUiConfig(props.initialConfig)
+          : innerConfig.ui,
+      };
+    })();
+  }
 
   return (
     <Suspense>
       <QueryClientProvider client={queryClient}>
         <AlchemyAccountProvider
-          config={localAlchemyConfig}
+          config={configRef.current}
           queryClient={queryClient}
           initialState={props.initialState}
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -18637,9 +18637,9 @@ prettier@^2.8.8:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-prettier@^3.1.1:
+prettier@^3.1.1, prettier@^3.3.3:
   version "3.3.3"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 prettier@^3.2.5:


### PR DESCRIPTION
# This PR
I've moved the alchemy config to be created once per request and added prettier to the code preview.

Even though prettier is async, it runs so quickly that you don't notice or see any flashes of unstyled content

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `alchemyConfig` to be a function, enhancing the configuration management in the application. It also adds `prettier` as a dependency and improves the `CodePreview` component by formatting code using `prettier`.

### Detailed summary
- Changed `alchemyConfig` from an object to a function in `examples/ui-demo/src/app/config.tsx`.
- Updated the usage of `alchemyConfig` in `examples/ui-demo/src/app/layout.tsx` and `examples/ui-demo/src/app/providers.tsx`.
- Added `prettier` dependency in `examples/ui-demo/package.json`.
- Enhanced `CodePreview` component in `examples/ui-demo/src/components/preview/CodePreview.tsx` to format code using `prettier`.
- Improved code rendering by displaying formatted code in the `CodeBlock` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->