### PR TITLE
fix: don't show error view when cancelling oauth

### DIFF
--- a/account-kit/react/package.json
+++ b/account-kit/react/package.json
@@ -70,6 +70,7 @@
     "@account-kit/core": "^4.4.0",
     "@account-kit/infra": "^4.4.0",
     "@account-kit/logging": "^4.4.0",
+    "@account-kit/signer": "^4.4.0",
     "@tanstack/react-form": "^0.33.0",
     "@tanstack/zod-form-adapter": "^0.33.0",
     "@wagmi/connectors": "^5.1.15",


### PR DESCRIPTION
This is an intentional action from the user and not an error. Instead, just return to the main screen.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the OAuth flow in the `CompletingOAuth` component by adding error handling for cancelled OAuth processes and updating the dependencies.

### Detailed summary
- Added `@account-kit/signer` as a new dependency.
- Imported `OauthCancelledError` from `@account-kit/signer`.
- Introduced a check for `oauthWasCancelled` to handle cancelled OAuth scenarios.
- Updated the dependency array in the `useEffect` hook to include `oauthWasCancelled`.
- Modified the error handling to exclude cancelled OAuth errors from triggering the `ConnectionError` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->