### PR TITLE
fix: don't re-initialize unless the user has changed

### DIFF
--- a/account-kit/signer/src/session/manager.ts
+++ b/account-kit/signer/src/session/manager.ts
@@ -245,8 +245,16 @@ export class SessionManager {
 
     // sync local state if persisted state has changed from another tab
     window.addEventListener("focus", () => {
+      const oldSession = this.store.getState().session;
       this.store.persist.rehydrate();
-      this.initialize();
+      const newSession = this.store.getState().session;
+      if (
+        oldSession?.user.orgId !== newSession?.user.orgId ||
+        oldSession?.user.userId !== newSession?.user.userId
+      ) {
+        // Initialize if the user has changed.
+        this.initialize();
+      }
     });
   };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the session management in `manager.ts` by ensuring that the local state is synchronized when the window gains focus. It checks if the user session has changed before reinitializing.

### Detailed summary
- Added a check for `oldSession` and `newSession` on window focus.
- Only calls `this.initialize()` if the `orgId` or `userId` has changed between sessions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->