### PR TITLE
fix(logging): add better dev mode checking so this works in RN

### DIFF
--- a/account-kit/logging/src/client.ts
+++ b/account-kit/logging/src/client.ts
@@ -6,11 +6,12 @@ import { noopLogger } from "./noop.js";
 import { ContextAllowlistPlugin } from "./plugins/contextAllowlist.js";
 import { DevDestinationPlugin } from "./plugins/devDestination.js";
 import type { EventsSchema, InnerLogger, LoggerContext } from "./types";
+import { isClientDevMode } from "./utils.js";
 
 export function createClientLogger<Schema extends EventsSchema = []>(
   context: LoggerContext
 ): InnerLogger<Schema> {
-  const isDev = window.location.hostname.includes("localhost");
+  const isDev = isClientDevMode();
   if (isDev && !WRITE_IN_DEV) {
     // If we don't have a write key, we don't want to log anything
     // This is useful for dev so we don't log dev metrics

--- a/account-kit/logging/src/utils.ts
+++ b/account-kit/logging/src/utils.ts
@@ -1,0 +1,22 @@
+// just in case we're in a setting that doesn't have these types defined
+declare const __DEV__: boolean | undefined;
+declare const window: Window | undefined;
+
+export function isClientDevMode() {
+  if (typeof __DEV__ !== "undefined" && __DEV__) {
+    return true;
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    return true;
+  }
+
+  if (
+    typeof window !== "undefined" &&
+    window.location?.hostname?.includes("localhost")
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the determination of the development mode in the logging utility by introducing a new function, `isClientDevMode`, and refactoring the client logger's initialization to handle errors more gracefully.

### Detailed summary
- Added `isClientDevMode` function in `utils.ts` to check if the client is in development mode.
- Refactored `createClientLogger` in `client.ts` to use `isClientDevMode` instead of directly checking `window.location`.
- Updated `createLogger` in `index.ts` to handle errors during logger initialization and return `noopLogger` if an error occurs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->