### PR TITLE
fix: border radius fixed for custom social auth

### DIFF
--- a/examples/ui-demo/src/components/configuration/Authentication.tsx
+++ b/examples/ui-demo/src/components/configuration/Authentication.tsx
@@ -90,7 +90,7 @@ export const Authentication = ({ className }: { className?: string }) => {
                 />
                 <ExternalLink
                   href="https://accountkit.alchemy.com/signer/authentication/auth0"
-                  className=" btn border border-border active:bg-demo-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-none"
+                  className=" btn rounded-lg border border-border active:bg-demo-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-none"
                 >
                   <p className="hidden lg:block font-normal text-sm text-secondary-foreground">
                     Custom

--- a/examples/ui-demo/src/components/configuration/PhotoUpload.tsx
+++ b/examples/ui-demo/src/components/configuration/PhotoUpload.tsx
@@ -2,6 +2,7 @@ import { useConfigStore } from "@/state";
 import { ChangeEvent } from "react";
 import { PhotoIcon } from "../icons/photo";
 import FileUploadInput from "../shared/FileUploadInput";
+import { cn } from "@/lib/utils";
 
 const sidebarButton = `self-start border rounded-lg py-2 px-[10px] gap-2 flex items-center justify-between hover:opacity-80 w-28 h-10 border-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background`;
 
@@ -33,7 +34,10 @@ export function PhotoUploads({ mode }: { mode: "dark" | "light" }) {
   return (
     <>
       {logo ? (
-        <button onClick={onRemove} className={sidebarButton}>
+        <button
+          onClick={onRemove}
+          className={cn(sidebarButton, "justify-center")}
+        >
           Remove
         </button>
       ) : (


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

Border radius should no longer change for the custom social auth button when radius is adjusted in the sidebar.

<img width="348" alt="Screenshot 2024-10-22 at 11 49 56 AM" src="https://github.com/user-attachments/assets/815caca3-3f48-4920-9476-591952eb2705">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the styling and functionality of components in the `Authentication.tsx` and `PhotoUpload.tsx` files. It includes adjustments to class names for improved appearance and the use of a utility function for dynamic class management.

### Detailed summary
- In `Authentication.tsx`, the `className` for `ExternalLink` was changed to include `rounded-lg`.
- In `PhotoUpload.tsx`, the `cn` utility function was imported.
- The `className` for the `button` in `PhotoUploads` was updated to use `cn` for dynamic styling, adding `justify-center`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->