### PR TITLE
fix(fee-estimator): add a 50% buffer to base fee by default in alchemy fee estimator

### DIFF
--- a/account-kit/infra/src/middleware/feeEstimator.ts
+++ b/account-kit/infra/src/middleware/feeEstimator.ts
@@ -1,5 +1,5 @@
 import type { ClientMiddlewareFn } from "@aa-sdk/core";
-import { applyUserOpOverrideOrFeeOption } from "@aa-sdk/core";
+import { applyUserOpOverrideOrFeeOption, bigIntMultiply } from "@aa-sdk/core";
 import type { AlchemyTransport } from "../alchemyTransport";
 
 /**
@@ -51,7 +51,7 @@ export const alchemyFeeEstimator: (
       feeOptions?.maxPriorityFeePerGas
     );
     const maxFeePerGas = applyUserOpOverrideOrFeeOption(
-      baseFeePerGas + BigInt(maxPriorityFeePerGas),
+      bigIntMultiply(baseFeePerGas, 1.5) + BigInt(maxPriorityFeePerGas),
       overrides?.maxFeePerGas,
       feeOptions?.maxFeePerGas
     );


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the fee estimation logic in the `alchemyFeeEstimator` function by incorporating a new multiplication function to adjust the `baseFeePerGas`.

### Detailed summary
- Added `bigIntMultiply` from `@aa-sdk/core`.
- Modified the calculation of `maxFeePerGas` to use `bigIntMultiply(baseFeePerGas, 1.5)` instead of simple addition with `baseFeePerGas`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->