### PR TITLE
fix: passkey shield icon now uses brand theme

### DIFF
--- a/account-kit/react/src/icons/illustrations/passkeys.tsx
+++ b/account-kit/react/src/icons/illustrations/passkeys.tsx
@@ -82,11 +82,13 @@ export const PasskeyShieldIllustration = ({
       {illustrationStyle === "outline" && (
         <>
           <PasskeyShieldOutlineLight
-            className={`dark:hidden ${className ?? ""}`}
+            className={`dark:hidden text-fg-accent-brand ${className ?? ""}`}
             {...props}
           />
           <PasskeyShieldOutlineDark
-            className={`hidden dark:block ${className ?? ""}`}
+            className={`hidden text-fg-accent-brand dark:block ${
+              className ?? ""
+            }`}
             {...props}
           />
         </>
@@ -94,11 +96,13 @@ export const PasskeyShieldIllustration = ({
       {illustrationStyle === "linear" && (
         <>
           <PasskeyShieldLinearLight
-            className={`dark:hidden ${className ?? ""}`}
+            className={`dark:hidden text-fg-accent-brand ${className ?? ""}`}
             {...props}
           />
           <PasskeyShieldLinearDark
-            className={`hidden dark:block ${className ?? ""}`}
+            className={`hidden text-fg-accent-brand dark:block ${
+              className ?? ""
+            }`}
             {...props}
           />
         </>
@@ -106,11 +110,13 @@ export const PasskeyShieldIllustration = ({
       {illustrationStyle === "filled" && (
         <>
           <PasskeyShieldFilledLight
-            className={`dark:hidden ${className ?? ""}`}
+            className={`dark:hidden text-fg-accent-brand ${className ?? ""}`}
             {...props}
           />
           <PasskeyShieldFilledDark
-            className={`hidden dark:block ${className ?? ""}`}
+            className={`hidden text-fg-accent-brand dark:block ${
+              className ?? ""
+            }`}
             {...props}
           />
         </>
@@ -118,11 +124,13 @@ export const PasskeyShieldIllustration = ({
       {illustrationStyle === "flat" && (
         <>
           <PasskeyShieldFlatLight
-            className={`dark:hidden ${className ?? ""}`}
+            className={`dark:hidden text-fg-accent-brand ${className ?? ""}`}
             {...props}
           />
           <PasskeyShieldFlatDark
-            className={`hidden dark:block ${className ?? ""}`}
+            className={`hidden dark:block text-fg-accent-brand ${
+              className ?? ""
+            }`}
             {...props}
           />
         </>


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

# Testing steps
Login via email with add passkey after sign up enabled.  You should see the shield icon in the popup matching the brand theme.
![Screenshot 2024-11-01 at 4 00 37 PM](https://github.com/user-attachments/assets/65400ca7-f956-4e27-a8f1-d895e004d3c2)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `className` properties of various `PasskeyShield` components to include the `text-fg-accent-brand` class, enhancing the styling for different illustration styles.

### Detailed summary
- Updated `className` in `PasskeyShieldOutlineLight` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldOutlineDark` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldLinearLight` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldLinearDark` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldFilledLight` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldFilledDark` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldFlatLight` to include `text-fg-accent-brand`.
- Updated `className` in `PasskeyShieldFlatDark` to include `text-fg-accent-brand`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->