### PR TITLE
fix: update hex codes for toggle

### DIFF
--- a/examples/ui-demo/src/components/shared/ThemeSwitch.tsx
+++ b/examples/ui-demo/src/components/shared/ThemeSwitch.tsx
@@ -26,7 +26,10 @@ const ThemeSwitch = React.forwardRef<
     ></SwitchPrimitives.Thumb>
     <div className="absolute flex text-sm items-center inset-1 z-10 justify-between bg-transparent">
       <div className="flex items-center data-[state=unchecked]:font-medium justify-center gap-1 flex-1 basis-0">
-        <Sun className={cn(checked && "stroke-demo-fg-secondary")} size={18} />
+        <Sun
+          className={cn(checked && "stroke-demo-fg-toggle-icon")}
+          size={18}
+        />
       </div>
       <div className="flex items-center justify-center gap-1 flex-1 basis-0">
         <Moon

--- a/examples/ui-demo/src/components/ui/switch.tsx
+++ b/examples/ui-demo/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-demo-bg-toggle-active data-[state=unchecked]:bg-demo-bg-toggle-inactive",
+      "peer inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:bg-demo-bg-toggle-disabled data-[state=checked]:bg-demo-bg-toggle-active data-[state=unchecked]:bg-demo-bg-toggle-inactive",
       className
     )}
     {...props}

--- a/examples/ui-demo/tailwind.config.ts
+++ b/examples/ui-demo/tailwind.config.ts
@@ -55,7 +55,9 @@ const config = {
         },
         // Demo app colors, not themable at this time
         "demo-bg-toggle-active": "#020617",
-        "demo-bg-toggle-inactive": "#94A3B8",
+        "demo-bg-toggle-inactive": "rgba(103, 106, 117, .4)",
+        "demo-bg-toggle-disabled": "#A3A6B1",
+        "demo-fg-toggle-icon": "#6E717C",
         "demo-bg": "#FFFFFF",
         "demo-text-invert": "#FBFDFF",
         "demo-nav-bg": "rgba(255, 255, 255, 0.5)",


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

Added hex codes as per direction from this asana ticket: https://app.asana.com/0/1205598840815267/1208522889766490

![Screenshot 2024-11-04 at 2 17 10 PM](https://github.com/user-attachments/assets/054e479f-44b4-4e70-8993-85368cc256b0)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `tailwind.config.ts` file to modify color values for demo components and adjusting the `ThemeSwitch` and `Switch` components to use these new color values.

### Detailed summary
- Updated `demo-bg-toggle-inactive` to use `rgba(103, 106, 117, .4)`.
- Added `demo-bg-toggle-disabled` with value `#A3A6B1`.
- Added `demo-fg-toggle-icon` with value `#6E717C`.
- Changed class name in `ThemeSwitch` from `stroke-demo-fg-secondary` to `stroke-demo-fg-toggle-icon`.
- Updated `Switch` component's class to use `disabled:bg-demo-bg-toggle-disabled`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->