### PR TITLE
feat(rn): add bundle injection logic

### DIFF
--- a/account-kit/rn-signer/android/build.gradle
+++ b/account-kit/rn-signer/android/build.gradle
@@ -114,6 +114,7 @@ dependencies {
   implementation "javax.xml.bind:jaxb-api:2.3.1"
   implementation "androidx.security:security-crypto:1.1.0-alpha06"
   implementation "com.google.crypto.tink:tink-android:1.15.0"
+  implementation "org.bitcoinj:bitcoinj-core:0.16.3"
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for the `bitcoinj` library and enhances the `NativeTEKStamperModule` by implementing hybrid encryption and decryption functionality. It also refines the use of `EncryptedSharedPreferences` for secure storage.

### Detailed summary
- Added `bitcoinj-core` dependency.
- Introduced new imports for `Tink` and `bitcoinj`.
- Created a new `BUNDLE_KEY` constant.
- Replaced the previous `masterKey` initialization with a new setup.
- Registered `TinkConfig` during module initialization.
- Modified the `init` method to support HPKE decryption.
- Updated `injectCredentialBundle` method to handle decryption of credential bundles.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->