### PR TITLE
feat(rn): add stamping logic to android stamper

### DIFF
--- a/account-kit/rn-signer/android/build.gradle
+++ b/account-kit/rn-signer/android/build.gradle
@@ -14,6 +14,12 @@ buildscript {
   }
 }
 
+plugins {
+  id 'org.jetbrains.kotlin.plugin.serialization' version "$ReactNativeSigner_kotlinVersion"
+}
+
+def kotlin_version = getExtOrDefault("kotlinVersion")
+
 def reactNativeArchitectures() {
   def value = rootProject.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -103,8 +109,6 @@ repositories {
   google()
 }
 
-def kotlin_version = getExtOrDefault("kotlinVersion")
-
 dependencies {
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
@@ -115,6 +119,7 @@ dependencies {
   implementation "androidx.security:security-crypto:1.1.0-alpha06"
   implementation "com.google.crypto.tink:tink-android:1.15.0"
   implementation "org.bitcoinj:bitcoinj-core:0.16.3"
+  implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1"
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `NativeTEKStamperModule` in the `rn-signer` project by adding Kotlin serialization support, improving key management, and implementing the `stamp` function for creating digital signatures.

### Detailed summary
- Added `kotlin.plugin.serialization` to `build.gradle`.
- Introduced `ApiStamp` data class for serialization.
- Updated `BUNDLE_KEY` constants in `NativeTEKStamperModule`.
- Implemented the `stamp` function for signing payloads.
- Added private key handling with `privateKeyToKeyPair`.
- Integrated BouncyCastle as a security provider if not already present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->