### PR TITLE
fix(signer): passkey sessions were being wiped by oauth prep

### DIFF
--- a/account-kit/signer/src/session/manager.ts
+++ b/account-kit/signer/src/session/manager.ts
@@ -96,6 +96,7 @@ export class SessionManager {
             orgId: existingSession.user.orgId,
             authenticatingType: existingSession.type,
             connectedEventName,
+            idToken: existingSession.user.idToken,
           })
           .catch((e) => {
             console.warn("Failed to load user from session", e);

--- a/account-kit/smart-contracts/package.json
+++ b/account-kit/smart-contracts/package.json
@@ -35,7 +35,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "generate": "npx tsx ../plugingen/src/cli.ts generate && yarn _lint:generated",
+    "generate": "npx tsx ../plugingen/src/cli.ts generate && yarn _lint:generated 1> /dev/null",
     "_lint:generated": "dotenv -e ../../.env -- eslint . --fix --config ../../.eslintrc --ignore-path ../../.prettierignore && prettier --write --ignore-path ../../.prettierignore .",
     "build": "yarn clean && yarn build:esm && yarn build:types",
     "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",

--- a/examples/ui-demo/src/components/shared/mint-card/MintCard.tsx
+++ b/examples/ui-demo/src/components/shared/mint-card/MintCard.tsx
@@ -61,7 +61,8 @@ export const MintCard = () => {
     });
     setNFTTransfered(true);
   };
-  const handleError = () => {
+  const handleError = (error: Error) => {
+    console.error(error);
     setStatus(initialValuePropState);
     setToast({
       type: "error",

--- a/turbo.json
+++ b/turbo.json
@@ -23,11 +23,6 @@
     "docs:gen": {
       "dependsOn": ["ak-docgen#build"],
       "outputs": ["../../site/pages/reference/**"]
-    },
-    "dev": {
-      "dependsOn": ["^build"],
-      "persistent": true,
-      "cache": false
     }
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the session management and error handling in the `account-kit` module, updating configurations, and improving the `MintCard` component. It also refines the `AlchemySignerWebClient` class to manage OAuth configurations and user connection events.

### Detailed summary
- Removed `dev` configuration from `turbo.json`.
- Added `idToken` to the session management in `manager.ts`.
- Updated `handleError` function in `MintCard.tsx` to log errors.
- Modified `generate` script in `package.json` to suppress output.
- Added `OAuthProvidersError` import back to `index.ts`.
- Emitted `connectedPasskey` event in `AlchemySignerWebClient` upon user connection.
- Ensured the stamper is set correctly based on user login in `getOauthConfig`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->