### PR TITLE
fix: changing protected by to powered by alchemy footer

### DIFF
--- a/account-kit/react/src/components/auth/card/footer/protected-by.tsx
+++ b/account-kit/react/src/components/auth/card/footer/protected-by.tsx
@@ -2,9 +2,9 @@ import { AlchemyLogo } from "../../../../icons/alchemy.js";
 import { ls } from "../../../../strings.js";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const PoweredBy = () => (
+export const ProtectedBy = () => (
   <div className="flex flex-row gap-1 items-center h-[14px] text-fg-disabled">
-    <span className="text-[11px]">{ls.poweredBy.title}</span>
+    <span className="text-[11px]">{ls.protectedBy.title}</span>
     <AlchemyLogo />
   </div>
 );

--- a/account-kit/react/src/components/auth/sections/Footer.tsx
+++ b/account-kit/react/src/components/auth/sections/Footer.tsx
@@ -1,7 +1,7 @@
 import { EmailNotReceivedDisclaimer } from "../card/footer/email-not-reveived.js";
 import { HelpText } from "../card/footer/help-text.js";
 import { OAuthContactSupport } from "../card/footer/oauth-contact-support.js";
-import { PoweredBy } from "../card/footer/poweredby.js";
+import { ProtectedBy } from "../card/footer/protected-by.js";
 import { RegistrationDisclaimer } from "../card/footer/registration-disclaimer.js";
 import type { AuthStep } from "../context.js";
 
@@ -34,7 +34,7 @@ export const Footer = ({ authStep }: FooterProps) => {
     <div className="p-5 pt-2">
       <RenderFooterText authStep={authStep} />
       <div className="flex justify-center">
-        <PoweredBy />
+        <ProtectedBy />
       </div>
     </div>
   );

--- a/account-kit/react/src/strings.ts
+++ b/account-kit/react/src/strings.ts
@@ -39,8 +39,8 @@ const STRINGS = {
       supportText: "Having trouble?",
       supportLink: "Contact support",
     },
-    poweredBy: {
-      title: "powered by",
+    protectedBy: {
+      title: "protected by",
     },
     error: {
       general: {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR renames and refactors components related to displaying branding information in the footer of the application. The `PoweredBy` component is changed to `ProtectedBy`, reflecting a shift in terminology.

### Detailed summary
- Updated `supportLink` in `strings.ts` to include `protectedBy`.
- Renamed `PoweredBy` component to `ProtectedBy` in `protected-by.tsx`.
- Changed the text reference in the `ProtectedBy` component from `ls.poweredBy.title` to `ls.protectedBy.title`.
- Updated the import statement in `Footer.tsx` to import `ProtectedBy` instead of `PoweredBy`.
- Replaced `<PoweredBy />` with `<ProtectedBy />` in the `Footer` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->