### PR TITLE
fix: oauth working

### DIFF
--- a/account-kit/react/src/components/auth/modal.tsx
+++ b/account-kit/react/src/components/auth/modal.tsx
@@ -27,8 +27,12 @@ export const AuthModal = () => {
       });
     }
   }, [addPasskeyOnSignup, openAuthModal, setAuthStep]);
-
-  useNewUserSignup(handleSignup, isConnected && authStep.type === "complete");
+  useNewUserSignup(
+    handleSignup,
+    isConnected &&
+      (authStep.type === "complete" || authStep.type === "initial") &&
+      !isOpen
+  );
 
   return (
     <Dialog isOpen={isOpen} onClose={closeAuthModal}>

--- a/account-kit/react/src/hooks/internal/useNewUserSignup.ts
+++ b/account-kit/react/src/hooks/internal/useNewUserSignup.ts
@@ -1,22 +1,23 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSigner } from "../useSigner.js";
 
 export function useNewUserSignup(onSignup: () => void, enabled?: boolean) {
   const hasHandled = useRef(false);
+  const [isNewUser, setIsNewUser] = useState(false);
   const signer = useSigner();
-
+  useEffect(() => {
+    const stopListening = signer?.on("newUserSignup", () => {
+      setIsNewUser(true);
+    });
+    return stopListening;
+  }, [signer]);
   useEffect(() => {
     if (!enabled) return;
     if (!signer) return;
-
-    const handleSignup = () => {
-      if (!hasHandled.current) {
-        hasHandled.current = true;
-        onSignup();
-      }
-    };
-
-    const stopListening = signer.on("newUserSignup", handleSignup);
-    return stopListening;
-  }, [enabled, onSignup, signer]);
+    if (hasHandled.current) return;
+    if (isNewUser) {
+      onSignup();
+      hasHandled.current = true;
+    }
+  }, [enabled, isNewUser, onSignup, signer]);
 }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useNewUserSignup` functionality by adding a condition to check for an initial signup state and whether the modal is open. It also modifies the logic to handle new user signups more effectively by introducing a new state variable.

### Detailed summary
- Updated `useNewUserSignup` invocation in `modal.tsx` to include additional conditions for `authStep.type` and `isOpen`.
- Introduced a new state variable `isNewUser` in `useNewUserSignup`.
- Adjusted the effect to listen for `newUserSignup` events and update `isNewUser`.
- Refactored signup handling logic to trigger `onSignup` based on `isNewUser` state instead of a separate handler.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->