### PR TITLE
Adding waitForUserOperationReceipt

### DIFF
--- a/aa-sdk/core/src/actions/smartAccount/internal/waitForUserOperation.ts
+++ b/aa-sdk/core/src/actions/smartAccount/internal/waitForUserOperation.ts
@@ -1,0 +1,56 @@
+import type { Chain, Client, Hex, Transport } from "viem";
+import type {WaitForUserOperationTxParameters} from "../types";
+import {isBaseSmartAccountClient} from "../../../client/isSmartAccountClient";
+import {IncompatibleClientError} from "../../../errors/client";
+import {Logger} from "../../../logger";
+import {FailedToFindTransactionError} from "../../../errors/transaction";
+import {UserOperationReceipt} from "../../../types";
+
+export async function _waitForUserOperationTransaction<
+    TTransport extends Transport = Transport,
+    TChain extends Chain | undefined = Chain | undefined
+>(
+    client: Client<TTransport, TChain, any>,
+    args: WaitForUserOperationTxParameters
+) : Promise<UserOperationReceipt>  {
+    if (!isBaseSmartAccountClient(client)) {
+        throw new IncompatibleClientError(
+            "BaseSmartAccountClient",
+            "waitForUserOperation",
+            client
+        );
+    }
+
+    const {
+        hash,
+        retries = {
+            maxRetries: client.txMaxRetries,
+            intervalMs: client.txRetryIntervalMs,
+            multiplier: client.txRetryMultiplier,
+        },
+    } = args;
+
+    for (let i = 0; i < retries.maxRetries; i++) {
+        const txRetryIntervalWithJitterMs =
+            retries.intervalMs * Math.pow(retries.multiplier, i) +
+            Math.random() * 100;
+
+        await new Promise((resolve) =>
+            setTimeout(resolve, txRetryIntervalWithJitterMs)
+        );
+
+        const receipt = await client
+            .getUserOperationReceipt(hash as `0x${string}`)
+            .catch((e) => {
+                Logger.error(
+                    `[SmartAccountProvider] waitForUserOperation error fetching receipt for ${hash}: ${e}`
+                );
+            });
+
+        if (receipt) {
+            return receipt
+        }
+    }
+
+
+};

--- a/aa-sdk/core/src/actions/smartAccount/waitForUserOperationReceipt.ts
+++ b/aa-sdk/core/src/actions/smartAccount/waitForUserOperationReceipt.ts
@@ -1,0 +1,25 @@
+
+// TODO: fill in documentation
+
+import type {Client, Chain, Transport} from "viem";
+import type {WaitForUserOperationTxParameters} from "./types";
+import {UserOperationReceipt} from "../../types";
+import {_waitForUserOperationTransaction} from "./internal/waitForUserOperation";
+import {FailedToFindTransactionError} from "../../errors/transaction";
+
+export const waitForUserOperationReceipt: <
+    TTransport extends Transport = Transport,
+    TChain extends Chain | undefined = Chain | undefined
+>(
+    client: Client<TTransport, TChain, any>,
+    args: WaitForUserOperationTxParameters
+) => Promise<UserOperationReceipt> = async (client, args) => {
+
+    const receipt =  _waitForUserOperationTransaction(client, args);
+
+    if (receipt) {
+        return receipt
+    }
+
+    throw new FailedToFindTransactionError(args.hash);
+};


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the functionality for waiting on user operation receipts in a smart account context. It introduces a new method for handling transaction receipts and refactors existing logic to streamline the process.

### Detailed summary
- Added `waitForUserOperationReceipt` function to handle user operation receipts.
- Introduced `_waitForUserOperationTransaction` for fetching transaction receipts with retries.
- Refactored `waitForUserOperationTransaction` to utilize `_waitForUserOperationTransaction`.
- Added error handling and logging for receipt fetching failures.
- Removed redundant retry logic from `waitForUserOperationTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->