### PR TITLE
fix: correctly align protected by copy

### DIFF
--- a/account-kit/react/src/components/auth/card/footer/protected-by.tsx
+++ b/account-kit/react/src/components/auth/card/footer/protected-by.tsx
@@ -4,7 +4,7 @@ import { ls } from "../../../../strings.js";
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const ProtectedBy = () => (
   <div className="flex flex-row gap-1 items-center h-[14px] text-fg-disabled">
-    <span className="text-[11px]">{ls.protectedBy.title}</span>
+    <span className="text-[11px] pt-[1px]">{ls.protectedBy.title}</span>
     <AlchemyLogo />
   </div>
 );


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

Added 1px padding to align the text.
Before: 
![Screenshot 2024-12-03 at 11 21 01 AM](https://github.com/user-attachments/assets/d655c926-e604-4b98-938c-be715b33f4b4)
After: 
![Screenshot 2024-12-03 at 11 21 28 AM](https://github.com/user-attachments/assets/6d80ef6a-639b-4aee-8adc-50e820a1cd26)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a minor style adjustment in the `ProtectedBy` component, specifically adding padding to the text element.

### Detailed summary
- In the `ProtectedBy` component, the `<span>` element now includes a `pt-[1px]` class for additional vertical padding.
- The class `text-[11px]` remains unchanged, ensuring consistent font size.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->