### PR TITLE
feat: address tooltip

### DIFF
--- a/examples/ui-demo/src/components/shared/user-connection-avatar/UserAddressLink.tsx
+++ b/examples/ui-demo/src/components/shared/user-connection-avatar/UserAddressLink.tsx
@@ -1,25 +1,46 @@
 import truncateAddress from "@/utils/truncate-address";
-import { useConnection } from "@account-kit/react";
-import { useMemo } from "react";
+import {
+  TooltipProvider,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipArrow,
+} from "@radix-ui/react-tooltip";
+import { useState } from "react";
 
 export const UserAddressLink = ({ address }: { address: string | null }) => {
-  const connection = useConnection();
+  const [showCopied, setShowCopied] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const truncatedAddress = truncateAddress(address ?? "");
-  const addressBlockExplorerUrl = useMemo(() => {
-    if (!address || !connection.chain.blockExplorers) {
-      return null;
-    }
 
-    return `${connection.chain.blockExplorers?.default.url}/address/${address}`;
-  }, [address, connection]);
+  const handleClick = async () => {
+    if (!address) return;
+    await navigator.clipboard.writeText(address);
+    setShowCopied(true);
+    setIsOpen(true);
+    setTimeout(() => setShowCopied(false), 2000);
+  };
 
   return (
-    <a
-      target="_blank"
-      className="text-fg-primary underline text-md md:text-sm"
-      href={addressBlockExplorerUrl ?? "#"}
-    >
-      {truncatedAddress}
-    </a>
+    <TooltipProvider>
+      <Tooltip open={isOpen} onOpenChange={setIsOpen}>
+        <TooltipTrigger asChild>
+          <button
+            onClick={handleClick}
+            className="text-fg-primary underline text-md md:text-sm"
+          >
+            {truncatedAddress}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          align="start"
+          alignOffset={-16}
+          className="bg-foreground text-background px-3 py-2 rounded-md"
+        >
+          <TooltipArrow />
+          <p className="text-xs">{showCopied ? "Copied!" : address}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

On hover
![Screenshot 2024-12-04 at 11 53 01 AM](https://github.com/user-attachments/assets/c894cb33-acad-4e89-aa75-f52a0c46cce4)
When clicked:
![Screenshot 2024-12-04 at 11 54 10 AM](https://github.com/user-attachments/assets/f394cda5-0a83-4331-b8a2-a3c7a981fb8d)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `UserAddressLink` component to enhance user interaction by replacing the existing address link with a button that copies the address to the clipboard and displays a tooltip indicating when the address has been copied.

### Detailed summary
- Removed the `useConnection` hook and related logic.
- Added `TooltipProvider`, `Tooltip`, `TooltipTrigger`, `TooltipContent`, and `TooltipArrow` from `@radix-ui/react-tooltip`.
- Introduced `useState` for managing copied state and tooltip visibility.
- Implemented `handleClick` function to copy the address to the clipboard.
- Replaced the anchor tag with a button wrapped in a tooltip for better user feedback.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->