### PR TITLE
feat: add multi-policy sponsorships

### DIFF
--- a/account-kit/core/src/createConfig.ts
+++ b/account-kit/core/src/createConfig.ts
@@ -63,7 +63,7 @@ export const createConfig = (
       connections.push({
         transport: transport?.config ?? connectionConfig.transport!.config,
         chain,
-        policyId,
+        policyId: policyId ?? connectionConfig.policyId,
       });
     });
   }

--- a/account-kit/core/src/types.ts
+++ b/account-kit/core/src/types.ts
@@ -61,7 +61,7 @@ export type AlchemyAccountsConfig = {
 export type Connection = {
   transport: AlchemyTransportConfig;
   chain: Chain;
-  policyId?: string;
+  policyId?: string | string[];
 };
 
 type RpcConnectionConfig =
@@ -69,7 +69,7 @@ type RpcConnectionConfig =
       chain: Chain;
       chains: {
         chain: Chain;
-        policyId?: string;
+        policyId?: string | string[];
         // optional transport override
         transport?: AlchemyTransport;
       }[];
@@ -83,7 +83,7 @@ type RpcConnectionConfig =
       chain: Chain;
       chains: {
         chain: Chain;
-        policyId?: string;
+        policyId?: string | string[];
         transport: AlchemyTransport;
       }[];
       transport?: never;
@@ -94,7 +94,7 @@ type RpcConnectionConfig =
   | {
       transport: AlchemyTransport;
       chain: Chain;
-      policyId?: string;
+      policyId?: string | string[];
       signerConnection?: ConnectionConfig;
       chains?: never;
     };

--- a/account-kit/infra/src/actions/types.ts
+++ b/account-kit/infra/src/actions/types.ts
@@ -55,7 +55,7 @@ export interface SimulateAssetChange {
 
 export type RequestGasAndPaymasterAndDataRequest = [
   {
-    policyId: string;
+    policyId: string | string[];
     entryPoint: Address;
     dummySignature: Hex;
     userOperation: UserOperationRequest;

--- a/account-kit/infra/src/client/smartAccountClient.ts
+++ b/account-kit/infra/src/client/smartAccountClient.ts
@@ -41,7 +41,7 @@ export type AlchemySmartAccountClientConfig<
 > = {
   account?: account;
   useSimulation?: boolean;
-  policyId?: string;
+  policyId?: string | string[];
 } & Pick<
   SmartAccountClientConfig<AlchemyTransport, chain, account, context>,
   | "customMiddleware"

--- a/account-kit/infra/src/middleware/gasManager.ts
+++ b/account-kit/infra/src/middleware/gasManager.ts
@@ -40,19 +40,19 @@ import { alchemyFeeEstimator } from "./feeEstimator.js";
  * });
  * ```
  *
- * @param {string} policyId the policyId for Alchemy's gas manager
+ * @param {string | string[]} policyId the policyId (or list of policyIds) for Alchemy's gas manager
  * @returns {Pick<ClientMiddlewareConfig, "dummyPaymasterAndData" | "paymasterAndData">} partial client middleware configuration containing `dummyPaymasterAndData` and `paymasterAndData`
  */
 export function alchemyGasManagerMiddleware(
-  policyId: string
+  policyId: string | string[]
 ): Pick<ClientMiddlewareConfig, "dummyPaymasterAndData" | "paymasterAndData"> {
-  return erc7677Middleware<{ policyId: string }>({
+  return erc7677Middleware<{ policyId: string | string[] }>({
     context: { policyId: policyId },
   });
 }
 
 interface AlchemyGasAndPaymasterAndDataMiddlewareParams {
-  policyId: string;
+  policyId: string | string[];
   transport: AlchemyTransport;
   gasEstimatorOverride?: ClientMiddlewareFn;
   feeEstimatorOverride?: ClientMiddlewareFn;

--- a/site/pages/reference/account-kit/infra/functions/alchemyGasManagerMiddleware.mdx
+++ b/site/pages/reference/account-kit/infra/functions/alchemyGasManagerMiddleware.mdx
@@ -33,8 +33,8 @@ const client = createSmartAccountClient({
 
 ### policyId
 
-`string`
-the policyId for Alchemy's gas manager
+`string | string[]`
+the policyId (or list of policyIds) for Alchemy's gas manager
 
 ## Returns
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the type of `policyId` across various files to allow it to accept either a `string` or an array of `string`. This change enhances flexibility in handling multiple policy IDs within the Alchemy gas manager.

### Detailed summary
- Updated `policyId` type to `string | string[]` in `createConfig.ts`.
- Modified `RequestGasAndPaymasterAndDataRequest` type in `types.ts`.
- Changed documentation for `policyId` in `alchemyGasManagerMiddleware.mdx`.
- Updated `policyId` type in `smartAccountClient.ts`.
- Altered `RpcConnectionConfig` to accept `policyId` as `string | string[]`.
- Adjusted parameter type in `alchemyGasManagerMiddleware` function to `string | string[]`.
- Updated interface `AlchemyGasAndPaymasterAndDataMiddlewareParams` to reflect new `policyId` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->