### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains all of the packages that make up Account Kit as well as the c
 
 ## @account-kit/\*
 
-Account Kit packages are all prefixed with `@account-kit` are are broken down into the following packages:
+Account Kit packages are all prefixed with `@account-kit` are broken down into the following packages:
 
 1. [`@account-kit/react`](https://github.com/alchemyplatform/aa-sdk/tree/main/account-kit/react)
 1. [`@account-kit/core`](https://github.com/alchemyplatform/aa-sdk/tree/main/account-kit/core)

--- a/site/pages/smart-contracts/modular-account/getting-started.mdx
+++ b/site/pages/smart-contracts/modular-account/getting-started.mdx
@@ -16,7 +16,7 @@ It is easy to get started with Modular Account! We will show you two different w
 
 **Installation**
 
-First, install the the `@account-kit/smart-contracts` package.
+First, install the `@account-kit/smart-contracts` package.
 
 :::code-group
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting minor typographical errors in the documentation files related to the `@account-kit/smart-contracts` package and the `@account-kit` packages.

### Detailed summary
- In `site/pages/smart-contracts/modular-account/getting-started.mdx`, removed the duplicate "the" in the installation instruction.
- In `README.md`, removed the redundant "are" in the description of Account Kit packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->