### PR TITLE
fix: rn stamper was returning stamp instead of response

### DIFF
--- a/account-kit/rn-signer/android/src/main/java/com/accountkit/reactnativesigner/NativeTEKStamperModule.kt
+++ b/account-kit/rn-signer/android/src/main/java/com/accountkit/reactnativesigner/NativeTEKStamperModule.kt
@@ -54,7 +54,7 @@ class NativeTEKStamperModule(reactContext: ReactApplicationContext) :
                 "stampHeaderValue",
                 stamp.stampHeaderValue
             )
-            return promise.resolve(stamp)
+            return promise.resolve(response)
         } catch (e: Exception) {
             promise.reject(e)
         }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the return value in the `NativeTEKStamperModule.kt` file from `stamp` to `response` when resolving a promise, which likely reflects a change in the data being returned after a stamping operation.

### Detailed summary
- Changed the promise resolution from `stamp` to `response` in the `NativeTEKStamperModule.kt` file.
- Added error handling to reject the promise in case of an exception during the operation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->