### PR TITLE
feat: add all mav2 contract addrs, abis

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/abis/accountFactoryAbi.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/accountFactoryAbi.ts
@@ -1,0 +1,638 @@
+export const accountFactoryAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "_entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "_accountImpl",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+      {
+        name: "_semiModularImpl",
+        type: "address",
+        internalType: "contract SemiModularAccountBytecode",
+      },
+      {
+        name: "_singleSignerValidationModule",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_webAuthnValidationModule",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "ACCOUNT_IMPL",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "ENTRY_POINT",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "SEMI_MODULAR_ACCOUNT_IMPL",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract SemiModularAccountBytecode",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "SINGLE_SIGNER_VALIDATION_MODULE",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "WEBAUTHN_VALIDATION_MODULE",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "acceptOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "addStake",
+    inputs: [
+      {
+        name: "unstakeDelay",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "createAccount",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "createSemiModularAccount",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract SemiModularAccountBytecode",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "createWebAuthnAccount",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getAddress",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getAddressSemiModular",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getAddressWebAuthn",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getSalt",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "getSaltWebAuthn",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "owner",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "pendingOwner",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "renounceOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "transferOwnership",
+    inputs: [
+      {
+        name: "newOwner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "unlockStake",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [
+      {
+        name: "to",
+        type: "address",
+        internalType: "address payable",
+      },
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdrawStake",
+    inputs: [
+      {
+        name: "withdrawAddress",
+        type: "address",
+        internalType: "address payable",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferStarted",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferred",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "SemiModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "WebAuthnModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "ownerX",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "AddressEmptyCode",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "AddressInsufficientBalance",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "FailedInnerCall",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidAction",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "OwnableInvalidOwner",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "OwnableUnauthorizedAccount",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "TransferFailed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/abis/modularAccountAbi.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/modularAccountAbi.ts
@@ -1,4 +1,4 @@
-export const smaV2Abi = [
+export const modularAccountAbi = [
   {
     type: "constructor",
     inputs: [
@@ -246,24 +246,6 @@ export const smaV2Abi = [
   },
   {
     type: "function",
-    name: "getFallbackSignerData",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
     name: "getValidationData",
     inputs: [
       {
@@ -302,6 +284,34 @@ export const smaV2Abi = [
       },
     ],
     stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "initializeWithValidation",
+    inputs: [
+      {
+        name: "validationConfig",
+        type: "bytes25",
+        internalType: "ValidationConfig",
+      },
+      {
+        name: "selectors",
+        type: "bytes4[]",
+        internalType: "bytes4[]",
+      },
+      {
+        name: "installData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hooks",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -716,24 +726,6 @@ export const smaV2Abi = [
   },
   {
     type: "function",
-    name: "updateFallbackSignerData",
-    inputs: [
-      {
-        name: "fallbackSigner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "isDisabled",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
     name: "upgradeToAndCall",
     inputs: [
       {
@@ -984,25 +976,6 @@ export const smaV2Abi = [
   },
   {
     type: "event",
-    name: "FallbackSignerUpdated",
-    inputs: [
-      {
-        name: "newFallbackSigner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "isDisabled",
-        type: "bool",
-        indexed: false,
-        internalType: "bool",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
     name: "Initialized",
     inputs: [
       {
@@ -1104,21 +1077,6 @@ export const smaV2Abi = [
   },
   {
     type: "error",
-    name: "FallbackSignerDisabled",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "FallbackSignerMismatch",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "FallbackValidationInstallationNotAllowed",
-    inputs: [],
-  },
-  {
-    type: "error",
     name: "InterfaceNotSupported",
     inputs: [
       {
@@ -1131,11 +1089,6 @@ export const smaV2Abi = [
   {
     type: "error",
     name: "InvalidInitialization",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidSignatureType",
     inputs: [],
   },
   {

--- a/account-kit/smart-contracts/src/ma-v2/abis/semiModularAccountBytecodeAbi.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/semiModularAccountBytecodeAbi.ts
@@ -1,0 +1,1288 @@
+export const semiModularAccountBytecodeAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "executionInstallDelegate",
+        type: "address",
+        internalType: "contract ExecutionInstallDelegate",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "fallback",
+    stateMutability: "payable",
+  },
+  {
+    type: "receive",
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "accountId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "entryPoint",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "execute",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "result",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeBatch",
+    inputs: [
+      {
+        name: "calls",
+        type: "tuple[]",
+        internalType: "struct Call[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "value",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "data",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: "results",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "executeWithRuntimeValidation",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "authorization",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "getExecutionData",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ExecutionDataView",
+        components: [
+          {
+            name: "module",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "skipRuntimeValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "allowGlobalValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getFallbackSignerData",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getValidationData",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ValidationDataView",
+        components: [
+          {
+            name: "validationFlags",
+            type: "uint8",
+            internalType: "ValidationFlags",
+          },
+          {
+            name: "validationHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "installExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+      {
+        name: "moduleInstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "installValidation",
+    inputs: [
+      {
+        name: "validationConfig",
+        type: "bytes25",
+        internalType: "ValidationConfig",
+      },
+      {
+        name: "selectors",
+        type: "bytes4[]",
+        internalType: "bytes4[]",
+      },
+      {
+        name: "installData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hooks",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "isValidSignature",
+    inputs: [
+      {
+        name: "hash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "onERC1155BatchReceived",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC1155Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC721Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "performCreate",
+    inputs: [
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "initCode",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "isCreate2",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "salt",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "createdAddr",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "proxiableUUID",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "uninstallExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+      {
+        name: "moduleUninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "uninstallValidation",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "uninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hookUninstallData",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateFallbackSignerData",
+    inputs: [
+      {
+        name: "fallbackSigner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "isDisabled",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "upgradeToAndCall",
+    inputs: [
+      {
+        name: "newImplementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "validateUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "userOpHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "missingAccountFunds",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "validationData",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ExecutionInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ExecutionUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "FallbackSignerUpdated",
+    inputs: [
+      {
+        name: "newFallbackSigner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "isDisabled",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Initialized",
+    inputs: [
+      {
+        name: "version",
+        type: "uint64",
+        indexed: false,
+        internalType: "uint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Upgraded",
+    inputs: [
+      {
+        name: "implementation",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "ArrayLengthMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "CreateFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredActionSignatureInvalid",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredValidationHasValidationHooks",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ExecutionHookAlreadySet",
+    inputs: [
+      {
+        name: "hookConfig",
+        type: "bytes25",
+        internalType: "HookConfig",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "FallbackSignerDisabled",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "FallbackSignerMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "FallbackValidationInstallationNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InterfaceNotSupported",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "InvalidInitialization",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidSignatureType",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ModuleInstallCallbackFailed",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "revertReason",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "NonCanonicalEncoding",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotEntryPoint",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "PreValidationHookDuplicate",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "RequireUserOperationContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SegmentOutOfOrder",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SelfCallRecursionDepthExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SignatureValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnauthorizedCallContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedAggregator",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "aggregator",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnrecognizedFunction",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UpgradeFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UserOpValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAlreadySet",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAssocHookLimitExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationEntityIdInUse",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationFunctionMissing",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationSignatureSegmentMissing",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/abis/semiModularAccountStorageAbi.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/semiModularAccountStorageAbi.ts
@@ -1,0 +1,1301 @@
+export const semiModularAccountStorageAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "executionInstallDelegate",
+        type: "address",
+        internalType: "contract ExecutionInstallDelegate",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "fallback",
+    stateMutability: "payable",
+  },
+  {
+    type: "receive",
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "accountId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "entryPoint",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "execute",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "result",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeBatch",
+    inputs: [
+      {
+        name: "calls",
+        type: "tuple[]",
+        internalType: "struct Call[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "value",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "data",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: "results",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "executeWithRuntimeValidation",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "authorization",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "getExecutionData",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ExecutionDataView",
+        components: [
+          {
+            name: "module",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "skipRuntimeValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "allowGlobalValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getFallbackSignerData",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getValidationData",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ValidationDataView",
+        components: [
+          {
+            name: "validationFlags",
+            type: "uint8",
+            internalType: "ValidationFlags",
+          },
+          {
+            name: "validationHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "initialize",
+    inputs: [
+      {
+        name: "initialSigner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "installExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+      {
+        name: "moduleInstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "installValidation",
+    inputs: [
+      {
+        name: "validationConfig",
+        type: "bytes25",
+        internalType: "ValidationConfig",
+      },
+      {
+        name: "selectors",
+        type: "bytes4[]",
+        internalType: "bytes4[]",
+      },
+      {
+        name: "installData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hooks",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "isValidSignature",
+    inputs: [
+      {
+        name: "hash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "onERC1155BatchReceived",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC1155Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC721Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "performCreate",
+    inputs: [
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "initCode",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "isCreate2",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "salt",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "createdAddr",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "proxiableUUID",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "uninstallExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+      {
+        name: "moduleUninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "uninstallValidation",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "uninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hookUninstallData",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateFallbackSignerData",
+    inputs: [
+      {
+        name: "fallbackSigner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "isDisabled",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "upgradeToAndCall",
+    inputs: [
+      {
+        name: "newImplementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "validateUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "userOpHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "missingAccountFunds",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "validationData",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ExecutionInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ExecutionUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "FallbackSignerUpdated",
+    inputs: [
+      {
+        name: "newFallbackSigner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "isDisabled",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Initialized",
+    inputs: [
+      {
+        name: "version",
+        type: "uint64",
+        indexed: false,
+        internalType: "uint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Upgraded",
+    inputs: [
+      {
+        name: "implementation",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "ArrayLengthMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "CreateFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredActionSignatureInvalid",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredValidationHasValidationHooks",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ExecutionHookAlreadySet",
+    inputs: [
+      {
+        name: "hookConfig",
+        type: "bytes25",
+        internalType: "HookConfig",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "FallbackSignerDisabled",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "FallbackSignerMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "FallbackValidationInstallationNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InterfaceNotSupported",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "InvalidInitialization",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidSignatureType",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ModuleInstallCallbackFailed",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "revertReason",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "NonCanonicalEncoding",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotEntryPoint",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "PreValidationHookDuplicate",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "RequireUserOperationContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SegmentOutOfOrder",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SelfCallRecursionDepthExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SignatureValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnauthorizedCallContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedAggregator",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "aggregator",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnrecognizedFunction",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UpgradeFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UserOpValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAlreadySet",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAssocHookLimitExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationEntityIdInUse",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationFunctionMissing",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationSignatureSegmentMissing",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/allowlist-module/abis/allowlistModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/allowlist-module/abis/allowlistModule.ts
@@ -1,0 +1,715 @@
+export const allowlistModuleAbi = [
+  {
+    type: "function",
+    name: "addressAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasSelectorAllowlist",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasERC20SpendLimit",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "checkAllowlistCalldata",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "callData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "deleteAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "inputs",
+        type: "tuple[]",
+        internalType: "struct AllowlistModule.AllowlistInput[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "hasSelectorAllowlist",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasERC20SpendLimit",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "erc20SpendLimit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "erc20SpendLimits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "postExecutionHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preExecutionHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "selectorAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "setAddressAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasSelectorAllowlist",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasERC20SpendLimit",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setSelectorAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "updateAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "inputs",
+        type: "tuple[]",
+        internalType: "struct AllowlistModule.AllowlistInput[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "hasSelectorAllowlist",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasERC20SpendLimit",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "erc20SpendLimit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateLimits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "hasERC20SpendLimit",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "AddressAllowlistUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "target",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entry",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct AllowlistModule.AddressAllowlistEntry",
+        components: [
+          {
+            name: "allowed",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasSelectorAllowlist",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasERC20SpendLimit",
+            type: "bool",
+            internalType: "bool",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ERC20SpendLimitUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "token",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "SelectorAllowlistUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "targetAndSelector",
+        type: "bytes24",
+        indexed: true,
+        internalType: "bytes24",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "AddressNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ERC20NotAllowed",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ExceededTokenLimit",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidCalldataLength",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NoSelectorSpecified",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SelectorNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SpendingRequestNotAllowed",
+    inputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/native-token-limit-module/abis/nativeTokenLimitModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/native-token-limit-module/abis/nativeTokenLimitModule.ts
@@ -1,0 +1,403 @@
+export const nativeTokenLimitModuleAbi = [
+  {
+    type: "function",
+    name: "limits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "limit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "postExecutionHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preExecutionHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "specialPaymasters",
+    inputs: [
+      {
+        name: "paymaster",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "updateLimits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateSpecialPaymaster",
+    inputs: [
+      {
+        name: "paymaster",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "NativeTokenSpendLimitUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "SpecialPaymasterUpdated",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "paymaster",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "ExceededNativeTokenLimit",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidPaymaster",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/paymaster-guard-module/abis/paymasterGuardModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/paymaster-guard-module/abis/paymasterGuardModule.ts
@@ -1,4 +1,4 @@
-export const singleSignerValidationAbi = [
+export const paymasterGuardModuleAbi = [
   {
     type: "function",
     name: "moduleId",
@@ -40,31 +40,7 @@ export const singleSignerValidationAbi = [
   },
   {
     type: "function",
-    name: "replaySafeHash",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "hash",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "signers",
+    name: "paymasters",
     inputs: [
       {
         name: "entityId",
@@ -79,7 +55,7 @@ export const singleSignerValidationAbi = [
     ],
     outputs: [
       {
-        name: "",
+        name: "paymaster",
         type: "address",
         internalType: "address",
       },
@@ -88,57 +64,15 @@ export const singleSignerValidationAbi = [
   },
   {
     type: "function",
-    name: "supportsInterface",
+    name: "preRuntimeValidationHook",
     inputs: [
-      {
-        name: "interfaceId",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
-    outputs: [
       {
         name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "transferSigner",
-    inputs: [
-      {
-        name: "entityId",
         type: "uint32",
         internalType: "uint32",
       },
       {
-        name: "newSigner",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "validateRuntime",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "entityId",
-        type: "uint32",
-        internalType: "uint32",
-      },
-      {
-        name: "sender",
+        name: "",
         type: "address",
         internalType: "address",
       },
@@ -163,15 +97,10 @@ export const singleSignerValidationAbi = [
   },
   {
     type: "function",
-    name: "validateSignature",
+    name: "preSignatureValidationHook",
     inputs: [
       {
-        name: "account",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "entityId",
+        name: "",
         type: "uint32",
         internalType: "uint32",
       },
@@ -181,28 +110,22 @@ export const singleSignerValidationAbi = [
         internalType: "address",
       },
       {
-        name: "digest",
+        name: "",
         type: "bytes32",
         internalType: "bytes32",
       },
       {
-        name: "signature",
+        name: "",
         type: "bytes",
         internalType: "bytes",
       },
     ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
-    stateMutability: "view",
+    outputs: [],
+    stateMutability: "pure",
   },
   {
     type: "function",
-    name: "validateUserOp",
+    name: "preUserOpValidationHook",
     inputs: [
       {
         name: "entityId",
@@ -262,7 +185,7 @@ export const singleSignerValidationAbi = [
         ],
       },
       {
-        name: "userOpHash",
+        name: "",
         type: "bytes32",
         internalType: "bytes32",
       },
@@ -277,44 +200,32 @@ export const singleSignerValidationAbi = [
     stateMutability: "view",
   },
   {
-    type: "event",
-    name: "SignerTransferred",
+    type: "function",
+    name: "supportsInterface",
     inputs: [
       {
-        name: "account",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "entityId",
-        type: "uint32",
-        indexed: true,
-        internalType: "uint32",
-      },
-      {
-        name: "newSigner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "previousSigner",
-        type: "address",
-        indexed: false,
-        internalType: "address",
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
       },
     ],
-    anonymous: true,
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
   },
   {
     type: "error",
-    name: "InvalidSignatureType",
+    name: "BadPaymasterSpecified",
     inputs: [],
   },
   {
     type: "error",
-    name: "NotAuthorized",
+    name: "InvalidPaymaster",
     inputs: [],
   },
   {

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/singleSignerValidationModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/singleSignerValidationModule.ts
@@ -1,0 +1,330 @@
+export const singleSignerValidationModuleAbi = [
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "replaySafeHash",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "hash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "signers",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "transferSigner",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "newSigner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "validateRuntime",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "sender",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "validateSignature",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "digest",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "validateUserOp",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "userOpHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "SignerTransferred",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "newSigner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "previousSigner",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+    ],
+    anonymous: true,
+  },
+  {
+    type: "error",
+    name: "InvalidSignatureType",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotAuthorized",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/module.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/module.ts
@@ -1,6 +1,6 @@
 import { encodeAbiParameters, type Address, type Hex } from "viem";
 
-import { singleSignerValidationAbi } from "./abis/singleSignerValidation.js";
+import { singleSignerValidationModuleAbi } from "./abis/singleSignerValidationModule.js";
 
 const addresses = {
   default: "0xEa3a0b544d517f6Ed3Dc2186C74D869c702C376e",
@@ -15,7 +15,7 @@ const meta = {
 // Todo: some unified type for ERC-6900 v0.8 modules. I couldn't figure out how to parameterize the class itself over the abi type parameters for onInstall and onUninstall.
 export const SingleSignerValidationModule = {
   meta,
-  abi: singleSignerValidationAbi,
+  abi: singleSignerValidationModuleAbi,
   encodeOnInstallData: (args: { entityId: number; signer: Address }): Hex => {
     const { entityId, signer } = args;
 

--- a/account-kit/smart-contracts/src/ma-v2/modules/time-range-module/abis/timeRangeModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/time-range-module/abis/timeRangeModule.ts
@@ -1,0 +1,295 @@
+export const timeRangeModuleAbi = [
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "setTimeRange",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "validUntil",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "validAfter",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "timeRanges",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "validUntil",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "validAfter",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "TimeRangeSet",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "validUntil",
+        type: "uint48",
+        indexed: false,
+        internalType: "uint48",
+      },
+      {
+        name: "validAfter",
+        type: "uint48",
+        indexed: false,
+        internalType: "uint48",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "TimeRangeNotValid",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/webauthn-validation/abis/webauthnValidation.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/webauthn-validation/abis/webauthnValidation.ts
@@ -1,4 +1,4 @@
-export const MAV2FactoryAbi = [
+export const webauthnValidationModuleAbi = [
   {
     type: "constructor",
     inputs: [
@@ -13,17 +13,7 @@ export const MAV2FactoryAbi = [
         internalType: "contract ModularAccount",
       },
       {
-        name: "_semiModularImpl",
-        type: "address",
-        internalType: "contract SemiModularAccountBytecode",
-      },
-      {
-        name: "_singleSignerValidationModule",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "_webAuthnValidationModule",
+        name: "_webauthnValidationModule",
         type: "address",
         internalType: "address",
       },
@@ -63,32 +53,6 @@ export const MAV2FactoryAbi = [
   },
   {
     type: "function",
-    name: "SEMI_MODULAR_ACCOUNT_IMPL",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "contract SemiModularAccountBytecode",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "SINGLE_SIGNER_VALIDATION_MODULE",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
     name: "WEBAUTHN_VALIDATION_MODULE",
     inputs: [],
     outputs: [
@@ -99,13 +63,6 @@ export const MAV2FactoryAbi = [
       },
     ],
     stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "acceptOwnership",
-    inputs: [],
-    outputs: [],
-    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -123,59 +80,6 @@ export const MAV2FactoryAbi = [
   {
     type: "function",
     name: "createAccount",
-    inputs: [
-      {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "entityId",
-        type: "uint32",
-        internalType: "uint32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "contract ModularAccount",
-      },
-    ],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "createSemiModularAccount",
-    inputs: [
-      {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "contract SemiModularAccountBytecode",
-      },
-    ],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "createWebAuthnAccount",
     inputs: [
       {
         name: "ownerX",
@@ -212,59 +116,6 @@ export const MAV2FactoryAbi = [
     name: "getAddress",
     inputs: [
       {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "entityId",
-        type: "uint32",
-        internalType: "uint32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "getAddressSemiModular",
-    inputs: [
-      {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "getAddressWebAuthn",
-    inputs: [
-      {
         name: "ownerX",
         type: "uint256",
         internalType: "uint256",
@@ -297,35 +148,6 @@ export const MAV2FactoryAbi = [
   {
     type: "function",
     name: "getSalt",
-    inputs: [
-      {
-        name: "owner",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "entityId",
-        type: "uint32",
-        internalType: "uint32",
-      },
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    stateMutability: "pure",
-  },
-  {
-    type: "function",
-    name: "getSaltWebAuthn",
     inputs: [
       {
         name: "ownerX",
@@ -372,23 +194,10 @@ export const MAV2FactoryAbi = [
   },
   {
     type: "function",
-    name: "pendingOwner",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
     name: "renounceOwnership",
     inputs: [],
     outputs: [],
-    stateMutability: "view",
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -457,35 +266,22 @@ export const MAV2FactoryAbi = [
         internalType: "address",
       },
       {
-        name: "owner",
-        type: "address",
+        name: "ownerX",
+        type: "uint256",
         indexed: true,
-        internalType: "address",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
       },
       {
         name: "salt",
         type: "uint256",
         indexed: false,
         internalType: "uint256",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "OwnershipTransferStarted",
-    inputs: [
-      {
-        name: "previousOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "newOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
       },
     ],
     anonymous: false,
@@ -505,62 +301,6 @@ export const MAV2FactoryAbi = [
         type: "address",
         indexed: true,
         internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "SemiModularAccountDeployed",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "owner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        indexed: false,
-        internalType: "uint256",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "WebAuthnModularAccountDeployed",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "ownerX",
-        type: "uint256",
-        indexed: true,
-        internalType: "uint256",
-      },
-      {
-        name: "ownerY",
-        type: "uint256",
-        indexed: true,
-        internalType: "uint256",
-      },
-      {
-        name: "salt",
-        type: "uint256",
-        indexed: false,
-        internalType: "uint256",
       },
     ],
     anonymous: false,
@@ -590,11 +330,6 @@ export const MAV2FactoryAbi = [
   {
     type: "error",
     name: "FailedInnerCall",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidAction",
     inputs: [],
   },
   {

--- a/account-kit/smart-contracts/src/ma-v2/utils.ts
+++ b/account-kit/smart-contracts/src/ma-v2/utils.ts
@@ -12,3 +12,31 @@ export const packSignature = ({
 }: PackSignatureParams): Hex => {
   return concat(["0xFF", "0x00", validationSignature]);
 };
+
+export const addresses = {
+  allowlistModule:
+    "0xE46ca4a98c485caEE2Abb6ef5116292B8c78a868" as `0x${string}`,
+  nativeTokenLimitModule:
+    "0xEa6a05306315196f2A7CA2ec7eEA45290bae00A0" as `0x${string}`,
+  paymasterGuardModule:
+    "0x976D01aF75D128cae526B5328AC268ac83D607f4" as `0x${string}`,
+  singleSignerValidationModule:
+    "0xF56716aE104545BdAf012e14e4640beb52727479" as `0x${string}`,
+  timeRangeModule:
+    "0x6FD0a9765a86788126a55aD5a483029a484F996C" as `0x${string}`,
+  webauthnValidationModule:
+    "0xCf3423F8EB9EE215560802D03a48cDD44f85bD28" as `0x${string}`,
+  executionInstallDelegate:
+    "0x8Bf909fEb66EBcC4725f04E70F319791Ec9d9628" as `0x${string}`,
+  modularAccountImpl:
+    "0x99090abd2700E24Cc70E3c486A89F7af876fFA33" as `0x${string}`,
+  semiModularAccountBytecodeImpl:
+    "0xDCBb5d4639428B18703801f7Cd7230add729E4b0" as `0x${string}`,
+  semiModularAccountStorageOnlyImpl:
+    "0x563ea43Ba0CD9150466B054Ce47FB0Fb45B234E2" as `0x${string}`,
+  accountFactory: "0xA5FC7aDc6d2c838443dF5bb826152c58b918f2c8" as `0x${string}`,
+  accountFactoryOwner:
+    "0x3BD786ac7Dec96eF9d06ebbCFa4e0E0947A2c303" as `0x${string}`,
+};
+
+export const tempChainId = 11155420;


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming several ABI exports for clarity and consistency, along with the addition of new ABI definitions for various modules in the smart contract codebase.

### Detailed summary
- Renamed `MAV2FactoryAbi` to `accountFactoryAbi`.
- Renamed `smaV2Abi` to `semiModularAccountBytecodeAbi`.
- Renamed `singleSignerValidationAbi` to `singleSignerValidationModuleAbi`.
- Updated import statements to reflect new names.
- Added `addresses` export with various module addresses.
- Introduced new ABIs for `paymasterGuardModule`, `timeRangeModule`, `webauthnValidationModule`, `nativeTokenLimitModule`, `allowlistModule`, `modularAccountAbi`, and `semiModularAccountStorageAbi`.

> The following files were skipped due to too many changes: `account-kit/smart-contracts/src/ma-v2/abis/semiModularAccountStorageAbi.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->