### PR TITLE
12 13 test add basic uo test

### DIFF
--- a/.vitest/src/instances.ts
+++ b/.vitest/src/instances.ts
@@ -10,6 +10,17 @@ import { split } from "../../aa-sdk/core/src/transport/split";
 import { poolId, rundlerBinaryPath } from "./constants";
 import { paymasterTransport } from "./paymaster/transport";
 
+export const local070InstanceOptSep = defineInstance({
+  chain: localhost,
+  forkBlockNumber: 21153995,
+  forkUrl:
+    process.env.VITEST_OPT_SEPOLIA_FORK_URL ??
+    "https://opt-sepolia-rpc.publicnode.com",
+  entryPointVersion: "0.7.0",
+  anvilPort: 8345,
+  bundlerPort: 8445,
+});
+
 export const local060Instance = defineInstance({
   chain: localhost,
   forkBlockNumber: 6381303,

--- a/account-kit/smart-contracts/src/ma-v2/abis/maV2.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/maV2.ts
@@ -1,0 +1,1241 @@
+export const maV2Abi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "executionInstallDelegate",
+        type: "address",
+        internalType: "contract ExecutionInstallDelegate",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "fallback",
+    stateMutability: "payable",
+  },
+  {
+    type: "receive",
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "accountId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "entryPoint",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "execute",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "result",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeBatch",
+    inputs: [
+      {
+        name: "calls",
+        type: "tuple[]",
+        internalType: "struct Call[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "value",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "data",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: "results",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "executeWithRuntimeValidation",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "authorization",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "getExecutionData",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ExecutionDataView",
+        components: [
+          {
+            name: "module",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "skipRuntimeValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "allowGlobalValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getValidationData",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ValidationDataView",
+        components: [
+          {
+            name: "validationFlags",
+            type: "uint8",
+            internalType: "ValidationFlags",
+          },
+          {
+            name: "validationHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "initializeWithValidation",
+    inputs: [
+      {
+        name: "validationConfig",
+        type: "bytes25",
+        internalType: "ValidationConfig",
+      },
+      {
+        name: "selectors",
+        type: "bytes4[]",
+        internalType: "bytes4[]",
+      },
+      {
+        name: "installData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hooks",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "installExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+      {
+        name: "moduleInstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "installValidation",
+    inputs: [
+      {
+        name: "validationConfig",
+        type: "bytes25",
+        internalType: "ValidationConfig",
+      },
+      {
+        name: "selectors",
+        type: "bytes4[]",
+        internalType: "bytes4[]",
+      },
+      {
+        name: "installData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hooks",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "isValidSignature",
+    inputs: [
+      {
+        name: "hash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "onERC1155BatchReceived",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC1155Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC721Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "performCreate",
+    inputs: [
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "initCode",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "isCreate2",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "salt",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "createdAddr",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "proxiableUUID",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "uninstallExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+      {
+        name: "moduleUninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "uninstallValidation",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "uninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hookUninstallData",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "upgradeToAndCall",
+    inputs: [
+      {
+        name: "newImplementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "validateUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "userOpHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "missingAccountFunds",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "validationData",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ExecutionInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ExecutionUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Initialized",
+    inputs: [
+      {
+        name: "version",
+        type: "uint64",
+        indexed: false,
+        internalType: "uint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Upgraded",
+    inputs: [
+      {
+        name: "implementation",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "ArrayLengthMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "CreateFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredActionSignatureInvalid",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredValidationHasValidationHooks",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ExecutionHookAlreadySet",
+    inputs: [
+      {
+        name: "hookConfig",
+        type: "bytes25",
+        internalType: "HookConfig",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "InterfaceNotSupported",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "InvalidInitialization",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ModuleInstallCallbackFailed",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "revertReason",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "NonCanonicalEncoding",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotEntryPoint",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "PreValidationHookDuplicate",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "RequireUserOperationContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SegmentOutOfOrder",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SelfCallRecursionDepthExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SignatureValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnauthorizedCallContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedAggregator",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "aggregator",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnrecognizedFunction",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UpgradeFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UserOpValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAlreadySet",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAssocHookLimitExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationEntityIdInUse",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationFunctionMissing",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationSignatureSegmentMissing",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/abis/maV2Factory.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/maV2Factory.ts
@@ -1,0 +1,638 @@
+export const MAV2FactoryAbi = [
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "_entryPoint",
+                "type": "address",
+                "internalType": "contract IEntryPoint"
+            },
+            {
+                "name": "_accountImpl",
+                "type": "address",
+                "internalType": "contract ModularAccount"
+            },
+            {
+                "name": "_semiModularImpl",
+                "type": "address",
+                "internalType": "contract SemiModularAccountBytecode"
+            },
+            {
+                "name": "_singleSignerValidationModule",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_webAuthnValidationModule",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "ACCOUNT_IMPL",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ModularAccount"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "ENTRY_POINT",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IEntryPoint"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "SEMI_MODULAR_ACCOUNT_IMPL",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract SemiModularAccountBytecode"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "SINGLE_SIGNER_VALIDATION_MODULE",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "WEBAUTHN_VALIDATION_MODULE",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "acceptOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "addStake",
+        "inputs": [
+            {
+                "name": "unstakeDelay",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "createAccount",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ModularAccount"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "createSemiModularAccount",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract SemiModularAccountBytecode"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "createWebAuthnAccount",
+        "inputs": [
+            {
+                "name": "ownerX",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "ownerY",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ModularAccount"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "getAddress",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getAddressSemiModular",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getAddressWebAuthn",
+        "inputs": [
+            {
+                "name": "ownerX",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "ownerY",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getSalt",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "getSaltWebAuthn",
+        "inputs": [
+            {
+                "name": "ownerX",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "ownerY",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "owner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "pendingOwner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "renounceOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "transferOwnership",
+        "inputs": [
+            {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "unlockStake",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "withdraw",
+        "inputs": [
+            {
+                "name": "to",
+                "type": "address",
+                "internalType": "address payable"
+            },
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "withdrawStake",
+        "inputs": [
+            {
+                "name": "withdrawAddress",
+                "type": "address",
+                "internalType": "address payable"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "event",
+        "name": "ModularAccountDeployed",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "owner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferStarted",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferred",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "SemiModularAccountDeployed",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "owner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "WebAuthnModularAccountDeployed",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "ownerX",
+                "type": "uint256",
+                "indexed": true,
+                "internalType": "uint256"
+            },
+            {
+                "name": "ownerY",
+                "type": "uint256",
+                "indexed": true,
+                "internalType": "uint256"
+            },
+            {
+                "name": "salt",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "AddressEmptyCode",
+        "inputs": [
+            {
+                "name": "target",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "AddressInsufficientBalance",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "FailedInnerCall",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidAction",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "OwnableInvalidOwner",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "OwnableUnauthorizedAccount",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "SafeERC20FailedOperation",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "TransferFailed",
+        "inputs": []
+    }
+];

--- a/account-kit/smart-contracts/src/ma-v2/abis/maV2Factory.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/maV2Factory.ts
@@ -1,638 +1,638 @@
 export const MAV2FactoryAbi = [
-    {
-        "type": "constructor",
-        "inputs": [
-            {
-                "name": "_entryPoint",
-                "type": "address",
-                "internalType": "contract IEntryPoint"
-            },
-            {
-                "name": "_accountImpl",
-                "type": "address",
-                "internalType": "contract ModularAccount"
-            },
-            {
-                "name": "_semiModularImpl",
-                "type": "address",
-                "internalType": "contract SemiModularAccountBytecode"
-            },
-            {
-                "name": "_singleSignerValidationModule",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "_webAuthnValidationModule",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "ACCOUNT_IMPL",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract ModularAccount"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "ENTRY_POINT",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract IEntryPoint"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "SEMI_MODULAR_ACCOUNT_IMPL",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract SemiModularAccountBytecode"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "SINGLE_SIGNER_VALIDATION_MODULE",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "WEBAUTHN_VALIDATION_MODULE",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "acceptOwnership",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addStake",
-        "inputs": [
-            {
-                "name": "unstakeDelay",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "createAccount",
-        "inputs": [
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract ModularAccount"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "createSemiModularAccount",
-        "inputs": [
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract SemiModularAccountBytecode"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "createWebAuthnAccount",
-        "inputs": [
-            {
-                "name": "ownerX",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "ownerY",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract ModularAccount"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "getAddress",
-        "inputs": [
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAddressSemiModular",
-        "inputs": [
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAddressWebAuthn",
-        "inputs": [
-            {
-                "name": "ownerX",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "ownerY",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getSalt",
-        "inputs": [
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "getSaltWebAuthn",
-        "inputs": [
-            {
-                "name": "ownerX",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "ownerY",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "owner",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pendingOwner",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "renounceOwnership",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "transferOwnership",
-        "inputs": [
-            {
-                "name": "newOwner",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "unlockStake",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [
-            {
-                "name": "to",
-                "type": "address",
-                "internalType": "address payable"
-            },
-            {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "amount",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawStake",
-        "inputs": [
-            {
-                "name": "withdrawAddress",
-                "type": "address",
-                "internalType": "address payable"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "ModularAccountDeployed",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "owner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "OwnershipTransferStarted",
-        "inputs": [
-            {
-                "name": "previousOwner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "newOwner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "OwnershipTransferred",
-        "inputs": [
-            {
-                "name": "previousOwner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "newOwner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "SemiModularAccountDeployed",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "owner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WebAuthnModularAccountDeployed",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "ownerX",
-                "type": "uint256",
-                "indexed": true,
-                "internalType": "uint256"
-            },
-            {
-                "name": "ownerY",
-                "type": "uint256",
-                "indexed": true,
-                "internalType": "uint256"
-            },
-            {
-                "name": "salt",
-                "type": "uint256",
-                "indexed": false,
-                "internalType": "uint256"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "AddressEmptyCode",
-        "inputs": [
-            {
-                "name": "target",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "AddressInsufficientBalance",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "FailedInnerCall",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidAction",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "OwnableInvalidOwner",
-        "inputs": [
-            {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "OwnableUnauthorizedAccount",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "SafeERC20FailedOperation",
-        "inputs": [
-            {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "TransferFailed",
-        "inputs": []
-    }
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "_entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "_accountImpl",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+      {
+        name: "_semiModularImpl",
+        type: "address",
+        internalType: "contract SemiModularAccountBytecode",
+      },
+      {
+        name: "_singleSignerValidationModule",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_webAuthnValidationModule",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "ACCOUNT_IMPL",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "ENTRY_POINT",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "SEMI_MODULAR_ACCOUNT_IMPL",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract SemiModularAccountBytecode",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "SINGLE_SIGNER_VALIDATION_MODULE",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "WEBAUTHN_VALIDATION_MODULE",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "acceptOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "addStake",
+    inputs: [
+      {
+        name: "unstakeDelay",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "createAccount",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "createSemiModularAccount",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract SemiModularAccountBytecode",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "createWebAuthnAccount",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getAddress",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getAddressSemiModular",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getAddressWebAuthn",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getSalt",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "getSaltWebAuthn",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "owner",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "pendingOwner",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "renounceOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "transferOwnership",
+    inputs: [
+      {
+        name: "newOwner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "unlockStake",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [
+      {
+        name: "to",
+        type: "address",
+        internalType: "address payable",
+      },
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdrawStake",
+    inputs: [
+      {
+        name: "withdrawAddress",
+        type: "address",
+        internalType: "address payable",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferStarted",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferred",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "SemiModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "WebAuthnModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "ownerX",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "AddressEmptyCode",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "AddressInsufficientBalance",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "FailedInnerCall",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidAction",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "OwnableInvalidOwner",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "OwnableUnauthorizedAccount",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "TransferFailed",
+    inputs: [],
+  },
 ];

--- a/account-kit/smart-contracts/src/ma-v2/abis/smaV2.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/smaV2.ts
@@ -1,0 +1,1288 @@
+export const smaV2Abi = [
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "entryPoint",
+                "type": "address",
+                "internalType": "contract IEntryPoint"
+            },
+            {
+                "name": "executionInstallDelegate",
+                "type": "address",
+                "internalType": "contract ExecutionInstallDelegate"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "fallback",
+        "stateMutability": "payable"
+    },
+    {
+        "type": "receive",
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "accountId",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string",
+                "internalType": "string"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "entryPoint",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IEntryPoint"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "execute",
+        "inputs": [
+            {
+                "name": "target",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "result",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "executeBatch",
+        "inputs": [
+            {
+                "name": "calls",
+                "type": "tuple[]",
+                "internalType": "struct Call[]",
+                "components": [
+                    {
+                        "name": "target",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "value",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "data",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [
+            {
+                "name": "results",
+                "type": "bytes[]",
+                "internalType": "bytes[]"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "executeUserOp",
+        "inputs": [
+            {
+                "name": "userOp",
+                "type": "tuple",
+                "internalType": "struct PackedUserOperation",
+                "components": [
+                    {
+                        "name": "sender",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "initCode",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "callData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "accountGasLimits",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "preVerificationGas",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "gasFees",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "paymasterAndData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "signature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            },
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "executeWithRuntimeValidation",
+        "inputs": [
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "authorization",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "getExecutionData",
+        "inputs": [
+            {
+                "name": "selector",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "data",
+                "type": "tuple",
+                "internalType": "struct ExecutionDataView",
+                "components": [
+                    {
+                        "name": "module",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "skipRuntimeValidation",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "allowGlobalValidation",
+                        "type": "bool",
+                        "internalType": "bool"
+                    },
+                    {
+                        "name": "executionHooks",
+                        "type": "bytes25[]",
+                        "internalType": "HookConfig[]"
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getFallbackSignerData",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getValidationData",
+        "inputs": [
+            {
+                "name": "validationFunction",
+                "type": "bytes24",
+                "internalType": "ModuleEntity"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "data",
+                "type": "tuple",
+                "internalType": "struct ValidationDataView",
+                "components": [
+                    {
+                        "name": "validationFlags",
+                        "type": "uint8",
+                        "internalType": "ValidationFlags"
+                    },
+                    {
+                        "name": "validationHooks",
+                        "type": "bytes25[]",
+                        "internalType": "HookConfig[]"
+                    },
+                    {
+                        "name": "executionHooks",
+                        "type": "bytes25[]",
+                        "internalType": "HookConfig[]"
+                    },
+                    {
+                        "name": "selectors",
+                        "type": "bytes4[]",
+                        "internalType": "bytes4[]"
+                    }
+                ]
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "installExecution",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "manifest",
+                "type": "tuple",
+                "internalType": "struct ExecutionManifest",
+                "components": [
+                    {
+                        "name": "executionFunctions",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionFunction[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "skipRuntimeValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "allowGlobalValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "executionHooks",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionHook[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "entityId",
+                                "type": "uint32",
+                                "internalType": "uint32"
+                            },
+                            {
+                                "name": "isPreHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "isPostHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "interfaceIds",
+                        "type": "bytes4[]",
+                        "internalType": "bytes4[]"
+                    }
+                ]
+            },
+            {
+                "name": "moduleInstallData",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "installValidation",
+        "inputs": [
+            {
+                "name": "validationConfig",
+                "type": "bytes25",
+                "internalType": "ValidationConfig"
+            },
+            {
+                "name": "selectors",
+                "type": "bytes4[]",
+                "internalType": "bytes4[]"
+            },
+            {
+                "name": "installData",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "hooks",
+                "type": "bytes[]",
+                "internalType": "bytes[]"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "isValidSignature",
+        "inputs": [
+            {
+                "name": "hash",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "onERC1155BatchReceived",
+        "inputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            },
+            {
+                "name": "",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            },
+            {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "onERC1155Received",
+        "inputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "onERC721Received",
+        "inputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "performCreate",
+        "inputs": [
+            {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "initCode",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "isCreate2",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "salt",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "createdAddr",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "proxiableUUID",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "supportsInterface",
+        "inputs": [
+            {
+                "name": "interfaceId",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "uninstallExecution",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "manifest",
+                "type": "tuple",
+                "internalType": "struct ExecutionManifest",
+                "components": [
+                    {
+                        "name": "executionFunctions",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionFunction[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "skipRuntimeValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "allowGlobalValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "executionHooks",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionHook[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "entityId",
+                                "type": "uint32",
+                                "internalType": "uint32"
+                            },
+                            {
+                                "name": "isPreHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "isPostHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "interfaceIds",
+                        "type": "bytes4[]",
+                        "internalType": "bytes4[]"
+                    }
+                ]
+            },
+            {
+                "name": "moduleUninstallData",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "uninstallValidation",
+        "inputs": [
+            {
+                "name": "validationFunction",
+                "type": "bytes24",
+                "internalType": "ModuleEntity"
+            },
+            {
+                "name": "uninstallData",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "hookUninstallData",
+                "type": "bytes[]",
+                "internalType": "bytes[]"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "updateFallbackSignerData",
+        "inputs": [
+            {
+                "name": "fallbackSigner",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "isDisabled",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "upgradeToAndCall",
+        "inputs": [
+            {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "validateUserOp",
+        "inputs": [
+            {
+                "name": "userOp",
+                "type": "tuple",
+                "internalType": "struct PackedUserOperation",
+                "components": [
+                    {
+                        "name": "sender",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "initCode",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "callData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "accountGasLimits",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "preVerificationGas",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "gasFees",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "paymasterAndData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "signature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            },
+            {
+                "name": "userOpHash",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "missingAccountFunds",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "validationData",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "event",
+        "name": "ExecutionInstalled",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "manifest",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct ExecutionManifest",
+                "components": [
+                    {
+                        "name": "executionFunctions",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionFunction[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "skipRuntimeValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "allowGlobalValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "executionHooks",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionHook[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "entityId",
+                                "type": "uint32",
+                                "internalType": "uint32"
+                            },
+                            {
+                                "name": "isPreHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "isPostHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "interfaceIds",
+                        "type": "bytes4[]",
+                        "internalType": "bytes4[]"
+                    }
+                ]
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "ExecutionUninstalled",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "onUninstallSucceeded",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            },
+            {
+                "name": "manifest",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct ExecutionManifest",
+                "components": [
+                    {
+                        "name": "executionFunctions",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionFunction[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "skipRuntimeValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "allowGlobalValidation",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "executionHooks",
+                        "type": "tuple[]",
+                        "internalType": "struct ManifestExecutionHook[]",
+                        "components": [
+                            {
+                                "name": "executionSelector",
+                                "type": "bytes4",
+                                "internalType": "bytes4"
+                            },
+                            {
+                                "name": "entityId",
+                                "type": "uint32",
+                                "internalType": "uint32"
+                            },
+                            {
+                                "name": "isPreHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            },
+                            {
+                                "name": "isPostHook",
+                                "type": "bool",
+                                "internalType": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "interfaceIds",
+                        "type": "bytes4[]",
+                        "internalType": "bytes4[]"
+                    }
+                ]
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "FallbackSignerUpdated",
+        "inputs": [
+            {
+                "name": "newFallbackSigner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "isDisabled",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Initialized",
+        "inputs": [
+            {
+                "name": "version",
+                "type": "uint64",
+                "indexed": false,
+                "internalType": "uint64"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Upgraded",
+        "inputs": [
+            {
+                "name": "implementation",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "ValidationInstalled",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "indexed": true,
+                "internalType": "uint32"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "ValidationUninstalled",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "indexed": true,
+                "internalType": "uint32"
+            },
+            {
+                "name": "onUninstallSucceeded",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "ArrayLengthMismatch",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "CreateFailed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "DeferredActionSignatureInvalid",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "DeferredValidationHasValidationHooks",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ExecutionHookAlreadySet",
+        "inputs": [
+            {
+                "name": "hookConfig",
+                "type": "bytes25",
+                "internalType": "HookConfig"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "FallbackSignerDisabled",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "FallbackSignerMismatch",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "FallbackValidationInstallationNotAllowed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InterfaceNotSupported",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "InvalidInitialization",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidSignatureType",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ModuleInstallCallbackFailed",
+        "inputs": [
+            {
+                "name": "module",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "revertReason",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "NonCanonicalEncoding",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotEntryPoint",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "PreValidationHookDuplicate",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "RequireUserOperationContext",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SegmentOutOfOrder",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SelfCallRecursionDepthExceeded",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SignatureValidationInvalid",
+        "inputs": [
+            {
+                "name": "validationFunction",
+                "type": "bytes24",
+                "internalType": "ModuleEntity"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "UnauthorizedCallContext",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UnexpectedAggregator",
+        "inputs": [
+            {
+                "name": "validationFunction",
+                "type": "bytes24",
+                "internalType": "ModuleEntity"
+            },
+            {
+                "name": "aggregator",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "UnrecognizedFunction",
+        "inputs": [
+            {
+                "name": "selector",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "UpgradeFailed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UserOpValidationInvalid",
+        "inputs": [
+            {
+                "name": "validationFunction",
+                "type": "bytes24",
+                "internalType": "ModuleEntity"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ValidationAlreadySet",
+        "inputs": [
+            {
+                "name": "selector",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            },
+            {
+                "name": "validationFunction",
+                "type": "bytes24",
+                "internalType": "ModuleEntity"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ValidationAssocHookLimitExceeded",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ValidationEntityIdInUse",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ValidationFunctionMissing",
+        "inputs": [
+            {
+                "name": "selector",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ValidationSignatureSegmentMissing",
+        "inputs": []
+    }
+];

--- a/account-kit/smart-contracts/src/ma-v2/abis/smaV2.ts
+++ b/account-kit/smart-contracts/src/ma-v2/abis/smaV2.ts
@@ -1,1288 +1,1288 @@
 export const smaV2Abi = [
-    {
-        "type": "constructor",
-        "inputs": [
-            {
-                "name": "entryPoint",
-                "type": "address",
-                "internalType": "contract IEntryPoint"
-            },
-            {
-                "name": "executionInstallDelegate",
-                "type": "address",
-                "internalType": "contract ExecutionInstallDelegate"
-            }
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "executionInstallDelegate",
+        type: "address",
+        internalType: "contract ExecutionInstallDelegate",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "fallback",
+    stateMutability: "payable",
+  },
+  {
+    type: "receive",
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "accountId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "entryPoint",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "execute",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "result",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeBatch",
+    inputs: [
+      {
+        name: "calls",
+        type: "tuple[]",
+        internalType: "struct Call[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "value",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "data",
+            type: "bytes",
+            internalType: "bytes",
+          },
         ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "fallback",
-        "stateMutability": "payable"
-    },
-    {
-        "type": "receive",
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "accountId",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "string",
-                "internalType": "string"
-            }
+      },
+    ],
+    outputs: [
+      {
+        name: "results",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
         ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "entryPoint",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "contract IEntryPoint"
-            }
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "executeWithRuntimeValidation",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "authorization",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "getExecutionData",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ExecutionDataView",
+        components: [
+          {
+            name: "module",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "skipRuntimeValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "allowGlobalValidation",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
         ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "execute",
-        "inputs": [
-            {
-                "name": "target",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "value",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "data",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getFallbackSignerData",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getValidationData",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+    outputs: [
+      {
+        name: "data",
+        type: "tuple",
+        internalType: "struct ValidationDataView",
+        components: [
+          {
+            name: "validationFlags",
+            type: "uint8",
+            internalType: "ValidationFlags",
+          },
+          {
+            name: "validationHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "executionHooks",
+            type: "bytes25[]",
+            internalType: "HookConfig[]",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
         ],
-        "outputs": [
-            {
-                "name": "result",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "installExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
         ],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "executeBatch",
-        "inputs": [
-            {
-                "name": "calls",
-                "type": "tuple[]",
-                "internalType": "struct Call[]",
-                "components": [
-                    {
-                        "name": "target",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "value",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    }
-                ]
-            }
+      },
+      {
+        name: "moduleInstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "installValidation",
+    inputs: [
+      {
+        name: "validationConfig",
+        type: "bytes25",
+        internalType: "ValidationConfig",
+      },
+      {
+        name: "selectors",
+        type: "bytes4[]",
+        internalType: "bytes4[]",
+      },
+      {
+        name: "installData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hooks",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "isValidSignature",
+    inputs: [
+      {
+        name: "hash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "onERC1155BatchReceived",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "uint256[]",
+        internalType: "uint256[]",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC1155Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onERC721Received",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "performCreate",
+    inputs: [
+      {
+        name: "value",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "initCode",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "isCreate2",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "salt",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "createdAddr",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "proxiableUUID",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "uninstallExecution",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
         ],
-        "outputs": [
-            {
-                "name": "results",
-                "type": "bytes[]",
-                "internalType": "bytes[]"
-            }
+      },
+      {
+        name: "moduleUninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "uninstallValidation",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "uninstallData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "hookUninstallData",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateFallbackSignerData",
+    inputs: [
+      {
+        name: "fallbackSigner",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "isDisabled",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "upgradeToAndCall",
+    inputs: [
+      {
+        name: "newImplementation",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "validateUserOp",
+    inputs: [
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
         ],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "executeUserOp",
-        "inputs": [
-            {
-                "name": "userOp",
-                "type": "tuple",
-                "internalType": "struct PackedUserOperation",
-                "components": [
-                    {
-                        "name": "sender",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "initCode",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "callData",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "accountGasLimits",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                    },
-                    {
-                        "name": "preVerificationGas",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "gasFees",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                    },
-                    {
-                        "name": "paymasterAndData",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "signature",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    }
-                ]
-            },
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
+      },
+      {
+        name: "userOpHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "missingAccountFunds",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "validationData",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ExecutionInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
         ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "executeWithRuntimeValidation",
-        "inputs": [
-            {
-                "name": "data",
-                "type": "bytes",
-                "internalType": "bytes"
-            },
-            {
-                "name": "authorization",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ExecutionUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+      {
+        name: "manifest",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct ExecutionManifest",
+        components: [
+          {
+            name: "executionFunctions",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionFunction[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "skipRuntimeValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "allowGlobalValidation",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "executionHooks",
+            type: "tuple[]",
+            internalType: "struct ManifestExecutionHook[]",
+            components: [
+              {
+                name: "executionSelector",
+                type: "bytes4",
+                internalType: "bytes4",
+              },
+              {
+                name: "entityId",
+                type: "uint32",
+                internalType: "uint32",
+              },
+              {
+                name: "isPreHook",
+                type: "bool",
+                internalType: "bool",
+              },
+              {
+                name: "isPostHook",
+                type: "bool",
+                internalType: "bool",
+              },
+            ],
+          },
+          {
+            name: "interfaceIds",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
         ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "getExecutionData",
-        "inputs": [
-            {
-                "name": "selector",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "data",
-                "type": "tuple",
-                "internalType": "struct ExecutionDataView",
-                "components": [
-                    {
-                        "name": "module",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "skipRuntimeValidation",
-                        "type": "bool",
-                        "internalType": "bool"
-                    },
-                    {
-                        "name": "allowGlobalValidation",
-                        "type": "bool",
-                        "internalType": "bool"
-                    },
-                    {
-                        "name": "executionHooks",
-                        "type": "bytes25[]",
-                        "internalType": "HookConfig[]"
-                    }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getFallbackSignerData",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "bool",
-                "internalType": "bool"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getValidationData",
-        "inputs": [
-            {
-                "name": "validationFunction",
-                "type": "bytes24",
-                "internalType": "ModuleEntity"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "data",
-                "type": "tuple",
-                "internalType": "struct ValidationDataView",
-                "components": [
-                    {
-                        "name": "validationFlags",
-                        "type": "uint8",
-                        "internalType": "ValidationFlags"
-                    },
-                    {
-                        "name": "validationHooks",
-                        "type": "bytes25[]",
-                        "internalType": "HookConfig[]"
-                    },
-                    {
-                        "name": "executionHooks",
-                        "type": "bytes25[]",
-                        "internalType": "HookConfig[]"
-                    },
-                    {
-                        "name": "selectors",
-                        "type": "bytes4[]",
-                        "internalType": "bytes4[]"
-                    }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "installExecution",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "manifest",
-                "type": "tuple",
-                "internalType": "struct ExecutionManifest",
-                "components": [
-                    {
-                        "name": "executionFunctions",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionFunction[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "skipRuntimeValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "allowGlobalValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "executionHooks",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionHook[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "entityId",
-                                "type": "uint32",
-                                "internalType": "uint32"
-                            },
-                            {
-                                "name": "isPreHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "isPostHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "interfaceIds",
-                        "type": "bytes4[]",
-                        "internalType": "bytes4[]"
-                    }
-                ]
-            },
-            {
-                "name": "moduleInstallData",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "installValidation",
-        "inputs": [
-            {
-                "name": "validationConfig",
-                "type": "bytes25",
-                "internalType": "ValidationConfig"
-            },
-            {
-                "name": "selectors",
-                "type": "bytes4[]",
-                "internalType": "bytes4[]"
-            },
-            {
-                "name": "installData",
-                "type": "bytes",
-                "internalType": "bytes"
-            },
-            {
-                "name": "hooks",
-                "type": "bytes[]",
-                "internalType": "bytes[]"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "isValidSignature",
-        "inputs": [
-            {
-                "name": "hash",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "signature",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "onERC1155BatchReceived",
-        "inputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "uint256[]",
-                "internalType": "uint256[]"
-            },
-            {
-                "name": "",
-                "type": "uint256[]",
-                "internalType": "uint256[]"
-            },
-            {
-                "name": "",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "onERC1155Received",
-        "inputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "onERC721Received",
-        "inputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "performCreate",
-        "inputs": [
-            {
-                "name": "value",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "initCode",
-                "type": "bytes",
-                "internalType": "bytes"
-            },
-            {
-                "name": "isCreate2",
-                "type": "bool",
-                "internalType": "bool"
-            },
-            {
-                "name": "salt",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "createdAddr",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "proxiableUUID",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "supportsInterface",
-        "inputs": [
-            {
-                "name": "interfaceId",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool",
-                "internalType": "bool"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "uninstallExecution",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "manifest",
-                "type": "tuple",
-                "internalType": "struct ExecutionManifest",
-                "components": [
-                    {
-                        "name": "executionFunctions",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionFunction[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "skipRuntimeValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "allowGlobalValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "executionHooks",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionHook[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "entityId",
-                                "type": "uint32",
-                                "internalType": "uint32"
-                            },
-                            {
-                                "name": "isPreHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "isPostHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "interfaceIds",
-                        "type": "bytes4[]",
-                        "internalType": "bytes4[]"
-                    }
-                ]
-            },
-            {
-                "name": "moduleUninstallData",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "uninstallValidation",
-        "inputs": [
-            {
-                "name": "validationFunction",
-                "type": "bytes24",
-                "internalType": "ModuleEntity"
-            },
-            {
-                "name": "uninstallData",
-                "type": "bytes",
-                "internalType": "bytes"
-            },
-            {
-                "name": "hookUninstallData",
-                "type": "bytes[]",
-                "internalType": "bytes[]"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateFallbackSignerData",
-        "inputs": [
-            {
-                "name": "fallbackSigner",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "isDisabled",
-                "type": "bool",
-                "internalType": "bool"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "upgradeToAndCall",
-        "inputs": [
-            {
-                "name": "newImplementation",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "data",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "validateUserOp",
-        "inputs": [
-            {
-                "name": "userOp",
-                "type": "tuple",
-                "internalType": "struct PackedUserOperation",
-                "components": [
-                    {
-                        "name": "sender",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "initCode",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "callData",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "accountGasLimits",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                    },
-                    {
-                        "name": "preVerificationGas",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "gasFees",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                    },
-                    {
-                        "name": "paymasterAndData",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "signature",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    }
-                ]
-            },
-            {
-                "name": "userOpHash",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "missingAccountFunds",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "validationData",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "ExecutionInstalled",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "manifest",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct ExecutionManifest",
-                "components": [
-                    {
-                        "name": "executionFunctions",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionFunction[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "skipRuntimeValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "allowGlobalValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "executionHooks",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionHook[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "entityId",
-                                "type": "uint32",
-                                "internalType": "uint32"
-                            },
-                            {
-                                "name": "isPreHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "isPostHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "interfaceIds",
-                        "type": "bytes4[]",
-                        "internalType": "bytes4[]"
-                    }
-                ]
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ExecutionUninstalled",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "onUninstallSucceeded",
-                "type": "bool",
-                "indexed": false,
-                "internalType": "bool"
-            },
-            {
-                "name": "manifest",
-                "type": "tuple",
-                "indexed": false,
-                "internalType": "struct ExecutionManifest",
-                "components": [
-                    {
-                        "name": "executionFunctions",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionFunction[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "skipRuntimeValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "allowGlobalValidation",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "executionHooks",
-                        "type": "tuple[]",
-                        "internalType": "struct ManifestExecutionHook[]",
-                        "components": [
-                            {
-                                "name": "executionSelector",
-                                "type": "bytes4",
-                                "internalType": "bytes4"
-                            },
-                            {
-                                "name": "entityId",
-                                "type": "uint32",
-                                "internalType": "uint32"
-                            },
-                            {
-                                "name": "isPreHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            },
-                            {
-                                "name": "isPostHook",
-                                "type": "bool",
-                                "internalType": "bool"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "interfaceIds",
-                        "type": "bytes4[]",
-                        "internalType": "bytes4[]"
-                    }
-                ]
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "FallbackSignerUpdated",
-        "inputs": [
-            {
-                "name": "newFallbackSigner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "isDisabled",
-                "type": "bool",
-                "indexed": false,
-                "internalType": "bool"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [
-            {
-                "name": "version",
-                "type": "uint64",
-                "indexed": false,
-                "internalType": "uint64"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [
-            {
-                "name": "implementation",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ValidationInstalled",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "indexed": true,
-                "internalType": "uint32"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ValidationUninstalled",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "indexed": true,
-                "internalType": "uint32"
-            },
-            {
-                "name": "onUninstallSucceeded",
-                "type": "bool",
-                "indexed": false,
-                "internalType": "bool"
-            }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "ArrayLengthMismatch",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "CreateFailed",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "DeferredActionSignatureInvalid",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "DeferredValidationHasValidationHooks",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ExecutionHookAlreadySet",
-        "inputs": [
-            {
-                "name": "hookConfig",
-                "type": "bytes25",
-                "internalType": "HookConfig"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "FallbackSignerDisabled",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "FallbackSignerMismatch",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "FallbackValidationInstallationNotAllowed",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InterfaceNotSupported",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "InvalidInitialization",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "InvalidSignatureType",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ModuleInstallCallbackFailed",
-        "inputs": [
-            {
-                "name": "module",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "revertReason",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "NonCanonicalEncoding",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "NotEntryPoint",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "PreValidationHookDuplicate",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "RequireUserOperationContext",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "SegmentOutOfOrder",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "SelfCallRecursionDepthExceeded",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "SignatureValidationInvalid",
-        "inputs": [
-            {
-                "name": "validationFunction",
-                "type": "bytes24",
-                "internalType": "ModuleEntity"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "UnauthorizedCallContext",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "UnexpectedAggregator",
-        "inputs": [
-            {
-                "name": "validationFunction",
-                "type": "bytes24",
-                "internalType": "ModuleEntity"
-            },
-            {
-                "name": "aggregator",
-                "type": "address",
-                "internalType": "address"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "UnrecognizedFunction",
-        "inputs": [
-            {
-                "name": "selector",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "UpgradeFailed",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "UserOpValidationInvalid",
-        "inputs": [
-            {
-                "name": "validationFunction",
-                "type": "bytes24",
-                "internalType": "ModuleEntity"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ValidationAlreadySet",
-        "inputs": [
-            {
-                "name": "selector",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            },
-            {
-                "name": "validationFunction",
-                "type": "bytes24",
-                "internalType": "ModuleEntity"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ValidationAssocHookLimitExceeded",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ValidationEntityIdInUse",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "ValidationFunctionMissing",
-        "inputs": [
-            {
-                "name": "selector",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ValidationSignatureSegmentMissing",
-        "inputs": []
-    }
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "FallbackSignerUpdated",
+    inputs: [
+      {
+        name: "newFallbackSigner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "isDisabled",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Initialized",
+    inputs: [
+      {
+        name: "version",
+        type: "uint64",
+        indexed: false,
+        internalType: "uint64",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "Upgraded",
+    inputs: [
+      {
+        name: "implementation",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationInstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ValidationUninstalled",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "onUninstallSucceeded",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "ArrayLengthMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "CreateFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredActionSignatureInvalid",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "DeferredValidationHasValidationHooks",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ExecutionHookAlreadySet",
+    inputs: [
+      {
+        name: "hookConfig",
+        type: "bytes25",
+        internalType: "HookConfig",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "FallbackSignerDisabled",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "FallbackSignerMismatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "FallbackValidationInstallationNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InterfaceNotSupported",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "InvalidInitialization",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidSignatureType",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ModuleInstallCallbackFailed",
+    inputs: [
+      {
+        name: "module",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "revertReason",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "NonCanonicalEncoding",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotEntryPoint",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "PreValidationHookDuplicate",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "RequireUserOperationContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SegmentOutOfOrder",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SelfCallRecursionDepthExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SignatureValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnauthorizedCallContext",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedAggregator",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+      {
+        name: "aggregator",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnrecognizedFunction",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UpgradeFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UserOpValidationInvalid",
+    inputs: [
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAlreadySet",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "validationFunction",
+        type: "bytes24",
+        internalType: "ModuleEntity",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationAssocHookLimitExceeded",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationEntityIdInUse",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValidationFunctionMissing",
+    inputs: [
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ValidationSignatureSegmentMissing",
+    inputs: [],
+  },
 ];

--- a/account-kit/smart-contracts/src/ma-v2/account/account.ts
+++ b/account-kit/smart-contracts/src/ma-v2/account/account.ts
@@ -22,7 +22,7 @@ import {
 import { accountFactoryAbi } from "../abis/accountFactoryAbi.js";
 import { addresses } from "../utils.js";
 import { standardExecutor } from "../../msca/account/standardExecutor.js";
-import { multiOwnerMessageSigner } from "../../msca/plugins/multi-owner/signer.js"; // TODO: swap for MA v2 signer
+import { singleSignerMessageSigner } from "../modules/single-signer-validation/signer.js";
 
 export const DEFAULT_OWNER_ENTITY_ID = 0;
 
@@ -120,13 +120,7 @@ export async function createSMAV2Account(
     source: `SMAV2Account`,
     getAccountInitCode,
     ...standardExecutor,
-    ...multiOwnerMessageSigner(
-      // TODO: temp
-      client,
-      addresses.accountFactory,
-      () => signer,
-      addresses.accountFactory
-    ),
+    ...singleSignerMessageSigner(signer),
   });
 
   // TODO: add deferred action flag
@@ -151,7 +145,7 @@ export async function createSMAV2Account(
     });
 
     return entryPointContract.read.getNonce([
-      accountAddress,
+      _accountAddress,
       nonceKey,
     ]) as Promise<bigint>;
   };

--- a/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
@@ -1,22 +1,14 @@
-import {
-  custom,
-  keccak256,
-  parseEther,
-  publicActions,
-  toHex,
-  type Address,
-} from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { custom, parseEther, publicActions } from "viem";
 
 import { LocalAccountSigner, type SmartAccountSigner } from "@aa-sdk/core";
 
-import { createSMAV2AccountClient } from "./client.js";
+import { createSMAV2SignerAccountClient } from "./client.js";
 
 import { local070InstanceOptSep } from "~test/instances.js";
 import { setBalance } from "viem/actions";
 import { accounts } from "~test/constants.js";
 
-describe("6900 RI installValidation Tests", async () => {
+describe("MA v2 Tests", async () => {
   const instance = local070InstanceOptSep;
   const client = instance.getClient().extend(publicActions);
 
@@ -24,13 +16,10 @@ describe("6900 RI installValidation Tests", async () => {
     accounts.fundedAccountOwner
   );
 
-  it("should send a UO", async () => {
+  it("sends a simple UO", async () => {
     // Generate and add the secondary signer
 
     const provider = await givenConnectedProvider({ signer });
-
-    console.log(signer);
-    console.log("provider: ", provider.getAddress());
 
     await setBalance(instance.getClient(), {
       address: provider.getAddress(),
@@ -38,83 +27,30 @@ describe("6900 RI installValidation Tests", async () => {
     });
 
     const target = "0x000000000000000000000000000000000000dEaD";
+    const sendAmount = parseEther("1");
 
-    const startBalance = await client.getBalance({
+    const startingAddressBalance = await client.getBalance({
       address: target,
     });
 
-    const result2 = provider.sendUserOperation({
+    const result = await provider.sendUserOperation({
       uo: {
         target: target,
-        value: parseEther("1"),
+        value: sendAmount,
         data: "0x",
       },
     });
-  });
 
-  it("should fail after uninstalling the secondary signer", async () => {
-    //   // Generate and add the secondary signer
-    //   const secondarySigner = new LocalAccountSigner(
-    //     privateKeyToAccount(keccak256(toHex("secondarySigner2")))
-    //   );
-    //   const provider = (await givenConnectedProvider({ signer })).extend(
-    //     installValidationActions
-    //   );
-    //   await setBalance(instance.getClient(), {
-    //     address: provider.getAddress(),
-    //     value: parseEther("2"),
-    //   });
-    //   const entityId = 2;
-    //   const result1 = await provider.installValidation({
-    //     args: {
-    //       validationConfig: {
-    //         moduleAddress: SingleSignerValidationModule.meta.addresses.default,
-    //         entityId,
-    //         isGlobal: true,
-    //         isSignatureValidation: true,
-    //       },
-    //       selectors: [],
-    //       installData: SingleSignerValidationModule.encodeOnInstallData({
-    //         entityId,
-    //         signer: await secondarySigner.getAddress(),
-    //       }),
-    //       hooks: [],
-    //     },
-    //   });
-    //   const txnHash1 = provider.waitForUserOperationTransaction(result1);
-    //   await expect(txnHash1).resolves.not.toThrowError();
-    //   // Now the new validation is installed, uninstall it
-    //   const result2 = await provider.uninstallValidation({
-    //     args: {
-    //       moduleAddress: SingleSignerValidationModule.meta.addresses.default,
-    //       entityId,
-    //       uninstallData: SingleSignerValidationModule.encodeOnUninstallData({
-    //         entityId,
-    //       }),
-    //       hookUninstallDatas: [],
-    //     },
-    //   });
-    //   const txnHash2 = provider.waitForUserOperationTransaction(result2);
-    //   await expect(txnHash2).resolves.not.toThrowError();
-    //   // Now the validation is uninstalled, attempt to use it to execute.
-    //   const accountAddress = provider.getAddress();
-    //   const newValidationAccountClient = await createSingleSignerRIAccountClient({
-    //     chain: instance.chain,
-    //     signer: secondarySigner,
-    //     accountAddress,
-    //     entityId,
-    //     transport: custom(instance.getClient()),
-    //   });
-    //   // Attempt to execute a transfer of 1 ETH from the account to a dead address.
-    //   const targetAddress = "0x000000000000000000000000000000000000dEaD";
-    //   const result3 = newValidationAccountClient.sendUserOperation({
-    //     uo: {
-    //       target: targetAddress,
-    //       value: parseEther("0.5"),
-    //       data: "0x",
-    //     },
-    //   });
-    //   await expect(result3).rejects.toThrowError();
+    const txnHash1 = provider.waitForUserOperationTransaction(result);
+    await expect(txnHash1).resolves.not.toThrowError();
+
+    const newAddressBalance = await client.getBalance({
+      address: target,
+    });
+
+    await expect(newAddressBalance).toEqual(
+      startingAddressBalance + sendAmount
+    );
   });
 
   const givenConnectedProvider = async ({
@@ -122,7 +58,7 @@ describe("6900 RI installValidation Tests", async () => {
   }: {
     signer: SmartAccountSigner;
   }) =>
-    createSMAV2AccountClient({
+    createSMAV2SignerAccountClient({
       chain: instance.chain,
       signer,
       transport: custom(instance.getClient()),

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/allowlistModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/allowlistModule.ts
@@ -1,0 +1,715 @@
+export const allowlistModuleAbi = [
+  {
+    type: "function",
+    name: "addressAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasSelectorAllowlist",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasERC20SpendLimit",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "checkAllowlistCalldata",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "callData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "deleteAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "inputs",
+        type: "tuple[]",
+        internalType: "struct AllowlistModule.AllowlistInput[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "hasSelectorAllowlist",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasERC20SpendLimit",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "erc20SpendLimit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "erc20SpendLimits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "postExecutionHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preExecutionHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "selectorAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "setAddressAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasSelectorAllowlist",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "hasERC20SpendLimit",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "setSelectorAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "selector",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "updateAllowlist",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "inputs",
+        type: "tuple[]",
+        internalType: "struct AllowlistModule.AllowlistInput[]",
+        components: [
+          {
+            name: "target",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "hasSelectorAllowlist",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasERC20SpendLimit",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "erc20SpendLimit",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "selectors",
+            type: "bytes4[]",
+            internalType: "bytes4[]",
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateLimits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "hasERC20SpendLimit",
+        type: "bool",
+        internalType: "bool",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "AddressAllowlistUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "target",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entry",
+        type: "tuple",
+        indexed: false,
+        internalType: "struct AllowlistModule.AddressAllowlistEntry",
+        components: [
+          {
+            name: "allowed",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasSelectorAllowlist",
+            type: "bool",
+            internalType: "bool",
+          },
+          {
+            name: "hasERC20SpendLimit",
+            type: "bool",
+            internalType: "bool",
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "ERC20SpendLimitUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "token",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "SelectorAllowlistUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "targetAndSelector",
+        type: "bytes24",
+        indexed: true,
+        internalType: "bytes24",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "AddressNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ERC20NotAllowed",
+    inputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ExceededTokenLimit",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidCalldataLength",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NoSelectorSpecified",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SelectorNotAllowed",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "SpendingRequestNotAllowed",
+    inputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/nativeTokenLimitModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/nativeTokenLimitModule.ts
@@ -1,0 +1,403 @@
+export const nativeTokenLimitModuleAbi = [
+  {
+    type: "function",
+    name: "limits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "limit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "postExecutionHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preExecutionHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "specialPaymasters",
+    inputs: [
+      {
+        name: "paymaster",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "updateLimits",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "updateSpecialPaymaster",
+    inputs: [
+      {
+        name: "paymaster",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "NativeTokenSpendLimitUpdated",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newLimit",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "SpecialPaymasterUpdated",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "paymaster",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "allowed",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "ExceededNativeTokenLimit",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidPaymaster",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/paymasterGuardModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/paymasterGuardModule.ts
@@ -1,0 +1,241 @@
+export const paymasterGuardModuleAbi = [
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "paymasters",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "paymaster",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "error",
+    name: "BadPaymasterSpecified",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidPaymaster",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/singleSignerValidation.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/singleSignerValidation.ts
@@ -1,330 +1,330 @@
 export const singleSignerValidationAbi = [
-    {
-        "type": "function",
-        "name": "moduleId",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "string",
-                "internalType": "string"
-            }
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "replaySafeHash",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "hash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "signers",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "transferSigner",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "newSigner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "validateRuntime",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "sender",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "validateSignature",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "digest",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "signature",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "validateUserOp",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
         ],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "onInstall",
-        "inputs": [
-            {
-                "name": "data",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "onUninstall",
-        "inputs": [
-            {
-                "name": "data",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "replaySafeHash",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "hash",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "signers",
-        "inputs": [
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            },
-            {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "supportsInterface",
-        "inputs": [
-            {
-                "name": "interfaceId",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool",
-                "internalType": "bool"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "transferSigner",
-        "inputs": [
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            },
-            {
-                "name": "newSigner",
-                "type": "address",
-                "internalType": "address"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "validateRuntime",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            },
-            {
-                "name": "sender",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "",
-                "type": "uint256",
-                "internalType": "uint256"
-            },
-            {
-                "name": "",
-                "type": "bytes",
-                "internalType": "bytes"
-            },
-            {
-                "name": "",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "validateSignature",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            },
-            {
-                "name": "",
-                "type": "address",
-                "internalType": "address"
-            },
-            {
-                "name": "digest",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            },
-            {
-                "name": "signature",
-                "type": "bytes",
-                "internalType": "bytes"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "bytes4",
-                "internalType": "bytes4"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "validateUserOp",
-        "inputs": [
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "internalType": "uint32"
-            },
-            {
-                "name": "userOp",
-                "type": "tuple",
-                "internalType": "struct PackedUserOperation",
-                "components": [
-                    {
-                        "name": "sender",
-                        "type": "address",
-                        "internalType": "address"
-                    },
-                    {
-                        "name": "nonce",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "initCode",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "callData",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "accountGasLimits",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                    },
-                    {
-                        "name": "preVerificationGas",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                    },
-                    {
-                        "name": "gasFees",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                    },
-                    {
-                        "name": "paymasterAndData",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    },
-                    {
-                        "name": "signature",
-                        "type": "bytes",
-                        "internalType": "bytes"
-                    }
-                ]
-            },
-            {
-                "name": "userOpHash",
-                "type": "bytes32",
-                "internalType": "bytes32"
-            }
-        ],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256",
-                "internalType": "uint256"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "event",
-        "name": "SignerTransferred",
-        "inputs": [
-            {
-                "name": "account",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "entityId",
-                "type": "uint32",
-                "indexed": true,
-                "internalType": "uint32"
-            },
-            {
-                "name": "newSigner",
-                "type": "address",
-                "indexed": true,
-                "internalType": "address"
-            },
-            {
-                "name": "previousSigner",
-                "type": "address",
-                "indexed": false,
-                "internalType": "address"
-            }
-        ],
-        "anonymous": true
-    },
-    {
-        "type": "error",
-        "name": "InvalidSignatureType",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "NotAuthorized",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "NotImplemented",
-        "inputs": []
-    },
-    {
-        "type": "error",
-        "name": "UnexpectedDataPassed",
-        "inputs": []
-    }
+      },
+      {
+        name: "userOpHash",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "SignerTransferred",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "newSigner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "previousSigner",
+        type: "address",
+        indexed: false,
+        internalType: "address",
+      },
+    ],
+    anonymous: true,
+  },
+  {
+    type: "error",
+    name: "InvalidSignatureType",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotAuthorized",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
 ];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/singleSignerValidation.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/singleSignerValidation.ts
@@ -1,0 +1,330 @@
+export const singleSignerValidationAbi = [
+    {
+        "type": "function",
+        "name": "moduleId",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string",
+                "internalType": "string"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "onInstall",
+        "inputs": [
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "onUninstall",
+        "inputs": [
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "replaySafeHash",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "hash",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "signers",
+        "inputs": [
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "supportsInterface",
+        "inputs": [
+            {
+                "name": "interfaceId",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "transferSigner",
+        "inputs": [
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "newSigner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "validateRuntime",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "sender",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "validateSignature",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "validateUserOp",
+        "inputs": [
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "userOp",
+                "type": "tuple",
+                "internalType": "struct PackedUserOperation",
+                "components": [
+                    {
+                        "name": "sender",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "initCode",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "callData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "accountGasLimits",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "preVerificationGas",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "gasFees",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "paymasterAndData",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    },
+                    {
+                        "name": "signature",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            },
+            {
+                "name": "userOpHash",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "event",
+        "name": "SignerTransferred",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "entityId",
+                "type": "uint32",
+                "indexed": true,
+                "internalType": "uint32"
+            },
+            {
+                "name": "newSigner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "previousSigner",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": true
+    },
+    {
+        "type": "error",
+        "name": "InvalidSignatureType",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotAuthorized",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotImplemented",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UnexpectedDataPassed",
+        "inputs": []
+    }
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/timeRangeModule.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/timeRangeModule.ts
@@ -1,0 +1,295 @@
+export const timeRangeModuleAbi = [
+  {
+    type: "function",
+    name: "moduleId",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "onInstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "onUninstall",
+    inputs: [
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "preRuntimeValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "preSignatureValidationHook",
+    inputs: [
+      {
+        name: "",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "preUserOpValidationHook",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "userOp",
+        type: "tuple",
+        internalType: "struct PackedUserOperation",
+        components: [
+          {
+            name: "sender",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "initCode",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "callData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "accountGasLimits",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "preVerificationGas",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "gasFees",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "paymasterAndData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "signature",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "setTimeRange",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "validUntil",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "validAfter",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "supportsInterface",
+    inputs: [
+      {
+        name: "interfaceId",
+        type: "bytes4",
+        internalType: "bytes4",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "timeRanges",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [
+      {
+        name: "validUntil",
+        type: "uint48",
+        internalType: "uint48",
+      },
+      {
+        name: "validAfter",
+        type: "uint48",
+        internalType: "uint48",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "TimeRangeSet",
+    inputs: [
+      {
+        name: "entityId",
+        type: "uint32",
+        indexed: true,
+        internalType: "uint32",
+      },
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "validUntil",
+        type: "uint48",
+        indexed: false,
+        internalType: "uint48",
+      },
+      {
+        name: "validAfter",
+        type: "uint48",
+        indexed: false,
+        internalType: "uint48",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "NotImplemented",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "TimeRangeNotValid",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedDataPassed",
+    inputs: [],
+  },
+];

--- a/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/webauthnValidation.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/single-signer-validation/abis/webauthnValidation.ts
@@ -1,0 +1,373 @@
+export const webauthnValidationModuleAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "_entryPoint",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+      {
+        name: "_accountImpl",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+      {
+        name: "_webauthnValidationModule",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "ACCOUNT_IMPL",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "ENTRY_POINT",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IEntryPoint",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "WEBAUTHN_VALIDATION_MODULE",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "addStake",
+    inputs: [
+      {
+        name: "unstakeDelay",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "createAccount",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract ModularAccount",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getAddress",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getSalt",
+    inputs: [
+      {
+        name: "ownerX",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "entityId",
+        type: "uint32",
+        internalType: "uint32",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "owner",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "renounceOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "transferOwnership",
+    inputs: [
+      {
+        name: "newOwner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "unlockStake",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [
+      {
+        name: "to",
+        type: "address",
+        internalType: "address payable",
+      },
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdrawStake",
+    inputs: [
+      {
+        name: "withdrawAddress",
+        type: "address",
+        internalType: "address payable",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "ModularAccountDeployed",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "ownerX",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "ownerY",
+        type: "uint256",
+        indexed: true,
+        internalType: "uint256",
+      },
+      {
+        name: "salt",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferred",
+    inputs: [
+      {
+        name: "previousOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "AddressEmptyCode",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "AddressInsufficientBalance",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "FailedInnerCall",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "OwnableInvalidOwner",
+    inputs: [
+      {
+        name: "owner",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "OwnableUnauthorizedAccount",
+    inputs: [
+      {
+        name: "account",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [
+      {
+        name: "token",
+        type: "address",
+        internalType: "address",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "TransferFailed",
+    inputs: [],
+  },
+];


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `local070InstanceOptSep` configuration, updates various account creation functionalities, and adds multiple new ABI definitions for modules related to single signer validation, time range, and paymaster functionalities, enhancing modularity and validation processes.

### Detailed summary
- Added `local070InstanceOptSep` with specific configuration.
- Replaced `multiOwnerMessageSigner` with `singleSignerMessageSigner` in `createSMAV2Account`.
- Introduced new ABI definitions for:
  - `paymasterGuardModule`
  - `timeRangeModule`
  - `singleSignerValidation`
  - `webauthnValidationModule`
  - `nativeTokenLimitModule`
  - `allowlistModule`
  - `MAV2Factory`
  - `maV2`
- Updated test cases to reflect changes in account creation and validation.

> The following files were skipped due to too many changes: `account-kit/smart-contracts/src/ma-v2/abis/maV2.ts`, `account-kit/smart-contracts/src/ma-v2/abis/smaV2.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->