### PR TITLE
feat: add switching for executeUserOp

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
@@ -1,15 +1,12 @@
 import { custom, parseEther, publicActions } from "viem";
-
 import { LocalAccountSigner, type SmartAccountSigner } from "@aa-sdk/core";
-
-import { createSMAV2AccountClient } from "./client.js";
-
+import { createSMAV2AccountClient, type SMAV2AccountClient } from "./client.js";
 import { local070Instance } from "~test/instances.js";
 import { setBalance } from "viem/actions";
 import { accounts } from "~test/constants.js";
-import { installValidationActions } from "../actions/install-validation/installValidation.js";
 import { getDefaultSingleSignerValidationModuleAddress } from "../modules/utils.js";
 import { SingleSignerValidationModule } from "../modules/single-signer-validation/module.js";
+import { installValidationActions } from "../actions/install-validation/installValidation.js";
 
 describe("MA v2 Tests", async () => {
   const instance = local070Instance;

--- a/account-kit/smart-contracts/src/ma-v2/client/client.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.ts
@@ -4,13 +4,17 @@ import {
   type SmartAccountSigner,
   type SmartAccountClientConfig,
 } from "@aa-sdk/core";
-import { type Chain, type CustomTransport, type Transport } from "viem";
+import { type Chain, type Transport } from "viem";
 
 import {
   createSMAV2Account,
   type CreateSMAV2AccountParams,
   type SMAV2Account,
 } from "../account/semiModularAccountV2.js";
+
+export type SMAV2AccountClient<
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+> = SmartAccountClient<Transport, Chain, SMAV2Account<TSigner>>;
 
 export type CreateSMAV2AccountClientParams<
   TTransport extends Transport = Transport,
@@ -27,7 +31,7 @@ export function createSMAV2AccountClient<
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
   args: CreateSMAV2AccountClientParams<Transport, TChain, TSigner>
-): Promise<SmartAccountClient<CustomTransport, Chain, SMAV2Account<TSigner>>>;
+): Promise<SMAV2AccountClient<TSigner>>;
 
 /**
  * Creates a MAv2 account client using the provided configuration parameters.
@@ -60,7 +64,7 @@ export function createSMAV2AccountClient<
  */
 export async function createSMAV2AccountClient({
   ...config
-}: CreateSMAV2AccountClientParams): Promise<SmartAccountClient> {
+}: CreateSMAV2AccountClientParams): Promise<SMAV2AccountClient> {
   const maV2Account = await createSMAV2Account({
     ...config,
   });

--- a/account-kit/smart-contracts/src/ma-v2/utils.ts
+++ b/account-kit/smart-contracts/src/ma-v2/utils.ts
@@ -12,6 +12,8 @@ import {
   sepolia,
 } from "@account-kit/infra";
 
+export const DEFAULT_OWNER_ENTITY_ID = 0;
+
 export type PackSignatureParams = {
   // orderedHookData: HookData[];
   validationSignature: Hex;


### PR DESCRIPTION
MA v2 requires the use of a `executeUserOp` wrapper on UO calldata if the validation used has associated execution hooks.

This PR adds 2 state view functions, a helper function `encodeMAV2FunctionData` that switches between the regular encoding v.s. executeUserOp encoding depending on the validation state. It also brings `encodeExecute` and `encodeBatchExecute` into the account natively and uses `encodeMAV2FunctionData` to encode it

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `SMAV2Account` functionality and improving the structure of the smart contract client by introducing new types, methods, and handling validation actions more effectively.

### Detailed summary
- Added `DEFAULT_OWNER_ENTITY_ID` constant in `utils.ts`.
- Introduced `SMAV2AccountClient` type in `client.ts`.
- Updated `createSMAV2AccountClient` to return `SMAV2AccountClient`.
- Enhanced `SMAV2Account` with new methods: `getExecutionData`, `getValidationData`, and `encodeCallData`.
- Refactored `installValidationActions` to use `SMAV2Account` type and handle `DEFAULT_OWNER_ENTITY_ID` check.
- Added new types for execution and validation data views in `semiModularAccountV2.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->