### PR TITLE
fix: updating styles for otp input field when focussed

### DIFF
--- a/account-kit/react/src/components/otp-input/otp-input.tsx
+++ b/account-kit/react/src/components/otp-input/otp-input.tsx
@@ -137,7 +137,7 @@ export const OTPInput: React.FC<OTPInputProps> = ({
       <div className="flex gap-2.5">
         {initialOTPValue.map((_, i) => (
           <input
-            className={`border w-8 bg-bg-surface-default h-10 text-fg-primary rounded text-center focus:outline-active ${
+            className={`border w-8 bg-bg-surface-default h-10 text-fg-primary rounded text-center focus:outline-none focus:border-active ${
               !!errorText && "border-fg-critical"
             }`}
             ref={(el) => (refs.current[i] = el)}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

Task: https://app.asana.com/0/1205598840815267/1209006976980114/f
Change: We were using the default outline style for focus elements, this is open to each browser or OS since all of them can display the focus differently; what we did here is disable the default focus style and set a custom style for when the input field is focused, this should display the same way in all browsers and OSs.
This also aligns better with the styles for the regular input field when focussed in other sections.

Chrome Before change:
![Screenshot 2024-12-17 at 10 49 32 AM](https://github.com/user-attachments/assets/d0000423-1a47-4b12-9874-6194afbe918a)

iPhone Before change:
![Screenshot 2024-12-17 at 10 49 05 AM](https://github.com/user-attachments/assets/09d4079c-5f3b-4c81-89a9-d4ba4f3c60cd)

Chrome After change:
![Screenshot 2024-12-17 at 12 52 14 PM](https://github.com/user-attachments/assets/7895ab0b-0f8b-4937-9ade-c66a78ffbcf8)

iPhone After change:
![Screenshot 2024-12-17 at 12 52 39 PM](https://github.com/user-attachments/assets/e5de8a0c-a2df-45d1-9ce2-e98e69ec2ce2)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `otp-input` component to change the focus outline behavior for input fields and adjust the border styling when there is an error.

### Detailed summary
- Changed the `focus:outline-active` class to `focus:outline-none` for input elements.
- Updated the border class to include `focus:border-active` for better focus indication.
- Maintained the conditional class for error state with `border-fg-critical`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->