### PR TITLE
feat: add OTP authentication capabilities to RN Signer

### DIFF
--- a/account-kit/rn-signer/example/package.json
+++ b/account-kit/rn-signer/example/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@account-kit/signer": "^4.3.0",
+    "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "7.0.3",
     "@react-navigation/native-stack": "7.1.0",
     "dotenv": "^16.4.5",

--- a/account-kit/rn-signer/example/redirect-server/index.ts
+++ b/account-kit/rn-signer/example/redirect-server/index.ts
@@ -8,14 +8,14 @@ const port = process.env.PORT || 5500;
 const appScheme = process.env.APP_SCHEME || "rn-signer-demo";
 
 app.get("/", (req, res) => {
-	const bundle = req.query.bundle;
-	const orgId = req.query.orgId;
+  const bundle = req.query.bundle;
+  const orgId = req.query.orgId;
 
-	res.redirect(
-		`${appScheme}://magic-link-auth?bundle=${bundle}&orgId=${orgId}`
-	);
+  res.redirect(
+    `${appScheme}://magic-link-auth?bundle=${bundle}&orgId=${orgId}`
+  );
 });
 
 app.listen(port, () => {
-	console.log(`Server is running on port ${port}`);
+  console.log(`Server is running on port ${port}`);
 });

--- a/account-kit/rn-signer/example/redirect-server/index.ts
+++ b/account-kit/rn-signer/example/redirect-server/index.ts
@@ -8,12 +8,14 @@ const port = process.env.PORT || 5500;
 const appScheme = process.env.APP_SCHEME || "rn-signer-demo";
 
 app.get("/", (req, res) => {
-  const bundle = req.query.bundle;
-  const orgId = req.query.orgId;
+	const bundle = req.query.bundle;
+	const orgId = req.query.orgId;
 
-  res.redirect(`${appScheme}://home?bundle=${bundle}&orgId=${orgId}`);
+	res.redirect(
+		`${appScheme}://magic-link-auth?bundle=${bundle}&orgId=${orgId}`
+	);
 });
 
 app.listen(port, () => {
-  console.log(`Server is running on port ${port}`);
+	console.log(`Server is running on port ${port}`);
 });

--- a/account-kit/rn-signer/example/src/App.tsx
+++ b/account-kit/rn-signer/example/src/App.tsx
@@ -1,21 +1,35 @@
 /* eslint-disable import/extensions */
 import { createStaticNavigation } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { Text } from "react-native";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
-import HomeScreen from "./screens/Home";
+import OtpAuthScreen from "./screens/otp-auth";
+import MagicLinkAuthScreen from "./screens/magic-link-auth";
 
 const linking = {
   enabled: "auto" as const /* Automatically generate paths for all screens */,
   prefixes: ["rn-signer-demo://"],
 };
 
-const RootStack = createNativeStackNavigator({
-  initialRouteName: "Home",
+const RootStack = createBottomTabNavigator({
+  initialRouteName: "MagicLinkAuth",
   screens: {
-    Home: {
-      screen: HomeScreen,
-      linking: { path: "home" },
+    MagicLinkAuth: {
+      screen: MagicLinkAuthScreen,
+      linking: { path: "magic-link-auth" },
+      options: {
+        tabBarLabel: "Magic Link",
+        tabBarIcon: () => <Text>🪄</Text>,
+      },
+    },
+    OtpAuth: {
+      screen: OtpAuthScreen,
+      linking: { path: "otp-auth" },
+      options: {
+        tabBarLabel: "OTP",
+        tabBarIcon: () => <Text>🔑</Text>,
+      },
     },
   },
 });

--- a/account-kit/rn-signer/example/src/screens/magic-link-auth.tsx
+++ b/account-kit/rn-signer/example/src/screens/magic-link-auth.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable import/extensions */
-import { RNAlchemySigner } from "@account-kit/react-native-signer";
 import type { User } from "@account-kit/signer";
 import { useEffect, useState } from "react";
 import {
@@ -10,14 +9,17 @@ import {
   Linking,
   TouchableOpacity,
 } from "react-native";
-import Config from "react-native-config";
 
-export default function HomeScreen() {
-  const [email, setEmail] = useState<string>("");
-  const [user, setUser] = useState<User | null>(null);
-  const signer = new RNAlchemySigner({
+import Config from "react-native-config";
+import { RNAlchemySigner } from "@account-kit/react-native-signer";
+
+export default function MagicLinkAuthScreen() {
+  const signer = RNAlchemySigner({
     client: { connection: { apiKey: Config.API_KEY! } },
   });
+
+  const [email, setEmail] = useState<string>("");
+  const [user, setUser] = useState<User | null>(null);
 
   const handleUserAuth = ({ bundle }: { bundle: string }) => {
     signer
@@ -73,12 +75,16 @@ export default function HomeScreen() {
             onChangeText={setEmail}
             value={email}
           />
-          {/* TODO: implement OTP */}
+
           <TouchableOpacity
             style={styles.button}
             onPress={() => {
               signer
-                .authenticate({ email, type: "email", emailMode: "magicLink" })
+                .authenticate({
+                  email,
+                  type: "email",
+                  emailMode: "magicLink",
+                })
                 .catch(console.error);
             }}
           >

--- a/account-kit/rn-signer/example/src/screens/otp-auth.tsx
+++ b/account-kit/rn-signer/example/src/screens/otp-auth.tsx
@@ -1,0 +1,150 @@
+/* eslint-disable import/extensions */
+import type { User } from "@account-kit/signer";
+import { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  TouchableOpacity,
+} from "react-native";
+
+import Config from "react-native-config";
+import { RNAlchemySigner } from "@account-kit/react-native-signer";
+export default function MagicLinkAuthScreen() {
+  const [email, setEmail] = useState<string>("");
+  const [user, setUser] = useState<User | null>(null);
+
+  const signer = RNAlchemySigner({
+    client: { connection: { apiKey: Config.API_KEY! } },
+  });
+
+  const [awaitingOtp, setAwaitingOtp] = useState<boolean>(false);
+
+  const [otpCode, setOtpCode] = useState<string>("");
+
+  const handleUserAuth = ({ otpCode }: { otpCode: string }) => {
+    setAwaitingOtp(false);
+    signer
+      .authenticate({
+        otpCode: otpCode,
+        type: "otp",
+      })
+      .then((res) => {
+        console.log("res", res);
+        setUser(res);
+      })
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    // get the user if already logged in
+    signer.getAuthDetails().then(setUser);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {awaitingOtp ? (
+        <>
+          <TextInput
+            style={styles.textInput}
+            placeholderTextColor="gray"
+            placeholder="enter your OTP code"
+            onChangeText={setOtpCode}
+            value={otpCode}
+          />
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => handleUserAuth({ otpCode })}
+          >
+            <Text style={styles.buttonText}>Sign in</Text>
+          </TouchableOpacity>
+        </>
+      ) : !user ? (
+        <>
+          <TextInput
+            style={styles.textInput}
+            placeholderTextColor="gray"
+            placeholder="enter your email"
+            onChangeText={setEmail}
+            value={email}
+          />
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => {
+              signer
+                .authenticate({
+                  email,
+                  type: "email",
+                  emailMode: "otp",
+                })
+                .catch(console.error);
+              setAwaitingOtp(true);
+            }}
+          >
+            <Text style={styles.buttonText}>Sign in</Text>
+          </TouchableOpacity>
+        </>
+      ) : (
+        <>
+          <Text style={styles.userText}>
+            Currently logged in as: {user.email}
+          </Text>
+          <Text style={styles.userText}>OrgId: {user.orgId}</Text>
+          <Text style={styles.userText}>Address: {user.address}</Text>
+
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => signer.disconnect().then(() => setUser(null))}
+          >
+            <Text style={styles.buttonText}>Sign out</Text>
+          </TouchableOpacity>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#FFFFF",
+    paddingHorizontal: 20,
+  },
+  textInput: {
+    width: "100%",
+    height: 40,
+    borderColor: "gray",
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    backgroundColor: "rgba(0,0,0,0.05)",
+    marginTop: 20,
+    marginBottom: 10,
+  },
+  box: {
+    width: 60,
+    height: 60,
+    marginVertical: 20,
+  },
+  button: {
+    width: 200,
+    padding: 10,
+    height: 50,
+    backgroundColor: "rgb(147, 197, 253)",
+    borderRadius: 5,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 20,
+  },
+  buttonText: {
+    color: "white",
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  userText: {
+    marginBottom: 10,
+    fontSize: 18,
+  },
+});

--- a/account-kit/rn-signer/src/client.ts
+++ b/account-kit/rn-signer/src/client.ts
@@ -36,12 +36,19 @@ export class RNSignerClient extends BaseSignerClient<undefined> {
       connection,
     });
   }
-  // TODO: implement OTP
+
   override async submitOtpCode(
     args: Omit<OtpParams, "targetPublicKey">
   ): Promise<{ bundle: string }> {
-    console.log("submitOtpCode", args);
-    throw new Error("Method not implemented.");
+    this.eventEmitter.emit("authenticating", { type: "otpVerify" });
+    const publicKey = await this.stamper.init();
+
+    const { credentialBundle } = await this.request("/v1/otp", {
+      ...args,
+      targetPublicKey: publicKey,
+    });
+
+    return { bundle: credentialBundle };
   }
 
   override async createAccount(
@@ -57,7 +64,7 @@ export class RNSignerClient extends BaseSignerClient<undefined> {
 
     const response = await this.request("/v1/signup", {
       email,
-      emailMode: "magicLink",
+      emailMode: params.emailMode,
       targetPublicKey: publicKey,
       expirationSeconds,
       redirectParams: params.redirectParams?.toString(),
@@ -72,11 +79,13 @@ export class RNSignerClient extends BaseSignerClient<undefined> {
     this.eventEmitter.emit("authenticating", { type: "email" });
     let targetPublicKey = await this.stamper.init();
 
-    return this.request("/v1/auth", {
+    const response = await this.request("/v1/auth", {
       email: params.email,
-      emailMode: "magicLink",
+      emailMode: params.emailMode,
       targetPublicKey,
     });
+
+    return response;
   }
 
   override async completeAuthWithBundle(params: {
@@ -86,7 +95,10 @@ export class RNSignerClient extends BaseSignerClient<undefined> {
     authenticatingType: AuthenticatingEventMetadata["type"];
     idToken?: string;
   }): Promise<User> {
-    if (params.authenticatingType !== "email") {
+    if (
+      params.authenticatingType !== "email" &&
+      params.authenticatingType !== "otp"
+    ) {
       throw new Error("Unsupported authenticating type");
     }
 

--- a/account-kit/rn-signer/src/signer.ts
+++ b/account-kit/rn-signer/src/signer.ts
@@ -19,8 +19,14 @@ const RNAlchemySignerParamsSchema = z
 
 export type RNAlchemySignerParams = z.input<typeof RNAlchemySignerParamsSchema>;
 
-export class RNAlchemySigner extends BaseAlchemySigner<RNSignerClient> {
-  constructor(params: RNAlchemySignerParams) {
+class RNAlchemySignerSingleton extends BaseAlchemySigner<RNSignerClient> {
+  private static instance: BaseAlchemySigner<RNSignerClient>;
+
+  private constructor(params: RNAlchemySignerParams) {
+    if (!!RNAlchemySignerSingleton.instance) {
+      return RNAlchemySignerSingleton.instance;
+    }
+
     const { sessionConfig, ...params_ } =
       RNAlchemySignerParamsSchema.parse(params);
 
@@ -36,4 +42,17 @@ export class RNAlchemySigner extends BaseAlchemySigner<RNSignerClient> {
       sessionConfig,
     });
   }
+
+  public static getInstance(params: RNAlchemySignerParams) {
+    if (!this.instance) {
+      this.instance = new RNAlchemySignerSingleton(params);
+    }
+    return this.instance;
+  }
+}
+
+export function RNAlchemySigner(params: RNAlchemySignerParams) {
+  const instance = RNAlchemySignerSingleton.getInstance(params);
+
+  return instance;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6239,6 +6239,14 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
+"@react-navigation/bottom-tabs@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.2.0.tgz#5b336b823226647a263b4fe743655462796b6aaf"
+  integrity sha512-1LxjgnbPyFINyf9Qr5d1YE0pYhuJayg5TCIIFQmbcX4PRhX7FKUXV7cX8OzrKXEdZi/UE/VNXugtozPAR9zgvA==
+  dependencies:
+    "@react-navigation/elements" "^2.2.5"
+    color "^4.2.3"
+
 "@react-navigation/core@^7.0.3":
   version "7.0.3"
   resolved "https://registry.npmjs.org/@react-navigation/core/-/core-7.0.3.tgz#bac011a459ae62bb91e3bc8adeb862f05ac19a88"
@@ -6263,6 +6271,13 @@
   version "2.2.4"
   resolved "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.2.4.tgz#b7ce5711298de72577a613e2e7a0c5be2dbf2fe5"
   integrity sha512-/H6Gu/Hn2E/pBQTkZEMbP5SDi7C2q96PrHGvsDJiFtxFgOJusA3+ygUguqTeTP402s/5KvJm47g0UloCMiECwA==
+  dependencies:
+    color "^4.2.3"
+
+"@react-navigation/elements@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.2.5.tgz#0e2ca76e2003e96b417a3d7c2829bf1afd69193f"
+  integrity sha512-sDhE+W14P7MNWLMxXg1MEVXwkLUpMZJGflE6nQNzLmolJQIHgcia0Mrm8uRa3bQovhxYu1UzEojLZ+caoZt7Fg==
   dependencies:
     color "^4.2.3"
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the navigation structure and authentication process in the `rn-signer` example. It introduces a singleton pattern for the `RNAlchemySigner` and updates the navigation to use bottom tabs, along with modifications to the authentication flow.

### Detailed summary
- Added `@react-navigation/bottom-tabs` dependency.
- Changed redirection URL in `redirect-server/index.ts`.
- Refactored `RNAlchemySigner` to `RNAlchemySignerSingleton` for singleton implementation.
- Updated navigation in `App.tsx` to use `createBottomTabNavigator`.
- Created `MagicLinkAuthScreen` and `OtpAuthScreen` for authentication.
- Modified `HomeScreen` to `MagicLinkAuthScreen`.
- Enhanced OTP authentication flow in `otp-auth.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

## Screenshots

Uploading screen-20241217-170256.mp4…