### PR TITLE
feat: add mekong devnet support

### DIFF
--- a/account-kit/infra/src/chains.ts
+++ b/account-kit/infra/src/chains.ts
@@ -478,3 +478,21 @@ export const arbitrumNova: Chain = {
     ...vabn.rpcUrls,
   },
 };
+
+export const mekong: Chain = defineChain({
+  id: 7078815900,
+  name: "Mekong Pectra Devnet",
+  nativeCurrency: { name: "eth", symbol: "eth", decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc.mekong.ethpandaops.io"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "Block Explorer",
+      url: "https://explorer.mekong.ethpandaops.io",
+    },
+  },
+  testnet: true,
+});

--- a/account-kit/infra/src/index.ts
+++ b/account-kit/infra/src/index.ts
@@ -39,6 +39,7 @@ export {
   unichainSepolia,
   inkMainnet,
   inkSepolia,
+  mekong,
 } from "./chains.js";
 export type * from "./client/decorators/alchemyEnhancedApis.js";
 export { alchemyEnhancedApiActions } from "./client/decorators/alchemyEnhancedApis.js";


### PR DESCRIPTION
Note: this is defined in the latest version of viem, but bumping viem would require bumping the minimum peer dependency version, which is a breaking change.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new blockchain configuration for the `Mekong Pectra Devnet`, adding it to the existing chains in the project.

### Detailed summary
- Added the `mekong` chain configuration in `chains.ts`.
- Defined `mekong` with:
  - `id`: 7078815900
  - `name`: "Mekong Pectra Devnet"
  - `nativeCurrency`: { name: "eth", symbol: "eth", decimals: 18 }
  - `rpcUrls`: Includes a default HTTP URL.
  - `blockExplorers`: Includes a default Block Explorer with a URL.
  - Marked as a testnet. 
- Updated `index.ts` to export `mekong`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->