### PR TITLE
feat: add native signer, implement signMessage and signTypedData

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
@@ -90,6 +90,11 @@ describe("MA v2 Tests", async () => {
       installValidationActions
     );
 
+    await setBalance(instance.getClient(), {
+      address: provider.getAddress(),
+      value: parseEther("2"),
+    });
+
     const accountContract = getContract({
       address: provider.getAddress(),
       abi: semiModularAccountBytecodeAbi,
@@ -131,8 +136,7 @@ describe("MA v2 Tests", async () => {
       signer: sessionKey,
       transport: custom(instance.getClient()),
       accountAddress: provider.getAddress(),
-      entityId: 1,
-      isGlobalValidation: true,
+      signerEntity: { entityId: 1, isGlobalValidation: true },
     });
 
     signature = await sessionKeyClient.signMessage({ message });

--- a/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
@@ -1,9 +1,16 @@
-import { custom, parseEther, publicActions, zeroAddress } from "viem";
 import {
   erc7677Middleware,
   LocalAccountSigner,
   type SmartAccountSigner,
 } from "@aa-sdk/core";
+import {
+  custom,
+  parseEther,
+  publicActions,
+  zeroAddress,
+  getContract,
+  hashMessage,
+} from "viem";
 import { createSMAV2AccountClient } from "./client.js";
 import { local070Instance } from "~test/instances.js";
 import { setBalance } from "viem/actions";
@@ -23,12 +30,15 @@ import { HookType } from "../actions/common/types.js";
 import { TimeRangeModule } from "../modules/time-range-module/module.js";
 import { allowlistModule } from "../modules/allowlist-module/module.js";
 import { nativeTokenLimitModule } from "../modules/native-token-limit-module/module.js";
+import { semiModularAccountBytecodeAbi } from "../abis/semiModularAccountBytecodeAbi.js";
 
 // TODO: Include a snapshot to reset to in afterEach.
 describe("MA v2 Tests", async () => {
   const instance = local070Instance;
   let client: ReturnType<typeof instance.getClient> &
     ReturnType<typeof publicActions>;
+
+  const isValidSigSuccess = "0x1626ba7e";
 
   beforeAll(async () => {
     client = instance.getClient().extend(publicActions);
@@ -73,6 +83,63 @@ describe("MA v2 Tests", async () => {
     await expect(getTargetBalance()).resolves.toEqual(
       startingAddressBalance + sendAmount
     );
+  });
+
+  it("successfully sign + validate a message, for native and single signer validation", async () => {
+    const provider = (await givenConnectedProvider({ signer })).extend(
+      installValidationActions
+    );
+
+    const accountContract = getContract({
+      address: provider.getAddress(),
+      abi: semiModularAccountBytecodeAbi,
+      client,
+    });
+
+    // UO deploys the account to test 1271 against
+    const result = await provider.installValidation({
+      validationConfig: {
+        moduleAddress: getDefaultSingleSignerValidationModuleAddress(
+          provider.chain
+        ),
+        entityId: 1,
+        isGlobal: true,
+        isSignatureValidation: true,
+        isUserOpValidation: true,
+      },
+      selectors: [],
+      installData: SingleSignerValidationModule.encodeOnInstallData({
+        entityId: 1,
+        signer: await sessionKey.getAddress(),
+      }),
+      hooks: [],
+    });
+
+    await provider.waitForUserOperationTransaction(result);
+
+    const message = "testmessage";
+
+    let signature = await provider.signMessage({ message });
+
+    await expect(
+      accountContract.read.isValidSignature([hashMessage(message), signature])
+    ).resolves.toEqual(isValidSigSuccess);
+
+    // connect session key and send tx with session key
+    let sessionKeyClient = await createSMAV2AccountClient({
+      chain: instance.chain,
+      signer: sessionKey,
+      transport: custom(instance.getClient()),
+      accountAddress: provider.getAddress(),
+      entityId: 1,
+      isGlobalValidation: true,
+    });
+
+    signature = await sessionKeyClient.signMessage({ message });
+
+    await expect(
+      accountContract.read.isValidSignature([hashMessage(message), signature])
+    ).resolves.toEqual(isValidSigSuccess);
   });
 
   it("adds a session key with no permissions", async () => {

--- a/account-kit/smart-contracts/src/ma-v2/utils.ts
+++ b/account-kit/smart-contracts/src/ma-v2/utils.ts
@@ -1,4 +1,4 @@
-import { concat, type Hex, type Chain, type Address } from "viem";
+import { concat, toHex, type Hex, type Chain, type Address } from "viem";
 import {
   arbitrum,
   arbitrumSepolia,
@@ -14,17 +14,37 @@ import {
 
 export const DEFAULT_OWNER_ENTITY_ID = 0;
 
-export type PackSignatureParams = {
+export type PackUOSignatureParams = {
   // orderedHookData: HookData[];
   validationSignature: Hex;
 };
 
-// Signature packing utility
-export const packSignature = ({
-  // orderedHookData, TO DO: integrate in next iteration of MAv2 sdk
+// TODO: direct call validation 1271
+export type Pack1271SignatureParams = {
+  validationSignature: Hex;
+  entityId: number;
+};
+
+// Signature packing utility for user operations
+export const packUOSignature = ({
+  // orderedHookData, TODO: integrate in next iteration of MAv2 sdk
   validationSignature,
-}: PackSignatureParams): Hex => {
+}: PackUOSignatureParams): Hex => {
   return concat(["0xFF", "0x00", validationSignature]);
+};
+
+// Signature packing utility for 1271 signatures
+export const pack1271Signature = ({
+  validationSignature,
+  entityId,
+}: Pack1271SignatureParams): Hex => {
+  return concat([
+    "0x00",
+    toHex(entityId, { size: 4 }),
+    "0xFF",
+    "0x00", // EOA type signature
+    validationSignature,
+  ]);
 };
 
 export const getDefaultMAV2FactoryAddress = (chain: Chain): Address => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing signature packing utilities for user operations and 1271 signatures in the `account-kit` smart contracts, along with updating the account creation logic to utilize these new utilities.

### Detailed summary
- Renamed `PackSignatureParams` to `PackUOSignatureParams`.
- Introduced `Pack1271SignatureParams` for 1271 signature packing.
- Added `pack1271Signature` function for 1271 signature packing.
- Updated `createSMAV2Account` to use `_accountAddress`.
- Modified `singleSignerMessageSigner` to accept `chain`, `accountAddress`, and `entityId`.
- Enhanced signature methods to utilize new packing functions.
- Added tests for message signing and validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->