### PR TITLE
fix: correctly trim implementation address

### DIFF
--- a/aa-sdk/core/src/account/smartContractAccount.ts
+++ b/aa-sdk/core/src/account/smartContractAccount.ts
@@ -1,7 +1,6 @@
 import {
   getContract,
   hexToBytes,
-  trim,
   type Address,
   type Chain,
   type CustomSource,
@@ -483,7 +482,9 @@ export async function toSmartContractAccount(
       );
     }
 
-    return trim(storage);
+    // The storage slot contains a full bytes32, but we want only the last 20 bytes.
+    // So, slice off the leading `0x` and the first 12 bytes (24 characters), leaving the last 20 bytes, then prefix with `0x`.
+    return `0x${storage.slice(26)}`;
   };
 
   if (entryPoint.version !== "0.6.0" && entryPoint.version !== "0.7.0") {

--- a/account-kit/smart-contracts/src/msca/client/client.test.ts
+++ b/account-kit/smart-contracts/src/msca/client/client.test.ts
@@ -165,6 +165,44 @@ describe("Modular Account Multi Owner Account Tests", async () => {
     `);
   }, 100000);
 
+  it("should get the implementation address correctly", async () => {
+    const provider = await givenConnectedProvider({
+      signer: signer1,
+      owners,
+      usePaymaster: true,
+    });
+
+    const implementationAddressPreDeploy =
+      await provider.account.getImplementationAddress();
+
+    expect(implementationAddressPreDeploy).toEqual(
+      "0x0000000000000000000000000000000000000000"
+    );
+
+    await setBalance(instance.getClient(), {
+      address: provider.getAddress(),
+      value: parseEther("1"),
+    });
+
+    const result = await provider.sendUserOperation({
+      uo: {
+        target: provider.getAddress(),
+        data: "0x",
+      },
+    });
+
+    const txnHash = provider.waitForUserOperationTransaction(result);
+
+    await expect(txnHash).resolves.not.toThrowError();
+
+    const implementationAddressPostDeploy =
+      await provider.account.getImplementationAddress();
+
+    expect(implementationAddressPostDeploy).toEqual(
+      "0x0046000000000151008789797b54fdb500e2a61e"
+    );
+  }, 200000);
+
   const givenConnectedProvider = ({
     signer,
     accountAddress,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "docs:gen": "turbo run docs:gen",
     "test": "vitest dev",
     "test:ci": "vitest run",
-    "lint:write": "eslint . --fix && yarn docs:gen && prettier --write --ignore-unknown .",
+    "lint:write": "eslint . --fix && yarn docs:gen && prettier --loglevel warn --write --ignore-unknown .",
     "lint:check": "eslint . && prettier --check .",
     "prepare": "husky install && yarn turbo prepare",
     "version": "yarn build:libs"


### PR DESCRIPTION
There's a bug in the logic of `getImplementationAddress`, where we call viem's `trim` over the ERC-1967 storage slot's value. This results in two issues:
- Before a contract is deployed, it returns `0x00` instead of `address(0)`.
- After deployment, if the address has leading or trailing zeros, these will incorrectly be trimmed.

Both of these could cause issues if the caller wants to use them as a viem `Address` type, because they will not be of the full length.

To fix this, we can manually trim out the first 12 bytes of the response, because if the response exists, it should always be 32 bytes in total.


Also updates `package.json` to not have verbose logging on by default, just for warnings. The number of files linted by prettier would fill up the entire scrollback buffer in my builtin terminal.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?
