### PR TITLE
fix: ci cleanup step should skip docker rmi if there are no images

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -80,7 +80,12 @@ jobs:
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean
-          docker rmi $(docker image ls -aq)
+          images=$(docker image ls -aq)
+          if [ -n "$images" ]; then
+            docker rmi $images
+          else
+            echo "No images to remove."
+          fi
           df -h
 
       - name: Setup


### PR DESCRIPTION
As noticed here: https://github.com/alchemyplatform/aa-sdk/actions/runs/12635284535/job/35205107297?pr=1261#step:3:18

If the command `docker image ls -aq` returns no images, then the call to `docker rmi` will fail with: `"docker rmi" requires at least 1 argument.`.

To fix, check if any are returned before running `docker rmi`.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `.github/workflows/on-pull-request.yml` file to improve the Docker image removal process by adding a conditional check before attempting to remove images. 

### Detailed summary
- Replaced `docker rmi $(docker image ls -aq)` with a conditional block.
- Added a check to see if there are any Docker images to remove.
- If no images are found, it outputs "No images to remove."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->