### PR TITLE
feat: add alchemy transport update for the mav2 account client

### DIFF
--- a/aa-sdk/core/src/utils/index.ts
+++ b/aa-sdk/core/src/utils/index.ts
@@ -24,6 +24,11 @@ export type Deferrable<T> = {
 };
 
 /**
+ * Used to ensure type doesn't extend another, for use in & chaining of properties
+ */
+export type NotType<A, B> = A extends B ? never : unknown;
+
+/**
  * Await all of the properties of a Deferrable object
  *
  * @param {Deferrable<T>} object - a Deferrable object

--- a/account-kit/smart-contracts/src/light-account/clients/alchemyClient.test.ts
+++ b/account-kit/smart-contracts/src/light-account/clients/alchemyClient.test.ts
@@ -12,7 +12,6 @@ import {
 } from "@account-kit/infra";
 import { Alchemy, Network } from "alchemy-sdk";
 import { avalanche, type Chain } from "viem/chains";
-import { createLightAccountAlchemyClient } from "./alchemyClient.js";
 import { createLightAccountClient } from "./client.js";
 
 describe("Light Account Client Tests", () => {

--- a/account-kit/smart-contracts/src/light-account/clients/client.ts
+++ b/account-kit/smart-contracts/src/light-account/clients/client.ts
@@ -1,5 +1,6 @@
 import {
   createSmartAccountClient,
+  type NotType,
   type SmartAccountClient,
   type SmartAccountClientActions,
   type SmartAccountClientConfig,
@@ -55,7 +56,8 @@ export function createLightAccountClient<
   TSigner extends SmartAccountSigner = SmartAccountSigner,
   TTransport extends Transport = Transport
 >(
-  args: CreateLightAccountClientParams<TTransport, TChain, TSigner>
+  args: CreateLightAccountClientParams<TTransport, TChain, TSigner> &
+    NotType<TTransport, AlchemyTransport>
 ): Promise<
   SmartAccountClient<
     CustomTransport,

--- a/account-kit/smart-contracts/src/light-account/clients/multiOwnerAlchemyClient.test.ts
+++ b/account-kit/smart-contracts/src/light-account/clients/multiOwnerAlchemyClient.test.ts
@@ -12,7 +12,6 @@ import {
 } from "@account-kit/infra";
 import { Alchemy, Network } from "alchemy-sdk";
 import { avalanche, type Chain } from "viem/chains";
-import { createMultiOwnerLightAccountAlchemyClient } from "./multiOwnerAlchemyClient.js";
 import { createMultiOwnerLightAccountClient } from "./multiOwnerLightAccount.js";
 
 describe("MultiOwnerLightAccount Client Tests", () => {

--- a/account-kit/smart-contracts/src/light-account/clients/multiOwnerLightAccount.ts
+++ b/account-kit/smart-contracts/src/light-account/clients/multiOwnerLightAccount.ts
@@ -1,5 +1,6 @@
 import {
   createSmartAccountClient,
+  type NotType,
   type SmartAccountClient,
   type SmartAccountClientActions,
   type SmartAccountClientConfig,
@@ -66,10 +67,12 @@ export async function createMultiOwnerLightAccountClient<
 >;
 
 export function createMultiOwnerLightAccountClient<
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateMultiOwnerLightAccountClientParams<Transport, TChain, TSigner>
+  args: CreateMultiOwnerLightAccountClientParams<TTransport, TChain, TSigner> &
+    NotType<TTransport, AlchemyTransport>
 ): Promise<
   SmartAccountClient<
     CustomTransport,

--- a/account-kit/smart-contracts/src/ma-v2/client/client.test-d.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.test-d.ts
@@ -1,0 +1,62 @@
+import {
+  erc7677Middleware,
+  LocalAccountSigner,
+  type SmartAccountSigner,
+} from "@aa-sdk/core";
+import { custom } from "viem";
+import { createSMAV2AccountClient } from "@account-kit/smart-contracts/experimental";
+import { local070Instance } from "~test/instances.js";
+import { accounts } from "~test/constants.js";
+import { alchemy } from "@account-kit/infra";
+
+// TODO: Include a snapshot to reset to in afterEach.
+describe("MA v2 Tests: Types", async () => {
+  const instance = local070Instance;
+
+  const signer: SmartAccountSigner = new LocalAccountSigner(
+    accounts.fundedAccountOwner
+  );
+
+  it("alchemy client instantiated can specify policy id but not for others ", async () => {
+    createSMAV2AccountClient({
+      chain: instance.chain,
+      signer,
+      transport: alchemy({ apiKey: "AN_API_KEY" }),
+      policyId: "test-policy-id",
+    });
+    // @ts-expect-error // A custom should not be able to specify an policy id
+    createSMAV2AccountClient({
+      chain: instance.chain,
+      signer,
+      transport: custom(instance.getClient()),
+      policyId: "test-policy-id",
+    });
+  });
+
+  it("alchemy client instantiated cannot specify paymaster", async () => {
+    const { paymasterAndData } = erc7677Middleware();
+    createSMAV2AccountClient({
+      chain: instance.chain,
+      signer,
+      transport: alchemy({ apiKey: "AN_API_KEY" }),
+    });
+    // @ts-expect-error Should not be able to pass paymasterAndData
+    createSMAV2AccountClient({
+      chain: instance.chain,
+      signer,
+      transport: alchemy({ apiKey: "AN_API_KEY" }),
+      paymasterAndData,
+    });
+    createSMAV2AccountClient({
+      chain: instance.chain,
+      signer,
+      transport: custom(instance.getClient()),
+    });
+    createSMAV2AccountClient({
+      chain: instance.chain,
+      signer,
+      transport: custom(instance.getClient()),
+      paymasterAndData,
+    });
+  });
+});

--- a/account-kit/smart-contracts/src/ma-v2/client/client.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.ts
@@ -1,8 +1,9 @@
 import {
-  createSmartAccountClient,
   type SmartAccountClient,
   type SmartAccountSigner,
   type SmartAccountClientConfig,
+  type NotType,
+  createSmartAccountClient,
 } from "@aa-sdk/core";
 import { type Chain, type Transport } from "viem";
 
@@ -11,10 +12,18 @@ import {
   type CreateSMAV2AccountParams,
   type MAV2Account,
 } from "../account/semiModularAccountV2.js";
-
+import {
+  createAlchemySmartAccountClient,
+  isAlchemyTransport,
+  type AlchemySmartAccountClientConfig,
+  type AlchemyTransport,
+} from "@account-kit/infra";
+import type { LightAccount } from "../../light-account/accounts/account.js";
 export type SMAV2AccountClient<
-  TSigner extends SmartAccountSigner = SmartAccountSigner
-> = SmartAccountClient<Transport, Chain, MAV2Account<TSigner>>;
+  TSigner extends SmartAccountSigner = SmartAccountSigner,
+  TChain extends Chain = Chain,
+  TTransport extends Transport | AlchemyTransport = Transport
+> = SmartAccountClient<TTransport, TChain, MAV2Account<TSigner>>;
 
 export type CreateSMAV2AccountClientParams<
   TTransport extends Transport = Transport,
@@ -25,13 +34,34 @@ export type CreateSMAV2AccountClientParams<
     SmartAccountClientConfig<TTransport, TChain>,
     "transport" | "account" | "chain"
   >;
+export type CreateSMAV2AlchemyAccountClientParams<
+  TTransport extends Transport = Transport,
+  TChain extends Chain = Chain,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+> = Omit<
+  CreateSMAV2AccountClientParams<TTransport, TChain, TSigner>,
+  "transport"
+> &
+  Omit<
+    AlchemySmartAccountClientConfig<TChain, LightAccount<TSigner>>,
+    "account"
+  > & { paymasterAndData?: never; dummyPaymasterAndData?: never };
 
 export function createSMAV2AccountClient<
   TChain extends Chain = Chain,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateSMAV2AccountClientParams<Transport, TChain, TSigner>
-): Promise<SMAV2AccountClient<TSigner>>;
+  args: CreateSMAV2AlchemyAccountClientParams<AlchemyTransport, TChain, TSigner>
+): Promise<SMAV2AccountClient<TSigner, TChain, AlchemyTransport>>;
+
+export function createSMAV2AccountClient<
+  TTransport extends Transport = Transport,
+  TChain extends Chain = Chain,
+  TSigner extends SmartAccountSigner = SmartAccountSigner
+>(
+  args: CreateSMAV2AccountClientParams<TTransport, TChain, TSigner> &
+    NotType<TTransport, AlchemyTransport>
+): Promise<SMAV2AccountClient<TSigner, TChain>>;
 
 /**
  * Creates a SMAv2 account client using the provided configuration parameters.
@@ -65,7 +95,20 @@ export function createSMAV2AccountClient<
 export async function createSMAV2AccountClient(
   config: CreateSMAV2AccountClientParams
 ): Promise<SmartAccountClient> {
-  const smaV2Account = await createSMAV2Account(config);
+  const { transport, chain } = config;
+  const smaV2Account = await createSMAV2Account({
+    ...config,
+    transport,
+    chain,
+  });
+  if (isAlchemyTransport(transport, chain)) {
+    return createAlchemySmartAccountClient({
+      ...config,
+      transport,
+      chain,
+      account: smaV2Account,
+    });
+  }
 
   return createSmartAccountClient({
     ...config,

--- a/account-kit/smart-contracts/src/msca/client/client.ts
+++ b/account-kit/smart-contracts/src/msca/client/client.ts
@@ -1,6 +1,7 @@
 import {
   createSmartAccountClient,
   smartAccountClientActions,
+  type NotType,
   type SmartAccountClient,
   type SmartAccountClientRpcSchema,
   type SmartAccountSigner,
@@ -104,10 +105,16 @@ export function createMultiOwnerModularAccountClient<
 >;
 
 export function createMultiOwnerModularAccountClient<
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateMultiOwnerModularAccountClientParams<Transport, TChain, TSigner>
+  args: CreateMultiOwnerModularAccountClientParams<
+    TTransport,
+    TChain,
+    TSigner
+  > &
+    NotType<TTransport, AlchemyTransport>
 ): Promise<
   SmartAccountClient<
     CustomTransport,
@@ -207,10 +214,12 @@ export function createMultisigModularAccountClient<
 >;
 
 export function createMultisigModularAccountClient<
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TSigner extends SmartAccountSigner = SmartAccountSigner
 >(
-  args: CreateMultisigModularAccountClientParams<Transport, TChain, TSigner>
+  args: CreateMultisigModularAccountClientParams<TTransport, TChain, TSigner> &
+    NotType<TTransport, AlchemyTransport>
 ): Promise<
   SmartAccountClient<
     CustomTransport,


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new type `NotType` for type safety in TypeScript and modifies various client functions to ensure that specific transport types are not used with certain clients. It also adds tests for the `createSMAV2AccountClient` function, ensuring proper behavior with Alchemy transport.

### Detailed summary
- Added `NotType` type to enforce type constraints.
- Updated parameters in `createLightAccountClient`, `createMultiOwnerLightAccountClient`, `createMultiOwnerModularAccountClient`, and `createMultisigModularAccountClient` to use `NotType`.
- Added tests for `createSMAV2AccountClient` to validate Alchemy transport behavior.
- Enhanced `createSMAV2AccountClient` to differentiate between Alchemy and custom transports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->