### PR TITLE
feat: session expiration improvements

### DIFF
--- a/account-kit/core/src/createConfig.test.ts
+++ b/account-kit/core/src/createConfig.test.ts
@@ -1,0 +1,28 @@
+import { alchemy, sepolia } from "@account-kit/infra";
+import { createConfig } from "./createConfig.js";
+
+describe("createConfig", () => {
+  it("should set the internal session length", async () => {
+    const config = await givenConfig();
+    expect(config._internal.sessionLength).toBe(5000);
+  });
+
+  it("should set the session config expiration time", async () => {
+    const config = await givenConfig();
+    expect(config.store.getState().config.sessionConfig?.expirationTimeMs).toBe(
+      5000
+    );
+  });
+
+  const givenConfig = async () => {
+    return createConfig({
+      chain: sepolia,
+      transport: alchemy({ rpcUrl: "/api/sepolia" }),
+      signerConnection: { rpcUrl: "/api/signer" },
+      storage: () => localStorage,
+      sessionConfig: {
+        expirationTimeMs: 5000,
+      },
+    });
+  };
+});

--- a/account-kit/core/src/createConfig.ts
+++ b/account-kit/core/src/createConfig.ts
@@ -87,7 +87,6 @@ export const createConfig = (
     storage: storage?.(
       sessionConfig
         ? {
-            sessionLength: sessionConfig.expirationTimeMs,
             domain: sessionConfig.domain,
           }
         : undefined

--- a/account-kit/core/src/types.ts
+++ b/account-kit/core/src/types.ts
@@ -103,7 +103,7 @@ export type CreateConfigProps = RpcConnectionConfig & {
   ssr?: boolean;
 
   // TODO: should probably abstract this out into a function
-  storage?: (config?: { sessionLength?: number; domain?: string }) => Storage;
+  storage?: (config?: { domain?: string }) => Storage;
 
   connectors?: CreateConnectorFn[];
 

--- a/account-kit/core/src/types.ts
+++ b/account-kit/core/src/types.ts
@@ -94,6 +94,12 @@ type RpcConnectionConfig =
       chains?: never;
     };
 
+type CreateStorageFn = (config?: {
+  /** @deprecated Use `sessionConfig` to define session length instead. */
+  sessionLength?: number;
+  domain?: string;
+}) => Storage;
+
 export type CreateConfigProps = RpcConnectionConfig & {
   sessionConfig?: AlchemySignerParams["sessionConfig"] & { domain?: string };
   /**
@@ -102,8 +108,7 @@ export type CreateConfigProps = RpcConnectionConfig & {
    */
   ssr?: boolean;
 
-  // TODO: should probably abstract this out into a function
-  storage?: (config?: { domain?: string }) => Storage;
+  storage?: CreateStorageFn;
 
   connectors?: CreateConnectorFn[];
 

--- a/account-kit/core/src/utils/cookies.ts
+++ b/account-kit/core/src/utils/cookies.ts
@@ -12,11 +12,12 @@ const MAX_COOKIE_DURATION_MS = 1000 * 60 * 60 * 24 * 400;
  * Function to create cookie based Storage
  *
  * @param {{sessionLength: number; domain?: string}} config optional config object
- * @param {number} config.sessionLength the duration until the cookie expires in milliseconds @deprecated
+ * @param {number} config.sessionLength the duration until the cookie expires in milliseconds (deprecated)
  * @param {string} config.domain optional domain to set the cookie on, eg: `example.com` if you want the cookie to work on all subdomains of example.com
  * @returns {Storage} an instance of a browser storage object that leverages cookies
  */
 export const cookieStorage = (config?: {
+  /** @deprecated this option is deprecated and will be ignored */
   sessionLength?: number;
   domain?: string;
 }): Storage => {

--- a/account-kit/core/src/utils/cookies.ts
+++ b/account-kit/core/src/utils/cookies.ts
@@ -86,6 +86,17 @@ export function cookieToInitialState(
     state: StoredState["alchemy"];
   }>(state).state;
 
+  // If the expirationTimeMs is changed in the config, we should use the new config
+  // value instead of restoring the value from the cookie, otherwise it can lead
+  // to confusion and unexpected behavior when it seems like the expirationTimeMs
+  // is being ignored.
+  alchemyClientState.config.sessionConfig = {
+    ...alchemyClientState.config.sessionConfig,
+    expirationTimeMs:
+      config.store.getInitialState().config.sessionConfig?.expirationTimeMs ??
+      alchemyClientState.config.sessionConfig?.expirationTimeMs,
+  };
+
   const wagmiClientState = wagmiCookieToInitialState(
     config._internal.wagmiConfig,
     decodeURIComponent(cookie)

--- a/account-kit/core/src/utils/cookies.ts
+++ b/account-kit/core/src/utils/cookies.ts
@@ -1,22 +1,19 @@
-import { DEFAULT_SESSION_MS } from "@account-kit/signer";
 import { cookieToInitialState as wagmiCookieToInitialState } from "@wagmi/core";
 import Cookies from "js-cookie";
 import type { StoredState } from "../store/types.js";
 import type { AlchemyAccountsConfig } from "../types.js";
 import { deserialize } from "./deserialize.js";
 
+const THIRTY_DAYS_MS = 1000 * 60 * 60 * 24 * 30;
+
 /**
  * Function to create cookie based Storage
  *
- * @param {{sessionLength: number; domain?: string}} config optional config object that allows you to set the session length
- * @param {number} config.sessionLength the length of the session in milliseconds
+ * @param {{domain?: string}} config optional config object
  * @param {string} config.domain optional domain to set the cookie on, eg: `example.com` if you want the cookie to work on all subdomains of example.com
  * @returns {Storage} an instance of a browser storage object that leverages cookies
  */
-export const cookieStorage = (config?: {
-  sessionLength?: number;
-  domain?: string;
-}): Storage => ({
+export const cookieStorage = (config?: { domain?: string }): Storage => ({
   // this is unused for now, we should update this if we do need it
   length: 0,
 
@@ -49,9 +46,8 @@ export const cookieStorage = (config?: {
     if (typeof document === "undefined") return;
 
     Cookies.set(key, value, {
-      expires: new Date(
-        Date.now() + (config?.sessionLength ?? DEFAULT_SESSION_MS)
-      ),
+      // Note that cookies without an expiration are removed when the browser is closed.
+      expires: new Date(Date.now() + THIRTY_DAYS_MS),
       domain: config?.domain,
     });
   },

--- a/account-kit/signer/src/session/manager.test.ts
+++ b/account-kit/signer/src/session/manager.test.ts
@@ -1,0 +1,36 @@
+import { AlchemySignerWebClient } from "../client/index.js";
+import { SessionManager } from "./manager.js";
+
+describe("session manager", () => {
+  beforeEach(() => {
+    // Mock the document.getElementById method
+    vi.spyOn(document, "getElementById").mockImplementation((id) => {
+      if (id === "alchemy-signer-iframe-container") {
+        return document.createElement("div");
+      }
+      return null;
+    });
+  });
+
+  it("should set the expiration time as defined in the config", () => {
+    const manager = createManager();
+    expect(manager.expirationTimeMs).toBe(5000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createManager = () => {
+    const client = new AlchemySignerWebClient({
+      connection: { rpcUrl: "/api/signer" },
+      iframeConfig: {
+        iframeContainerId: "alchemy-signer-iframe-container",
+      },
+    });
+    return new SessionManager({
+      client,
+      expirationTimeMs: 5000,
+    });
+  };
+});

--- a/account-kit/signer/vitest.config.ts
+++ b/account-kit/signer/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
   defineProject({
     test: {
       name: "account-kit/signer",
+      environment: "jsdom",
     },
   })
 );

--- a/site/pages/react/quickstart.mdx
+++ b/site/pages/react/quickstart.mdx
@@ -220,7 +220,7 @@ export const config = createConfig(
     ssr: true, // Defers hydration of the account state to the client after the initial mount solving any inconsistencies between server and client state (read more here: https://accountkit.alchemy.com/react/ssr)
     storage: cookieStorage, // persist the account state using cookies (read more here: https://accountkit.alchemy.com/react/ssr#persisting-the-account-state)
     enablePopupOauth: true, // must be set to "true" if you plan on using popup rather than redirect in the social login flow
-    // optional config to override default session manager configs
+    // optional config to override default session manager config
     sessionConfig: {
       expirationTimeMs: 1000 * 60 * 60, // 60 minutes (default is 15 min)
     },

--- a/site/pages/react/quickstart.mdx
+++ b/site/pages/react/quickstart.mdx
@@ -196,6 +196,7 @@ The [**demo app**](https://demo.alchemy.com/) provides an interactive sandbox to
        - **ssr** (optional): Highly recommended for NextJs applications to keep account state consistent between the server and client
        - **storage** (optional): Cookie storage highly recommended for NextJs applications to persist and cache account state across page loads
        - **enablePopupOauth** (optional): If implementing social login, allow for the sign in window to appear as a pop up to your user.
+       - **sessionConfig** (optional):
 
      - `ui`: for creating Alchemy Accounts UI components
 
@@ -219,6 +220,10 @@ export const config = createConfig(
     ssr: true, // Defers hydration of the account state to the client after the initial mount solving any inconsistencies between server and client state (read more here: https://accountkit.alchemy.com/react/ssr)
     storage: cookieStorage, // persist the account state using cookies (read more here: https://accountkit.alchemy.com/react/ssr#persisting-the-account-state)
     enablePopupOauth: true, // must be set to "true" if you plan on using popup rather than redirect in the social login flow
+    // optional config to override default session manager configs
+    sessionConfig: {
+      expirationTimeMs: 1000 * 60 * 60, // 60 minutes (default is 15 min)
+    },
   },
   {
     // authentication ui config - your customizations here

--- a/site/pages/react/quickstart.mdx
+++ b/site/pages/react/quickstart.mdx
@@ -196,7 +196,7 @@ The [**demo app**](https://demo.alchemy.com/) provides an interactive sandbox to
        - **ssr** (optional): Highly recommended for NextJs applications to keep account state consistent between the server and client
        - **storage** (optional): Cookie storage highly recommended for NextJs applications to persist and cache account state across page loads
        - **enablePopupOauth** (optional): If implementing social login, allow for the sign in window to appear as a pop up to your user.
-       - **sessionConfig** (optional):
+       - **sessionConfig** (optional): Used to configure the session duration
 
      - `ui`: for creating Alchemy Accounts UI components
 

--- a/site/pages/reference/account-kit/core/functions/cookieStorage.mdx
+++ b/site/pages/reference/account-kit/core/functions/cookieStorage.mdx
@@ -18,8 +18,13 @@ import { cookieStorage } from "@account-kit/core";
 
 ### config
 
-`{domain?: string}`
+`{sessionLength: number; domain?: string}`
 optional config object
+
+### config.sessionLength
+
+`number`
+the duration until the cookie expires in milliseconds (deprecated)
 
 ### config.domain
 

--- a/site/pages/reference/account-kit/core/functions/cookieStorage.mdx
+++ b/site/pages/reference/account-kit/core/functions/cookieStorage.mdx
@@ -18,13 +18,8 @@ import { cookieStorage } from "@account-kit/core";
 
 ### config
 
-`{sessionLength: number; domain?: string}`
-optional config object that allows you to set the session length
-
-### config.sessionLength
-
-`number`
-the length of the session in milliseconds
+`{domain?: string}`
+optional config object
 
 ### config.domain
 


### PR DESCRIPTION
Improvement 1:
- The main source of truth for the signer session lives in local storage. The config store is also persisted to a cookie (so that it can rehydrate when the page loads or is refreshed). Currently, a `sessionLength` config option is exposed on the `cookieStorage`, but this is a bit of a footgun because it doesn't actually change the session length in local storage. It only changes the duration of the cookie.
- Since the main source of truth for the session is in local storage (and the cookie is automatically updated whenever the session expires in local storage), the cookie can just be longer-lived, and the option to set the cookie duration can be removed, reducing any confusion.
- Updated docs to make it more clear how to properly change the session length.

Improvement 2:
- When the value `expirationTimeMs` passed to `createConfig` is changed, the store currently just rehydrates with the old value from the cookie whenever the page is refreshed. This can also cause confusion because the new config doesn't become active unless the local/cookie storage is manually cleared.
- Updated the `cookieToInitialState` function so that the `expirationTimeMs` in the session config takes priority over the value that was persisted in the cookie whenever the page reloads.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing session management and configuration in the `account-kit` library. It introduces a new session configuration system, updates documentation, and modifies the cookie storage implementation to reflect these changes.

### Detailed summary
- Added `environment: "jsdom"` to `vitest.config.ts`.
- Deprecated `sessionLength` in favor of `expirationTimeMs` in session configurations.
- Updated `cookieStorage` handling for session length.
- Introduced `CreateStorageFn` type for storage configuration.
- Added tests for session length and expiration time in `createConfig.test.ts`.
- Modified documentation to clarify session configuration usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->