### PR TITLE
feat: ui demo user card reflects 7702 delegation status

### DIFF
--- a/examples/ui-demo/src/components/shared/user-connection-avatar/RenderUserConnectionAvatar.tsx
+++ b/examples/ui-demo/src/components/shared/user-connection-avatar/RenderUserConnectionAvatar.tsx
@@ -43,7 +43,7 @@ export const RenderUserConnectionAvatar = (
         delegationStatus,
       };
     },
-    refetchInterval: autoRefresh ? 5000 : false, // refetch every 5 seconds
+    refetchInterval: autoRefresh ? 5000 : false, // refetch every 5 seconds until delegation address becomes available
   });
 
   const { data: deploymentStatusSCA = false, refetch: refetchSCA } = useQuery({

--- a/examples/ui-demo/src/components/shared/user-connection-avatar/RenderUserConnectionAvatar.tsx
+++ b/examples/ui-demo/src/components/shared/user-connection-avatar/RenderUserConnectionAvatar.tsx
@@ -41,7 +41,7 @@ export const RenderUserConnectionAvatar = (
             address: await signer?.getAddress(),
           })
         : "0x";
-      const delegationStatus = delegationAddress && delegationAddress !== "0x";
+      const delegationStatus = delegationAddress !== "0x";
       return {
         delegationAddress,
         delegationStatus,

--- a/examples/ui-demo/src/components/shared/user-connection-avatar/UserConnectionDetails.tsx
+++ b/examples/ui-demo/src/components/shared/user-connection-avatar/UserConnectionDetails.tsx
@@ -3,6 +3,7 @@ import { ExternalLinkIcon } from "@/components/icons/external-link";
 import { LogoutIcon } from "@/components/icons/logout";
 import { DeploymentStatusIndicator } from "@/components/shared/DeploymentStatusIndicator";
 import { UserAddressLink } from "@/components/shared/user-connection-avatar/UserAddressLink";
+import { ODYSSEY_EXPLORER_URL } from "@/hooks/7702/constants";
 import { useConfigStore } from "@/state";
 import { useAccount, useLogout, useSigner, useUser } from "@account-kit/react";
 import { useQuery } from "@tanstack/react-query";
@@ -128,7 +129,7 @@ export function UserConnectionDetails({
             <span className="text-fg-primary block ml-1 text-md md:text-sm">
               {deploymentStatus && delegationAddress ? (
                 <a
-                  href={`https://odyssey-explorer.ithaca.xyz/address/0x${delegationAddress.slice(
+                  href={`${ODYSSEY_EXPLORER_URL}/address/0x${delegationAddress.slice(
                     8
                   )}`}
                   target="_blank"

--- a/examples/ui-demo/src/components/shared/user-connection-avatar/UserConnectionDetails.tsx
+++ b/examples/ui-demo/src/components/shared/user-connection-avatar/UserConnectionDetails.tsx
@@ -6,12 +6,15 @@ import { UserAddressLink } from "@/components/shared/user-connection-avatar/User
 import { useConfigStore } from "@/state";
 import { useAccount, useLogout, useSigner, useUser } from "@account-kit/react";
 import { useQuery } from "@tanstack/react-query";
+import { Hex } from "viem";
 
 type UserConnectionDetailsProps = {
   deploymentStatus: boolean;
+  delegationAddress?: Hex;
 };
 export function UserConnectionDetails({
   deploymentStatus,
+  delegationAddress,
 }: UserConnectionDetailsProps) {
   const user = useUser();
   const signer = useSigner();
@@ -36,6 +39,13 @@ export function UserConnectionDetails({
     queryKey: ["signerAddress"],
     queryFn: getSignerAddress,
   });
+
+  let explorerPage = "";
+  if (delegationAddress) {
+    explorerPage = `https://odyssey-explorer.ithaca.xyz/address/0x${delegationAddress.slice(
+      8
+    )}`;
+  }
 
   if (!user) return null;
 
@@ -119,11 +129,17 @@ export function UserConnectionDetails({
           </span>
           <div className="flex flex-row items-center">
             <DeploymentStatusIndicator
-              isDeployed={false}
+              isDeployed={deploymentStatus}
               className="w-[12px] h-[12px]"
             />
             <span className="text-fg-primary block ml-1 text-md md:text-sm">
-              None
+              {deploymentStatus ? (
+                <a href={explorerPage} target="_blank" className="underline">
+                  Modular Account
+                </a>
+              ) : (
+                "None"
+              )}
             </span>
           </div>
         </div>

--- a/examples/ui-demo/src/components/shared/user-connection-avatar/UserConnectionDetails.tsx
+++ b/examples/ui-demo/src/components/shared/user-connection-avatar/UserConnectionDetails.tsx
@@ -40,13 +40,6 @@ export function UserConnectionDetails({
     queryFn: getSignerAddress,
   });
 
-  let explorerPage = "";
-  if (delegationAddress) {
-    explorerPage = `https://odyssey-explorer.ithaca.xyz/address/0x${delegationAddress.slice(
-      8
-    )}`;
-  }
-
   if (!user) return null;
 
   if (isEOAUser) {
@@ -133,8 +126,14 @@ export function UserConnectionDetails({
               className="w-[12px] h-[12px]"
             />
             <span className="text-fg-primary block ml-1 text-md md:text-sm">
-              {deploymentStatus ? (
-                <a href={explorerPage} target="_blank" className="underline">
+              {deploymentStatus && delegationAddress ? (
+                <a
+                  href={`https://odyssey-explorer.ithaca.xyz/address/0x${delegationAddress.slice(
+                    8
+                  )}`}
+                  target="_blank"
+                  className="underline"
+                >
                   Modular Account
                 </a>
               ) : (


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `UserConnectionDetails` component and its usage in the `RenderUserConnectionAvatar` component by adding delegation address handling and integrating new functionality for hybrid accounts.

### Detailed summary
- Added `delegationAddress` prop to `UserConnectionDetails` and `RenderUserConnectionAvatar`.
- Integrated `ODYSSEY_EXPLORER_URL` for linking to delegation addresses.
- Updated deployment status logic to handle hybrid accounts.
- Refactored query logic to fetch delegation address and status.
- Modified `RenderPopoverMenu` and `RenderDialogMenu` to pass `delegationAddress` to `UserConnectionDetails`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->