### PR TITLE
fix: twitter logo not visible in dark mode in demo

### DIFF
--- a/account-kit/react/src/components/auth/sections/OAuth.tsx
+++ b/account-kit/react/src/components/auth/sections/OAuth.tsx
@@ -35,7 +35,13 @@ export const OAuth = memo(({ ...config }: Props) => {
       return (
         <Button
           variant="social"
-          icon={<img src={config.logoUrl} alt={config.auth0Connection} />}
+          icon={
+            <img
+              src={config.logoUrl}
+              alt={config.auth0Connection}
+              className={`${config.invertDarkLogo ? "dark:invert" : ""}`}
+            />
+          }
           onClick={authenticate}
         ></Button>
       );

--- a/account-kit/react/src/components/auth/types.ts
+++ b/account-kit/react/src/components/auth/types.ts
@@ -23,6 +23,7 @@ export type AuthType =
           auth0Connection?: string;
           displayName: string;
           logoUrl: string;
+          invertDarkLogo?: boolean;
         }
       | {
           authProviderId: KnownAuthProvider;
@@ -30,6 +31,7 @@ export type AuthType =
           auth0Connection?: never;
           displayName?: never;
           logoUrl?: never;
+          invertDarkLogo?: never;
         }
     ) &
       OauthRedirectConfig);

--- a/examples/ui-demo/src/app/config.tsx
+++ b/examples/ui-demo/src/app/config.tsx
@@ -13,7 +13,7 @@ export type Config = {
     showPasskey: boolean;
     addPasskey: boolean;
     showOAuth: boolean;
-    oAuthMethods: Record<KnownAuthProvider | "auth0" | "twitter", boolean>;
+    oAuthMethods: Record<KnownAuthProvider | "twitter", boolean>;
   };
   ui: {
     theme: "light" | "dark";

--- a/examples/ui-demo/src/app/sections.ts
+++ b/examples/ui-demo/src/app/sections.ts
@@ -31,6 +31,7 @@ export function getSectionsForConfig(
           auth0Connection: "twitter",
           displayName: "X",
           logoUrl: "/images/twitter.svg",
+          invertDarkLogo: true,
           scope: "openid profile",
         });
       } else if (enabled) {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `invertDarkLogo` property to enhance logo visibility based on the theme and updates the OAuth configuration accordingly.

### Detailed summary
- Added `invertDarkLogo: true` in `examples/ui-demo/src/app/sections.ts`.
- Updated `oAuthMethods` type to include only `KnownAuthProvider | "twitter"` in `examples/ui-demo/src/app/config.tsx`.
- Added optional `invertDarkLogo` property in `account-kit/react/src/components/auth/types.ts`.
- Modified the `<Button>` component in `account-kit/react/src/components/auth/sections/OAuth.tsx` to conditionally apply a CSS class based on `invertDarkLogo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->