### PR TITLE
chore: fix the post install to include building templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "generate": "turbo run generate",
     "postgenerate": "yarn lint:write",
     "preinstall": "yarn config set ignore-engines true",
-    "postinstall": "git submodule update --init --recursive && patch-package",
+    "postinstall": "git submodule update --init --recursive && patch-package && turbo run build --filter='./templates/*'",
     "build": "yarn build:libs --filter='!@account-kit/react-native-signer' --filter='!@account-kit/react-native-signer-example'",
     "postbuild": "yarn lint:write",
     "build:libs": "turbo run build --filter='@account-kit/*' --filter='@aa-sdk/*' --filter='./templates/*'",


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `postinstall` script in `package.json` to include a build command after updating git submodules and applying patches. It enhances the installation process by ensuring the necessary build steps are executed.

### Detailed summary
- Updated `postinstall` script:
  - Added `turbo run build --filter='./templates/*'` to the existing command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->