### PR TITLE
 fix the link for SmartAccountSigner.

### DIFF
--- a/site/pages/third-party/signers.mdx
+++ b/site/pages/third-party/signers.mdx
@@ -8,7 +8,7 @@ description: Learn how to use a 3rd party Signer with Account Kit
 Account Kit is designed to be flexible and allow you to use any Signer you want. If you choose not use our signer, you can either:
 
 1. Use a 3rd party library as a Signer that integrates with Account Kit.
-1. Implement [`SmartAccountSigner`]( https://github.com/alchemyplatform/aa-sdk/blob/main/aa-sdk/core/src/signer/types.ts) (exported in `@aa-sdk/core`).
+1. Implement [`SmartAccountSigner`](https://github.com/alchemyplatform/aa-sdk/blob/main/aa-sdk/core/src/signer/types.ts) (exported in `@aa-sdk/core`).
 1. If your Signer is an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) compliant provider, you can leverage `viem`'s `WalletClient` and the [`WalletClientSigner`](/reference/aa-sdk/core/classes/WalletClientSigner/constructor) (exported in `@aa-sdk/core`).
 
 Then you can use your Signer as an owner on Smart Contracts exported from `@account-kit/smart-contracts` and with our infra Smart Account Clients exported from `@account-kit/infra`.


### PR DESCRIPTION
This PR updates the documentation to fix the link for SmartAccountSigner.
Changed the link to point to the current documentation in smart-account-signer.mdx.
This ensures users have easier access to information about SmartAccountSigner exported from @aa-sdk/core.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for using a third-party library as a Signer with Account Kit, specifically correcting the link to the `SmartAccountSigner` implementation.

### Detailed summary
- Corrected the link to `SmartAccountSigner` implementation from `.../main/packages/core/src/...` to `.../main/aa-sdk/core/src/...` in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->