### PR TITLE
docs: added two slash to account kit react hooks

### DIFF
--- a/account-kit/react/src/hooks/useAccount.ts
+++ b/account-kit/react/src/hooks/useAccount.ts
@@ -38,18 +38,18 @@ export type UseAccountProps<TAccount extends SupportedAccountTypes> =
  *
  * If using an EOA, returns address of signer
  *
+ * @template {SupportedAccountTypes} TAccount The type of account to use
+ * @param {UseAccountProps<TAccount>} params The parameters required for account management, including account type, specific account parameters, and optional mutation arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAccount.ts#L28)
+ * @returns {UseAccountResult<TAccount>} An object containing the account information, address, and loading state. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAccount.ts#L22)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useAccount } from "@account-kit/react";
  *
  * const { account, address, isLoadingAccount } = useAccount({
  *  type: "LightAccount"
  * });
  * ```
- *
- * @template {SupportedAccountTypes} TAccount The type of account to use
- * @param {UseAccountProps<TAccount>} params The parameters required for account management, including account type, specific account parameters, and optional mutation arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAccount.ts#L28)
- * @returns {UseAccountResult<TAccount>} An object containing the account information, address, and loading state. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAccount.ts#L22)
  */
 export function useAccount<TAccount extends SupportedAccountTypes>(
   params: UseAccountProps<TAccount>

--- a/account-kit/react/src/hooks/useAddPasskey.ts
+++ b/account-kit/react/src/hooks/useAddPasskey.ts
@@ -24,8 +24,11 @@ export type UseAddPasskeyResult = {
 /**
  * A custom [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAddPasskey.ts) to handle the addition of a passkey to an already authenticated account, which includes executing a mutation with optional parameters.
  *
+ * @param {UseAddPasskeyMutationArgs} [mutationArgs] Optional arguments for the mutation used for adding a passkey. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAddPasskey.ts#L8)
+ * @returns {UseAddPasskeyResult} An object containing the `addPasskey` function, a boolean `isAddingPasskey` to track the mutation status, and any error encountered. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAddPasskey.ts#L13)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useAddPasskey } from "@account-kit/react";
  *
  * const { addPasskey, isAddingPasskey, error } = useAddPasskey({
@@ -36,9 +39,6 @@ export type UseAddPasskeyResult = {
  *  onError: (error) => console.error(error),
  * });
  * ```
- *
- * @param {UseAddPasskeyMutationArgs} [mutationArgs] Optional arguments for the mutation used for adding a passkey. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAddPasskey.ts#L8)
- * @returns {UseAddPasskeyResult} An object containing the `addPasskey` function, a boolean `isAddingPasskey` to track the mutation status, and any error encountered. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAddPasskey.ts#L13)
  */
 export function useAddPasskey(
   mutationArgs?: UseAddPasskeyMutationArgs

--- a/account-kit/react/src/hooks/useAuthError.ts
+++ b/account-kit/react/src/hooks/useAuthError.ts
@@ -5,8 +5,10 @@ export type UseAuthErrorResult = Error | undefined;
 /**
  * Returns the error returned from the current auth step, if it exists
  *
+ * @returns {UseAuthErrorResult} the current Error object
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
  * import { useAuthError } from "@account-kit/react";
  *
  * const error = useAuthError();
@@ -15,8 +17,6 @@ export type UseAuthErrorResult = Error | undefined;
  *  console.error("Error occurred during auth step", error);
  * }
  * ```
- *
- * @returns {UseAuthErrorResult} the current Error object
  */
 export function useAuthError(): UseAuthErrorResult {
   const { authStep } = useAuthContext();

--- a/account-kit/react/src/hooks/useAuthModal.ts
+++ b/account-kit/react/src/hooks/useAuthModal.ts
@@ -10,8 +10,11 @@ export type UseAuthModalResult = {
  * A [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthModal.ts) that returns the open and close functions for the Auth Modal if uiConfig
  * is enabled on the Account Provider
  *
+ * @returns {UseAuthModalResult} an object containing methods for opening or closing the auth modal. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthModal.ts#L4)
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
+ * import React from 'react';
  * import { useAuthModal } from "@account-kit/react";
  *
  * const ComponentWithAuthModal = () => {
@@ -24,8 +27,6 @@ export type UseAuthModalResult = {
  *  );
  * };
  * ```
- *
- * @returns {UseAuthModalResult} an object containing methods for opening or closing the auth modal. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthModal.ts#L4)
  */
 export const useAuthModal = () => {
   const { isOpen, setModalOpen } = useUiConfig(

--- a/account-kit/react/src/hooks/useAuthenticate.ts
+++ b/account-kit/react/src/hooks/useAuthenticate.ts
@@ -31,8 +31,11 @@ export type UseAuthenticateResult = {
  *
  * This can be complex for magic link or OTP flows: OPT calls authenticate twice, but this should be handled by the signer.
  *
+ * @param {UseAuthenticateMutationArgs} [mutationArgs] Optional mutation arguments to configure the authentication mutation. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthenticate.ts#L15)
+ * @returns {UseAuthenticateResult} An object containing functions and state for handling user authentication, including methods for synchronously and asynchronously executing the authentication. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthenticate.ts#L20)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useAuthenticate } from "@account-kit/react";
  *
  * const { authenticate, authenticateAsync, isPending, error } = useAuthenticate({
@@ -43,9 +46,6 @@ export type UseAuthenticateResult = {
  *  onError: (error) => console.error(error),
  * });
  * ```
- *
- * @param {UseAuthenticateMutationArgs} [mutationArgs] Optional mutation arguments to configure the authentication mutation. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthenticate.ts#L15)
- * @returns {UseAuthenticateResult} An object containing functions and state for handling user authentication, including methods for synchronously and asynchronously executing the authentication. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useAuthenticate.ts#L20)
  */
 export function useAuthenticate(
   mutationArgs?: UseAuthenticateMutationArgs

--- a/account-kit/react/src/hooks/useBundlerClient.ts
+++ b/account-kit/react/src/hooks/useBundlerClient.ts
@@ -9,17 +9,18 @@ export type UseBundlerClientResult = ClientWithAlchemyMethods;
 
 /**
  * Custom [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useBundlerClient.ts) to get a bundler client using the Alchemy account context.
- * It uses `useSyncExternalStore` to watch for any changes in the bundler client configuration and provides the updated bundler client. React hooks don’t handle their own state management directly, so they rely on external stores, like `useSyncExternalStore`, to manage state.. useBundlerClient’s only job is to call the bundler JSON RPC methods directly; it does not do additional processing, unlike useSmartAccountClient. For example, if you call sendUserOperation, it expects a fully formed user operation.
+ * It uses `useSyncExternalStore` to watch for any changes in the bundler client configuration and provides the updated bundler client. React hooks don’t handle their own state management directly, so they rely on external stores, like `useSyncExternalStore`, to manage state. useBundlerClient’s only job is to call the bundler JSON RPC methods directly; it does not do additional processing, unlike useSmartAccountClient. For example, if you call sendUserOperation, it expects a fully formed user operation.
  * It is an extension of [Viem’s Public Client](https://viem.sh/docs/clients/public) and provides access to public actions, talking to public RPC APIs like getBlock, eth_call, etc. It does not require an account as context.
  * Use cases: connecting with a EOA or checking for gas eligibility.
  *
+ * @returns {BundlerClient} The bundler client based on the current Alchemy account configuration. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/aa-sdk/core/src/client/bundlerClient.ts#L24)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useBundlerClient } from "@account-kit/react";
  *
  * const bundlerClient = useBundlerClient();
  * ```
- * @returns {BundlerClient} The bundler client based on the current Alchemy account configuration. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/aa-sdk/core/src/client/bundlerClient.ts#L24)
  */
 export const useBundlerClient = () => {
   const { config } = useAlchemyAccountContext();

--- a/account-kit/react/src/hooks/useBundlerClient.ts
+++ b/account-kit/react/src/hooks/useBundlerClient.ts
@@ -9,8 +9,8 @@ export type UseBundlerClientResult = ClientWithAlchemyMethods;
 
 /**
  * Custom [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useBundlerClient.ts) to get a bundler client using the Alchemy account context.
- * It uses `useSyncExternalStore` to watch for any changes in the bundler client configuration and provides the updated bundler client. React hooks don’t handle their own state management directly, so they rely on external stores, like `useSyncExternalStore`, to manage state. useBundlerClient’s only job is to call the bundler JSON RPC methods directly; it does not do additional processing, unlike useSmartAccountClient. For example, if you call sendUserOperation, it expects a fully formed user operation.
- * It is an extension of [Viem’s Public Client](https://viem.sh/docs/clients/public) and provides access to public actions, talking to public RPC APIs like getBlock, eth_call, etc. It does not require an account as context.
+ * It uses `useSyncExternalStore` to watch for any changes in the bundler client configuration and provides the updated bundler client. React hooks don’t handle their own state management directly, so they rely on external stores, like `useSyncExternalStore`, to manage state. `useBundlerClient`’s only job is to call the bundler JSON RPC methods directly; it does not do additional processing, unlike `useSmartAccountClient`. For example, if you call `sendUserOperation`, it expects a fully formed user operation.
+ * It is an extension of [Viem’s Public Client](https://viem.sh/docs/clients/public) and provides access to public actions, talking to public RPC APIs like `getBlock`, `eth_call`, etc. It does not require an account as context.
  * Use cases: connecting with a EOA or checking for gas eligibility.
  *
  * @returns {BundlerClient} The bundler client based on the current Alchemy account configuration. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/aa-sdk/core/src/client/bundlerClient.ts#L24)

--- a/account-kit/react/src/hooks/useChain.ts
+++ b/account-kit/react/src/hooks/useChain.ts
@@ -26,8 +26,12 @@ export interface UseChainResult {
  *
  * For switching chains, you can also use [createBundlerClient](https://accountkit.alchemy.com/reference/aa-sdk/core/functions/createBundlerClient#createbundlerclient) or [createSmartAccoutClient](https://accountkit.alchemy.com/reference/aa-sdk/core/functions/createSmartAccountClient) directly and create a different client for each chain. You would have to manage different clients, but you wouldn't have to wait for any hooks to complete and can run these queries in parallel. This way the chain set in the config that the smart account client and other hooks inherit is not also affected.
  *
+ * @param {UseChainParams} mutationArgs optional properties which contain mutation arg overrides. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useChain.ts#L14)
+ * @returns {UseChainResult} an object containing the current chain and a function to set the chain as well as loading state of setting the chain. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useChain.ts#L16)
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
+ * import React from 'react';
  * import { useChain } from "@account-kit/react";
  * // Assuming the chain sepolia is defined in your initial createConfig call
  * import { sepolia } from "@account-kit/infra";
@@ -43,9 +47,6 @@ export interface UseChainResult {
  *  );
  * }
  * ```
- *
- * @param {UseChainParams} mutationArgs optional properties which contain mutation arg overrides. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useChain.ts#L14)
- * @returns {UseChainResult} an object containing the current chain and a function to set the chain as well as loading state of setting the chain. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useChain.ts#L16)
  */
 export function useChain(mutationArgs?: UseChainParams): UseChainResult {
   const { config } = useAlchemyAccountContext();

--- a/account-kit/react/src/hooks/useClientActions.ts
+++ b/account-kit/react/src/hooks/useClientActions.ts
@@ -80,13 +80,23 @@ export type ClientActionParameters<
  * and await them in your UX. This is particularly useful for using Plugins
  * with Modular Accounts.
  *
+ * @param {UseClientActionsProps<TTransport, TChain, TActions>} args the hooks arguments highlighted below. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useClientActions.ts#L10)
+ * @param {SmartAccountClient} args.client the smart account client returned from useSmartAccountClient
+ * @param {object} args.actions the smart account client decorator you want to execute actions from
+ * @returns {UseClientActionsResult<TActions>} an object containing methods to execute the actions as well loading and error states [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useClientActions.ts#L21)
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
+ * import React from 'react';
+ * import { useSmartAccountClient } from "@account-kit/react";
+ * import { sessionKeyPluginActions } from "@account-kit/smart-contracts";
+ * import { useClientActions } from "@account-kit/react";
+ *
  * const Foo = () => {
  *  const { client } = useSmartAccountClient({ type: "MultiOwnerModularAccount" });
  *  const { executeAction } = useClientActions({
- *    client,
- *    pluginActions: sessionKeyPluginActions,
+ *    client: client,
+ *    actions: sessionKeyPluginActions,
  *  });
  *
  *  executeAction({
@@ -95,11 +105,6 @@ export type ClientActionParameters<
  *  });
  * };
  * ```
- *
- * @param {UseClientActionsProps<TTransport, TChain, TActions>} args the hooks arguments highlighted below. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useClientActions.ts#L10)
- * @param {SmartAccountClient} args.client the smart account client returned from useSmartAccountClient
- * @param {object} args.actions the smart account client decorator you want to execute actions from
- * @returns {UseClientActionsResult<TActions>} an object containing methods to execute the actions as well loading and error states [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useClientActions.ts#L21)
  */
 export function useClientActions<
   TTransport extends Transport = Transport,

--- a/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts
+++ b/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts
@@ -47,8 +47,12 @@ export type UseDropAndReplaceUserOperationResult<
 /**
  * Custom [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts) that handles the drop and replace user operation for a given client and mutation arguments.
  *
+ * @param {UseDropAndReplaceUserOperationArgs<TEntryPointVersion, TAccount>} config The configuration parameters including the client and other mutation arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts#L23)
+ * @returns {UseDropAndReplaceUserOperationResult<TEntryPointVersion, TAccount>} The result containing the mutation function, result data, loading state, and any error. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts#L30)
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
+ * import React from 'react';
  * import {
  *   useDropAndReplaceUserOperation,
  *   useSendUserOperation,
@@ -103,9 +107,6 @@ export type UseDropAndReplaceUserOperationResult<
  *   );
  * }
  * ```
- *
- * @param {UseDropAndReplaceUserOperationArgs<TEntryPointVersion, TAccount>} config The configuration parameters including the client and other mutation arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts#L23)
- * @returns {UseDropAndReplaceUserOperationResult<TEntryPointVersion, TAccount>} The result containing the mutation function, result data, loading state, and any error. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useDropAndReplaceUserOperation.ts#L30)
  */
 export function useDropAndReplaceUserOperation<
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount>,

--- a/account-kit/react/src/hooks/useExportAccount.ts
+++ b/account-kit/react/src/hooks/useExportAccount.ts
@@ -38,7 +38,7 @@ export type UseExportAccountResult = {
 };
 
 /**
- * A [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts) used to export the private key for an account. It returns the mutation functions to kick off the export process, as well as a component to render the account recovery details in an iframe.
+ * A [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts) use to export the private key for an account. It returns the mutation functions to kick off the export process, as well as a component to render the account recovery details in an iframe.
  * What is returned is dependent on what you used most recently used to authenticate. If your session was initiated with a passkey, then a private key is returned. Otherwise, a seed phrase.
  *
  * @example
@@ -59,11 +59,7 @@ export type UseExportAccountResult = {
  * ```
  *
  * @param {UseExportAccountMutationArgs} args Optional arguments for the mutation and export parameters. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L11)
-<<<<<<< HEAD
  * @returns {UseExportAccountResult} An object containing the export state, possible error, and the export account function and component. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L32)*
-=======
- * @returns {UseExportAccountResult} An object containing the export state, possible error, and the export account function and component. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L32)
->>>>>>> 796d0d71 (docs: updated account kit react hook docs)
  */
 export function useExportAccount(
   args?: UseExportAccountMutationArgs

--- a/account-kit/react/src/hooks/useExportAccount.ts
+++ b/account-kit/react/src/hooks/useExportAccount.ts
@@ -38,11 +38,14 @@ export type UseExportAccountResult = {
 };
 
 /**
- * A [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts) use to export the private key for an account. It returns the mutation functions to kick off the export process, as well as a component to render the account recovery details in an iframe.
+ * A [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts) used to export the private key for an account. It returns the mutation functions to kick off the export process, as well as a component to render the account recovery details in an iframe.
  * What is returned is dependent on what you used most recently used to authenticate. If your session was initiated with a passkey, then a private key is returned. Otherwise, a seed phrase.
  *
+ * @param {UseExportAccountMutationArgs} args Optional arguments for the mutation and export parameters. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L11)
+ * @returns {UseExportAccountResult} An object containing the export state, possible error, and the export account function and component. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L32)*
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useExportAccount } from "@account-kit/react";
  *
  * const {
@@ -57,9 +60,6 @@ export type UseExportAccountResult = {
  *  },
  * });
  * ```
- *
- * @param {UseExportAccountMutationArgs} args Optional arguments for the mutation and export parameters. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L11)
- * @returns {UseExportAccountResult} An object containing the export state, possible error, and the export account function and component. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L32)*
  */
 export function useExportAccount(
   args?: UseExportAccountMutationArgs

--- a/account-kit/react/src/hooks/useExportAccount.ts
+++ b/account-kit/react/src/hooks/useExportAccount.ts
@@ -59,7 +59,11 @@ export type UseExportAccountResult = {
  * ```
  *
  * @param {UseExportAccountMutationArgs} args Optional arguments for the mutation and export parameters. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L11)
+<<<<<<< HEAD
  * @returns {UseExportAccountResult} An object containing the export state, possible error, and the export account function and component. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L32)*
+=======
+ * @returns {UseExportAccountResult} An object containing the export state, possible error, and the export account function and component. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useExportAccount.ts#L32)
+>>>>>>> 796d0d71 (docs: updated account kit react hook docs)
  */
 export function useExportAccount(
   args?: UseExportAccountMutationArgs

--- a/account-kit/react/src/hooks/useLogout.ts
+++ b/account-kit/react/src/hooks/useLogout.ts
@@ -17,8 +17,11 @@ export type UseLogoutResult = {
 /**
  * Provides a [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useLogout.ts) to log out a user, disconnecting the signer and triggering the disconnectAsync function.
  *
+ * @param {UseLogoutMutationArgs} [mutationArgs] optional arguments to customize the mutation behavior
+ * @returns {UseLogoutResult} an object containing the logout function, a boolean indicating if logout is in progress, and any error encountered during logout
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useLogout } from "@account-kit/react";
  *
  * const { logout, isLoggingOut, error } = useLogout({
@@ -29,9 +32,6 @@ export type UseLogoutResult = {
  *  onError: (error) => console.error(error),
  * });
  * ```
- *
- * @param {UseLogoutMutationArgs} [mutationArgs] optional arguments to customize the mutation behavior
- * @returns {UseLogoutResult} an object containing the logout function, a boolean indicating if logout is in progress, and any error encountered during logout
  */
 export function useLogout(
   mutationArgs?: UseLogoutMutationArgs

--- a/account-kit/react/src/hooks/useSendUserOperation.ts
+++ b/account-kit/react/src/hooks/useSendUserOperation.ts
@@ -78,8 +78,12 @@ export type UseSendUserOperationResult<
  * You can also optionally wait for a user operation to be mined and get the transaction hash before returning using `waitForTx`.
  * Like any method that takes a smart account client, throws an error if client undefined or is signer not authenticated.
  *
+ * @param {UseSendUserOperationArgs<TEntryPointVersion, TAccount>} params the parameters for the hook including the client, a flag to wait for tx mining, and mutation args. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSendUserOperation.ts#L45)
+ * @returns {UseSendUserOperationResult<TEntryPointVersion, TAccount>} functions and state for sending UOs. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSendUserOperation.ts#L53)
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
+ * import React from 'react';
  * import {
  *   useSendUserOperation,
  *   useSmartAccountClient,
@@ -122,9 +126,6 @@ export type UseSendUserOperationResult<
  *   );
  * }
  * ```
- *
- * @param {UseSendUserOperationArgs<TEntryPointVersion, TAccount>} params the parameters for the hook including the client, a flag to wait for tx mining, and mutation args. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSendUserOperation.ts#L45)
- * @returns {UseSendUserOperationResult<TEntryPointVersion, TAccount>} functions and state for sending UOs. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSendUserOperation.ts#L53)
  */
 export function useSendUserOperation<
   TEntryPointVersion extends GetEntryPointFromAccount<TAccount>,

--- a/account-kit/react/src/hooks/useSignMessage.ts
+++ b/account-kit/react/src/hooks/useSignMessage.ts
@@ -49,8 +49,11 @@ export type UseSignMessageResult = {
  *
  * To reiterate, the signature that is returned must be verified against the account itself not the signer. The final structure of the signature is dictated by how the account does 1271 validation. You don’t want to be verifying in a different way than the way the account itself structures the signatures to be validated. For example LightAccount has three different ways to validate the account.
  *
+ * @param {UseSignMessageArgs} config The configuration arguments for the hook, including the client and additional mutation arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignMessage.ts#L25)
+ * @returns {UseSignMessageResult} An object containing methods and state for signing messages. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignMessage.ts#L29)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useSignMessage, useSmartAccountClient } from "@account-kit/react";
  *
  * const { client } = useSmartAccountClient({ type: "LightAccount" });
@@ -63,9 +66,6 @@ export type UseSignMessageResult = {
  *  onError: (error) => console.error(error),
  * });
  * ```
- *
- * @param {UseSignMessageArgs} config The configuration arguments for the hook, including the client and additional mutation arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignMessage.ts#L25)
- * @returns {UseSignMessageResult} An object containing methods and state for signing messages. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignMessage.ts#L29)
  */
 export function useSignMessage({
   client,

--- a/account-kit/react/src/hooks/useSignTypedData.ts
+++ b/account-kit/react/src/hooks/useSignTypedData.ts
@@ -43,8 +43,11 @@ export type UseSignTypedDataResult = {
  *
  * Uses `eth_signTypedData` to sign structured, typed data. Accepts typed, complex data structures as input. Like `useSignMessage`, this hook also handles deployed (1271) and undeployed accounts (6492).
  *
+ * @param {UseSignTypedDataArgs} args The arguments for the hook, including client and mutation-related arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignTypedData.ts#L24)
+ * @returns {UseSignTypedDataResult} An object containing methods and state related to the sign typed data mutation process. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignTypedData.ts#L28)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useSignTypedData, useSmartAccountClient } from "@account-kit/react";
  *
  * const { client } = useSmartAccountClient({ type: "LightAccount" });
@@ -57,9 +60,6 @@ export type UseSignTypedDataResult = {
  *  onError: (error) => console.error(error),
  * });
  * ```
- *
- * @param {UseSignTypedDataArgs} args The arguments for the hook, including client and mutation-related arguments. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignTypedData.ts#L24)
- * @returns {UseSignTypedDataResult} An object containing methods and state related to the sign typed data mutation process. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignTypedData.ts#L28)
  */
 export function useSignTypedData({
   client,

--- a/account-kit/react/src/hooks/useSigner.ts
+++ b/account-kit/react/src/hooks/useSigner.ts
@@ -7,16 +7,16 @@ import { useAlchemyAccountContext } from "../context.js";
 
 /**
  * [Hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSigner.ts) for accessing the current Alchemy signer within a React component. It uses a synchronous external store for updates.
- * This is a good use case if you want to use the signer as an EOA, giving you direct access to it. The signer returned from `usSigner` just does a `personal_sign` or `eth_signTypedData` without any additional logic, but a smart contract account might have additional logic for creating signatures for 1271 validation so `useSignMessage` or `useSignTypeData` instead.
+ * This is a good use case if you want to use the signer as an EOA, giving you direct access to it. The signer returned from `useSigner` just does a `personal_sign` or `eth_signTypedData` without any additional logic, but a smart contract account might have additional logic for creating signatures for 1271 validation so `useSignMessage` or `useSignTypeData` instead.
+ *
+ * @returns {AlchemyWebSigner | null} The current Alchemy signer or null if none is available. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/index.ts#L50)
  *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useSigner } from "@account-kit/react";
  *
  * const signer = useSigner();
  * ```
- *
- * @returns {AlchemyWebSigner | null} The current Alchemy signer or null if none is available. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/index.ts#L50)
  */
 export const useSigner = (): AlchemyWebSigner | null => {
   const { config } = useAlchemyAccountContext();

--- a/account-kit/react/src/hooks/useSigner.ts
+++ b/account-kit/react/src/hooks/useSigner.ts
@@ -7,7 +7,7 @@ import { useAlchemyAccountContext } from "../context.js";
 
 /**
  * [Hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSigner.ts) for accessing the current Alchemy signer within a React component. It uses a synchronous external store for updates.
- * This is a good use case if you want to use the signer as an EOA, giving you direct access to it. The signer returned from `useSigner` just does a `personal_sign` or `eth_signTypedData` without any additional logic, but a smart contract account might have additional logic for creating signatures for 1271 validation so `useSignMessage` or `useSignTypeData` instead.
+ * This is a good use case if you want to use the signer as an EOA, giving you direct access to it. The signer returned from `usSigner` just does a `personal_sign` or `eth_signTypedData` without any additional logic, but a smart contract account might have additional logic for creating signatures for 1271 validation so `useSignMessage` or `useSignTypeData` instead.
  *
  * @example
  * ```ts

--- a/account-kit/react/src/hooks/useSignerStatus.ts
+++ b/account-kit/react/src/hooks/useSignerStatus.ts
@@ -13,15 +13,15 @@ export type UseSignerStatusResult = SignerStatus;
 /**
  * [Hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSignerStatus.ts) to get the signer status, optionally using an override configuration, useful if you’re building your own login.
  *
+ * @param {AlchemyAccountContextProps} [override] optional configuration to override the default context. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/context.tsx#L26)
+ * @returns {UseSignerStatusResult} the current state of the signer. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/core/src/store/types.ts#L53)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useSignerStatus } from "@account-kit/react";
  *
  * const signerStatus = useSignerStatus();
  * ```
- *
- * @param {AlchemyAccountContextProps} [override] optional configuration to override the default context. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/context.tsx#L26)
- * @returns {UseSignerStatusResult} the current state of the signer. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/core/src/store/types.ts#L53)
  */
 export const useSignerStatus = (
   override?: AlchemyAccountContextProps

--- a/account-kit/react/src/hooks/useSmartAccountClient.ts
+++ b/account-kit/react/src/hooks/useSmartAccountClient.ts
@@ -41,18 +41,23 @@ export function useSmartAccountClient<
  *
  * If using with an EOA, Smart Account Client won’t throw an error, but the client itself will stay undefined forever. We recommend useBundlerClient instead when using an EOA. The EOA must also be connected or authenticated with a signer.
  *
+ * @param {UseSmartAccountClientProps} props The properties required to use the smart account client, including optional [account parameters](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/core/src/actions/createAccount.ts#L23), type, and additional client parameters. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSmartAccountClient.ts#L19)
+ * @returns {UseSmartAccountClientResult} An object containing the smart account client, the address, and a loading state. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSmartAccountClient.ts#L24)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useSmartAccountClient } from "@account-kit/react";
  *
  * const { client, address, isLoadingClient } = useSmartAccountClient({
  *  type: "LightAccount",
- *  accountParams: {...}, // optional [params](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/core/src/actions/createAccount.ts#L23) to further configure the account
+ *  accountParams: {
+ *    salt?: 1n,
+ *    factoryAddress?: '0x0000000000000000000000000000',
+ *    initCode?: "0x0",
+ *    accountAddress?: '0x0000000000000000000000000000'
+ *   }
  * });
  * ```
- *
- * @param {UseSmartAccountClientProps} props The properties required to use the smart account client, including account parameters, type, and additional client parameters. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSmartAccountClient.ts#L19)
- * @returns {UseSmartAccountClientResult} An object containing the smart account client, the address, and a loading state. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useSmartAccountClient.ts#L24)
  */
 export function useSmartAccountClient({
   accountParams,

--- a/account-kit/react/src/hooks/useUiConfig.tsx
+++ b/account-kit/react/src/hooks/useUiConfig.tsx
@@ -67,16 +67,16 @@ export function useUiConfig<T = UiConfigStore>(
  * A custom [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUiConfig.tsx) for accessing UI configuration from the `UiConfigContext`. Allows optional selection of specific parts of the UI config state using a selector function.
  * For editing and updating the underlying UI config on the fly.
  *
+ * @param {(state: UiConfigStore) => T} [selector] - An optional function to select specific parts of the UI config state. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUiConfig.tsx#L23)
+ * @returns {T} - The selected state passed through the selector function or the entire state if no selector is provided
+ * @throws Will throw an error if the `UiConfigContext` is not present in the component tree
+ *
  * @example
- * ```tsx
+ * ```tsx twoslash
  * import { useUiConfig } from "@account-kit/react";
  *
  * const { illustrationStyle, auth } = useUiConfig(({ illustrationStyle, auth }) => ({ illustrationStyle, auth }));
  * ```
- *
- * @param {(state: UiConfigStore) => T} [selector] - An optional function to select specific parts of the UI config state. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUiConfig.tsx#L23)
- * @returns {T} - The selected state passed through the selector function or the entire state if no selector is provided
- * @throws Will throw an error if the `UiConfigContext` is not present in the component tree
  */
 export function useUiConfig(
   selector?: (state: UiConfigStore) => UiConfigStore

--- a/account-kit/react/src/hooks/useUser.ts
+++ b/account-kit/react/src/hooks/useUser.ts
@@ -14,15 +14,19 @@ export type UseUserResult = (User & { type: "eoa" | "sca" }) | null;
  *
  * If using smart contract account, returns address of the signer. If only using smart account contracts then you can use [useSignerStatus](https://accountkit.alchemy.com/reference/account-kit/react/hooks/useSignerStatus#usesignerstatus) or [useAccount](https://accountkit.alchemy.com/reference/account-kit/react/hooks/useAccount#useaccount) to see if the account is defined.
  *
- * @example
- * ```ts
- * import { useUser } from "@account-kit/react";
- *
- * const user = useUser();
- * ```
- *
  * @returns {UseUserResult} The user information, including address, orgId, userId, and type. If the user is not connected, it returns null. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUser.ts#L9)
+ *
+ * @example
+ * ```ts twoslash
+ * import { useUser } from "@account-kit/react";
+ * import type { User } from "@account-kit/signer";
+ * type UseUserResult  = (User & { type: "eoa" | "sca" }) | null;
+ *
+ * const user : UseUserResult | null = useUser();
+ *
+ * ```
  */
+
 export const useUser = (): UseUserResult => {
   const { config } = useAlchemyAccountContext();
   const {

--- a/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts
+++ b/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts
@@ -31,8 +31,11 @@ export type UseWaitForUserOperationTransactionResult = {
 /**
  * Custom [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts) to wait for a user operation transaction and manage its state (pending, error, result).
  *
+ * @param {UseWaitForUserOperationTransactionArgs} config Configuration object containing the client. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts#L15)
+ * @returns {UseWaitForUserOperationTransactionResult} An object containing methods and state related to waiting for a user operation transaction. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts#L19)
+ *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { useWaitForUserOperationTransaction, useSmartAccountClient } from "@account-kit/react";
  *
  * const { client } = useSmartAccountClient({ type: "LightAccount" });
@@ -50,9 +53,6 @@ export type UseWaitForUserOperationTransactionResult = {
  *  onError: (error) => console.error(error),
  * });
  * ```
- *
- * @param {UseWaitForUserOperationTransactionArgs} config Configuration object containing the client. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts#L15)
- * @returns {UseWaitForUserOperationTransactionResult} An object containing methods and state related to waiting for a user operation transaction. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts#L19)
  */
 export function useWaitForUserOperationTransaction({
   client,


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the documentation of various hooks in the `@account-kit/react` library by adding detailed JSDoc comments, including return types, parameters, and examples for better clarity and usability.

### Detailed summary
- Improved JSDoc comments for multiple hooks, including `useAuthError`, `useAuthModal`, and `useSigner`.
- Added return types and parameter descriptions for hooks like `useLogout`, `useSignerStatus`, and `useUser`.
- Included usage examples with `twoslash` for better code demonstration.
- Enhanced clarity on optional parameters and return types for hooks such as `useExportAccount`, `useSendUserOperation`, and `useAuthenticate`.
- Updated documentation for `useClientActions` and `useBundlerClient` to clarify their functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->