### PR TITLE
feat: add defaults for useSmartAccountClient to ma v2

### DIFF
--- a/account-kit/react/src/hooks/useSmartAccountClient.ts
+++ b/account-kit/react/src/hooks/useSmartAccountClient.ts
@@ -18,8 +18,13 @@ import { useAlchemyAccountContext } from "../context.js";
 
 export type UseSmartAccountClientProps<
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SupportedAccountTypes = SupportedAccountTypes
-> = GetSmartAccountClientParams<TChain, TAccount>;
+  TAccount extends SupportedAccountTypes | undefined =
+    | SupportedAccountTypes
+    | undefined
+> = GetSmartAccountClientParams<
+  TChain,
+  TAccount extends undefined ? "ModularAccountV2" : TAccount
+>;
 
 export type UseSmartAccountClientResult<
   TChain extends Chain | undefined = Chain | undefined,
@@ -28,10 +33,15 @@ export type UseSmartAccountClientResult<
 
 export function useSmartAccountClient<
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SupportedAccountTypes = SupportedAccountTypes
+  TAccount extends SupportedAccountTypes | undefined =
+    | SupportedAccountTypes
+    | undefined
 >(
   args: UseSmartAccountClientProps<TChain, TAccount>
-): UseSmartAccountClientResult<TChain, SupportedAccount<TAccount>>;
+): UseSmartAccountClientResult<
+  TChain,
+  SupportedAccount<TAccount extends undefined ? "ModularAccountV2" : TAccount>
+>;
 
 /**
  * Uses the provided smart account client parameters to create or retrieve an existing smart account client, handling different types of accounts including LightAccount, MultiOwnerLightAccount, and MultiOwnerModularAccount.


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the type definitions in the `useSmartAccountClient` hook to allow for better flexibility with the `TAccount` type, enabling it to be `undefined` and adjusting the resulting types accordingly.

### Detailed summary
- Updated `TAccount` type to allow `undefined`.
- Adjusted `GetSmartAccountClientParams` to handle `TAccount` as `undefined`, defaulting to `"ModularAccountV2"`.
- Modified return type of `useSmartAccountClient` to reflect changes in `TAccount`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->