### PR TITLE
fix: make mode optional in useSmartAccountClient

### DIFF
--- a/account-kit/core/src/actions/createAccount.ts
+++ b/account-kit/core/src/actions/createAccount.ts
@@ -1,3 +1,4 @@
+import { type OptionalFields } from "@aa-sdk/core";
 import type { AlchemyWebSigner } from "@account-kit/signer";
 import {
   createLightAccount,
@@ -47,7 +48,10 @@ export type AccountConfig<TAccount extends SupportedAccountTypes> =
       >
     : TAccount extends "ModularAccountV2"
     ? OmitSignerTransportChain<
-        CreateModularAccountV2Params<Transport, AlchemyWebSigner>
+        OptionalFields<
+          CreateModularAccountV2Params<Transport, AlchemyWebSigner>,
+          "mode"
+        >
       >
     : never;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the type definition for `AccountConfig` to include optional fields for `CreateModularAccountV2Params`, specifically adding the `"mode"` field.

### Detailed summary
- Updated `AccountConfig` type definition.
- Changed `CreateModularAccountV2Params<Transport, AlchemyWebSigner>` to `OptionalFields<CreateModularAccountV2Params<Transport, AlchemyWebSigner>, "mode">`.
- This change allows the `"mode"` field to be optional in the `ModularAccountV2` context.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->