### PR TITLE
fix: make type really optional, add defaults for return type

### DIFF
--- a/account-kit/react/src/hooks/useSmartAccountClient.ts
+++ b/account-kit/react/src/hooks/useSmartAccountClient.ts
@@ -1,5 +1,5 @@
 "use client";
-
+import { type OptionalFields } from "@aa-sdk/core";
 import type {
   GetSmartAccountClientParams,
   GetSmartAccountClientResult,
@@ -21,9 +21,12 @@ export type UseSmartAccountClientProps<
   TAccount extends SupportedAccountTypes | undefined =
     | SupportedAccountTypes
     | undefined
-> = GetSmartAccountClientParams<
-  TChain,
-  TAccount extends undefined ? "ModularAccountV2" : TAccount
+> = OptionalFields<
+  GetSmartAccountClientParams<
+    TChain,
+    TAccount extends undefined ? "ModularAccountV2" : TAccount
+  >,
+  "type"
 >;
 
 export type UseSmartAccountClientResult<
@@ -33,9 +36,7 @@ export type UseSmartAccountClientResult<
 
 export function useSmartAccountClient<
   TChain extends Chain | undefined = Chain | undefined,
-  TAccount extends SupportedAccountTypes | undefined =
-    | SupportedAccountTypes
-    | undefined
+  TAccount extends SupportedAccountTypes | undefined = "ModularAccountV2"
 >(
   args: UseSmartAccountClientProps<TChain, TAccount>
 ): UseSmartAccountClientResult<
@@ -66,7 +67,7 @@ export function useSmartAccountClient<
  */
 export function useSmartAccountClient({
   accountParams,
-  type,
+  type = "ModularAccountV2",
   ...clientParams
 }: UseSmartAccountClientProps): UseSmartAccountClientResult {
   const {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `useSmartAccountClient` hook in the `account-kit/react/src/hooks/useSmartAccountClient.ts` file to improve type handling and default values for account types.

### Detailed summary
- Added `OptionalFields` to `GetSmartAccountClientParams`.
- Changed the default type of `TAccount` to `"ModularAccountV2"`.
- Updated the `type` parameter in the function signature to default to `"ModularAccountV2"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->