### PR TITLE
docs: adds mode and 7702 info to smart-contracts docs

### DIFF
--- a/site/pages/smart-contracts/modular-account-v2/getting-started.mdx
+++ b/site/pages/smart-contracts/modular-account-v2/getting-started.mdx
@@ -54,6 +54,13 @@ const accountClient = await createModularAccountV2Client({
 });
 ```
 
+:::tip[Choosing which mode to use]
+We currently offer two variants of Modular Account v2: `default` and `7702`.
+
+- (Recommended) `default` provides you with the cheapest, most flexible and advanced Smart Account
+- `7702` if you are looking for 7702 support, learn about how to set up and take adavantage of our EIP-7702 compliant account [here](#TODO/smart-contracts/upgrade-eoa-with-eip-7702)
+  :::
+
 Want to enable social login methods? Set up your [Alchemy Signer](/signer/quickstart).
 
 Alternatively, you can [bring a 3rd party signer](/third-party/signers) as the owner of your new account.

--- a/site/pages/smart-contracts/modular-account-v2/overview.mdx
+++ b/site/pages/smart-contracts/modular-account-v2/overview.mdx
@@ -51,3 +51,9 @@ Regardless of how feature-rich MAv2 is, it's all for nothing if it's not easy to
 Leveraging the standard's lack of ambiguity, aa-sdk can safely create high-level zero-cost abstractions, which translate down to RPC calls exactly how you expect them to. No more fighting with your tools.
 
 The SDK is designed from the ground up to get out of your way so you can focus on what matters-- building the best smart wallet experience for your app!
+
+## EIP-7702 support
+
+EIP-7702 is an upcoming Ethereum upgrade set to launch in the coming months as part of the Pectra hardfork. Specifically, EIP-7702 enables Externally Owned Accounts (EOAs) to use smart contract account features.
+
+You can create an EIP-7702 compliant version of an MAv2 account, learn how to [here](#TODO/smart-contracts/upgrade-eoa-with-eip-7702)


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for EIP-7702 in the `Modular Account v2` documentation, detailing the upcoming Ethereum upgrade and its implications for Externally Owned Accounts (EOAs). It also provides guidance on choosing between different account modes.

### Detailed summary
- Added a new section titled `EIP-7702 support` in `overview.mdx` explaining its features and compliance.
- Included a link for creating an EIP-7702 compliant version of an MAv2 account.
- Updated `getting-started.mdx` with a tip on choosing between `default` and `7702` modes for Modular Account v2.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->