### PR TITLE
fix: only reconnect accounts for active chain during rehydration

### DIFF
--- a/account-kit/core/src/hydrate.ts
+++ b/account-kit/core/src/hydrate.ts
@@ -110,25 +110,27 @@ const hydrateAccountState = (
     ([, cnx]) => cnx.chain
   );
   const initialState = createDefaultAccountState(chains);
+  const activeChainId = config.store.getState().chain.id;
 
   return Object.entries(accountConfigs).reduce((acc, [chainKey, config]) => {
     const chainId = Number(chainKey);
+    const isActiveChain = chainId === activeChainId;
+    const shouldReconnect = shouldReconnectAccounts && isActiveChain;
     acc[chainId] = {
       LightAccount:
-        config.LightAccount?.accountAddress && shouldReconnectAccounts
+        shouldReconnect && config.LightAccount?.accountAddress
           ? reconnectingState(config.LightAccount.accountAddress)
           : defaultAccountState(),
       MultiOwnerModularAccount:
-        config.MultiOwnerModularAccount?.accountAddress &&
-        shouldReconnectAccounts
+        shouldReconnect && config.MultiOwnerModularAccount?.accountAddress
           ? reconnectingState(config.MultiOwnerModularAccount.accountAddress)
           : defaultAccountState(),
       MultiOwnerLightAccount:
-        config.MultiOwnerLightAccount?.accountAddress && shouldReconnectAccounts
+        shouldReconnect && config.MultiOwnerLightAccount?.accountAddress
           ? reconnectingState(config.MultiOwnerLightAccount.accountAddress)
           : defaultAccountState(),
       ModularAccountV2:
-        config.ModularAccountV2?.accountAddress && shouldReconnectAccounts
+        shouldReconnect && config.ModularAccountV2?.accountAddress
           ? reconnectingState(config.ModularAccountV2.accountAddress)
           : defaultAccountState(),
     };


### PR DESCRIPTION
# Bug when switching chains after refreshing page

## Explanation
- When the page is refreshed, the store is rehydrated using the cookie data.
- The `hydrate` function calls `hydrateAccountState`, which reads all existing accounts from the store and sets them to "RECONNECTING" on **all chains**.
- The `hydrate` function then calls the `reconnect` function, which calls `createAccount` for each account. **But this only happens on the active chain**, so any other chain's accounts will get stuck in the "RECONNECTING" state but never actually reconnect.

## Solutions
- The easiest solution is to not set accounts to "RECONNECTING" if they are not on the active chain during hydration. We can just set them to "DISCONNECTED", then they will naturally reconnect if they are attempted to be used again.
- An alternative solution would be to alter the `createAccount` function to accept an option `chain` param instead of only being able to reconnect accounts on the active chain.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the account state management by introducing an `activeChainId` that determines if the current chain is active, affecting the reconnection logic for various account types.

### Detailed summary
- Added `activeChainId` to track the current active chain.
- Introduced `isActiveChain` to check if the current chain matches `activeChainId`.
- Updated the reconnection logic for `LightAccount`, `MultiOwnerModularAccount`, `MultiOwnerLightAccount`, and `ModularAccountV2` to consider `shouldReconnect` based on the active chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->