### PR TITLE
docs: updates react native docs to use createModularAccountV2Client

### DIFF
--- a/site/pages/react-native/using-smart-accounts/retry-user-operations.mdx
+++ b/site/pages/react-native/using-smart-accounts/retry-user-operations.mdx
@@ -15,8 +15,8 @@ import Snippet from "../../../shared/infra/drop-and-replace-description.mdx";
 import React, { useState, useEffect } from "react";
 import { Alert, View, Button } from "react-native";
 import {
-  createLightAccountClient,
-  LightAccount,
+  createModularAccountV2Client,
+  ModularAccountV2,
 } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { User } from "@account-kit/signer";
@@ -37,7 +37,7 @@ export default function MyComponent() {
   useEffect(() => {
     if (user) {
       // Create a smart account client for the authenticated user
-      createLightAccountClient({
+      createModularAccountV2Client({
         signer,
         chain: sepolia,
         transport: alchemy({ apiKey: "API_KEY" }),

--- a/site/pages/react-native/using-smart-accounts/send-user-operations.mdx
+++ b/site/pages/react-native/using-smart-accounts/send-user-operations.mdx
@@ -15,7 +15,7 @@ If you want to sponsor the gas for a user, see our [guide](/react-native/using-s
 ## Single user operation
 
 :::tip
-In the below example, we use `ModularAccountV2` as the underlying Smart Contract type. You can also use a different account type (see other options [here](/smart-contract/other-accounts)).
+In the below example, we use `ModularAccountV2` as the underlying Smart Contract type. You can also use a different account type (see other options [here](/smart-contracts/other-accounts/modular-account)).
 :::
 
 :::code-group

--- a/site/pages/react-native/using-smart-accounts/send-user-operations.mdx
+++ b/site/pages/react-native/using-smart-accounts/send-user-operations.mdx
@@ -7,7 +7,7 @@ description: Learn how to send user operations using Account Kit in a React Nati
 
 Once your users have been [authenticated](/react-native/signer/authenticating-users/authenticating-with-otp), you can start sending user operations! Account Kit makes it really easy to send user operations using React hooks.
 
-To send user operations, you need to first create a `SmartAccountClient` using the [`createLightAccountClient`](/reference/account-kit/smart-contracts/functions/createLightAccountClient) function.
+To send user operations, you need to first create a `SmartAccountClient` using the [`createModularAccountV2Client`](/reference/account-kit/smart-contracts/functions/createModularAccountV2Client) function.
 Once you have a `SmartAccountClient`, you can use the [`sendUserOperation`](/reference/aa-sdk/core/functions/sendUserOperation#senduseroperation) function to send user operations.
 
 If you want to sponsor the gas for a user, see our [guide](/react-native/using-smart-accounts/sponsor-gas).
@@ -15,8 +15,7 @@ If you want to sponsor the gas for a user, see our [guide](/react-native/using-s
 ## Single user operation
 
 :::tip
-In the below example, we use `LightAccount` as the underlying Smart Contract type. You can also use `MultiOwnerModularAccount` if you want to provide your users with an ERC-6900 compliant modular account,
-or you can use `MultiOwnerLightAccount` if you want to support an account with multiple owners.
+In the below example, we use `ModularAccountV2` as the underlying Smart Contract type. You can also use a different account type (see other options [here](/smart-contract/other-accounts)).
 :::
 
 :::code-group
@@ -26,8 +25,8 @@ import React, { useState, useEffect } from "react";
 import { Alert, View, Button } from "react-native";
 import { User } from "@account-kit/signer";
 import {
-  createLightAccountClient,
-  LightAccount,
+  createModularAccountV2Client,
+  ModularAccountV2,
 } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { SmartAccountClient } from "@aa-sdk/core";
@@ -48,7 +47,7 @@ export default function MyOpSenderComponent() {
   useEffect(() => {
     if (user) {
       // Create a light account client for the authenticated user
-      createLightAccountClient({
+      createModularAccountV2Client({
         signer,
         chain: sepolia,
         transport: alchemy({ apiKey: "YOUR_API_KEY" }),
@@ -109,8 +108,8 @@ import React, { useState, useEffect } from "react";
 import { Alert, View, Button } from "react-native";
 import { User } from "@account-kit/signer";
 import {
-  createLightAccountClient,
-  LightAccount,
+  createModularAccountV2Client,
+  ModularAccountV2,
 } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { SmartAccountClient } from "@aa-sdk/core";
@@ -131,7 +130,7 @@ export default function MyOpSenderComponent() {
   useEffect(() => {
     if (user) {
       // Create a light account client for the authenticated user
-      createLightAccountClient({
+      createModularAccountV2Client({
         signer,
         chain: sepolia,
         transport: alchemy({ apiKey: "YOUR_API_KEY" }),

--- a/site/pages/react-native/using-smart-accounts/sponsor-gas.mdx
+++ b/site/pages/react-native/using-smart-accounts/sponsor-gas.mdx
@@ -27,8 +27,8 @@ Now you can send a sponsored User Operation with the Policy ID.
 import React, { useState, useEffect } from "react";
 import { View, Button } from "react-native";
 import {
-  createLightAccountClient,
-  LightAccount,
+  createModularAccountV2Client,
+  ModularAccountV2,
 } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { User } from "@account-kit/signer";
@@ -49,7 +49,7 @@ export default function MyComponent() {
   useEffect(() => {
     if (user) {
       // Create a smart account client for the authenticated user with the policy ID
-      createLightAccountClient({
+      createModularAccountV2Client({
         signer,
         chain: sepolia,
         policyId: "YOUR_GAS_POLICY_ID", // [!code ++]


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the account client creation from `createLightAccountClient` to `createModularAccountV2Client` in various components, reflecting a shift to a newer modular account structure.

### Detailed summary
- Replaced `createLightAccountClient` with `createModularAccountV2Client` in multiple files.
- Updated references from `LightAccount` to `ModularAccountV2`.
- Adjusted documentation to reflect the new client and account type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->