### PR TITLE
chore: use arb sepolia for "default" session key demo

### DIFF
--- a/examples/ui-demo/src/components/small-cards/TransactionsCard.tsx
+++ b/examples/ui-demo/src/components/small-cards/TransactionsCard.tsx
@@ -7,14 +7,26 @@ import {
   UseRecurringTransactionReturn,
   useRecurringTransactions,
 } from "@/hooks/useRecurringTransactions";
+import { alchemy, arbitrumSepolia } from "@account-kit/infra";
+import { odyssey, splitOdysseyTransport } from "@/hooks/7702/transportSetup";
 
 export const TransactionsCardDefault = () => {
-  const recurringTxns = useRecurringTransactions({ mode: "default" });
+  const recurringTxns = useRecurringTransactions({
+    mode: "default",
+    chain: arbitrumSepolia,
+    transport: alchemy({
+      rpcUrl: "/api/rpc",
+    }),
+  });
   return <TransactionsCardInner {...recurringTxns} />;
 };
 
 export const TransactionsCard7702 = () => {
-  const recurringTxns = useRecurringTransactions({ mode: "7702" });
+  const recurringTxns = useRecurringTransactions({
+    mode: "7702",
+    chain: odyssey,
+    transport: splitOdysseyTransport,
+  });
   return <TransactionsCardInner {...recurringTxns} />;
 };
 

--- a/examples/ui-demo/src/hooks/useModularAccountV2Client.ts
+++ b/examples/ui-demo/src/hooks/useModularAccountV2Client.ts
@@ -56,7 +56,7 @@ export const useModularAccountV2Client = ({
     let isMounted = true;
 
     const init = async () => {
-      if (!signer || !isConnected) {
+      if (!signer || !isConnected || client) {
         return;
       }
 
@@ -114,6 +114,7 @@ export const useModularAccountV2Client = ({
   }, [
     accountAddress,
     chain,
+    client,
     entityId,
     isConnected,
     key,

--- a/examples/ui-demo/src/hooks/useRecurringTransactions.ts
+++ b/examples/ui-demo/src/hooks/useRecurringTransactions.ts
@@ -6,6 +6,7 @@ import {
   Hex,
   parseEther,
   getAbiItem,
+  Chain,
 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import {
@@ -22,8 +23,8 @@ import { DEMO_USDC_ADDRESS, SWAP_VENUE_ADDRESS } from "./7702/dca/constants";
 import { swapAbi } from "./7702/dca/abi/swap";
 import { erc20MintableAbi } from "./7702/dca/abi/erc20Mintable";
 import { genEntityId } from "./7702/genEntityId";
-import { odyssey, splitOdysseyTransport } from "./7702/transportSetup";
 import { SESSION_KEY_VALIDITY_TIME_SECONDS } from "./7702/constants";
+import { AlchemyTransport } from "@account-kit/infra";
 
 export type CardStatus = "initial" | "setup" | "active" | "done";
 
@@ -56,10 +57,10 @@ export interface UseRecurringTransactionReturn {
   handleTransactions: () => void;
 }
 
-export const useRecurringTransactions = ({
-  mode,
-}: {
+export const useRecurringTransactions = (clientOptions: {
   mode: "default" | "7702";
+  chain: Chain;
+  transport: AlchemyTransport;
 }): UseRecurringTransactionReturn => {
   const [transactions, setTransactions] =
     useState<TransactionType[]>(initialTransactions);
@@ -71,15 +72,11 @@ export const useRecurringTransactions = ({
   const [sessionKeyAdded, setSessionKeyAdded] = useState<boolean>(false);
 
   const { client, isLoadingClient } = useModularAccountV2Client({
-    mode,
-    chain: odyssey,
-    transport: splitOdysseyTransport,
+    ...clientOptions,
   });
 
   const { client: sessionKeyClient } = useModularAccountV2Client({
-    mode,
-    chain: odyssey,
-    transport: splitOdysseyTransport,
+    ...clientOptions,
     localKeyOverride: {
       key: localSessionKey,
       entityId: sessionKeyEntityId,
@@ -130,8 +127,9 @@ export const useRecurringTransactions = ({
     setTransactions((prev) => {
       const newState = [...prev];
       newState[transactionIndex].state = "complete";
-      newState[transactionIndex].externalLink = odyssey.blockExplorers
-        ? `${odyssey.blockExplorers?.default.url}/tx/${txnHash}`
+      newState[transactionIndex].externalLink = clientOptions.chain
+        .blockExplorers
+        ? `${clientOptions.chain.blockExplorers.default.url}/tx/${txnHash}`
         : undefined;
       return newState;
     });
@@ -192,7 +190,7 @@ export const useRecurringTransactions = ({
                 validationConfig: {
                   moduleAddress:
                     await getDefaultSingleSignerValidationModuleAddress(
-                      odyssey
+                      clientOptions.chain
                     ),
                   entityId: sessionKeyEntityId,
                   isGlobal: false,
@@ -232,7 +230,7 @@ export const useRecurringTransactions = ({
                         },
                       ],
                     },
-                    getDefaultAllowlistModuleAddress(odyssey)
+                    getDefaultAllowlistModuleAddress(clientOptions.chain)
                   ),
                   TimeRangeModule.buildHook(
                     {
@@ -242,7 +240,7 @@ export const useRecurringTransactions = ({
                         SESSION_KEY_VALIDITY_TIME_SECONDS,
                       validAfter: 0,
                     },
-                    getDefaultTimeRangeModuleAddress(odyssey)
+                    getDefaultTimeRangeModuleAddress(clientOptions.chain)
                   ),
                 ],
               }),

--- a/examples/ui-demo/src/hooks/useRecurringTransactions.ts
+++ b/examples/ui-demo/src/hooks/useRecurringTransactions.ts
@@ -6,7 +6,7 @@ import {
   Hex,
   parseEther,
   getAbiItem,
-  Chain,
+  type Chain,
 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `useRecurringTransactions` hook and the `TransactionsCard` components to support varying `chain` and `transport` options, improving flexibility and integration with different blockchain environments.

### Detailed summary
- Updated the `init` function to include `client` in the connection check.
- Modified `TransactionsCardDefault` to accept `chain` and `transport` parameters.
- Modified `TransactionsCard7702` to accept `chain` and `transport` parameters.
- Updated `useRecurringTransactions` to accept `chain` and `transport` as part of `clientOptions`.
- Replaced hardcoded `odyssey` with `clientOptions.chain` in transaction handling and validation calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->