### PR TITLE
fix: update 404 link in foundry.toml

### DIFF
--- a/examples/contracts/DAAppNFT/foundry.toml
+++ b/examples/contracts/DAAppNFT/foundry.toml
@@ -5,4 +5,4 @@ libs = ['lib']
 remappings = ['ds-test/=lib/ds-test/src/']
 solc = "0.8.10"
 
-# See more config options https://github.com/gakonst/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
## Changes  
I fixed an outdated link in `foundry.toml`:  
  - **Old:** `https://github.com/gakonst/foundry/tree/master/config`  
  - **New:** `https://github.com/foundry-rs/foundry/tree/master/crates/config`

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation link in the `foundry.toml` file for the `DAAppNFT` project to point to the correct repository for configuration options.

### Detailed summary
- Changed the documentation link from `https://github.com/gakonst/foundry/tree/master/config` to `https://github.com/foundry-rs/foundry/tree/master/crates/config` in `examples/contracts/DAAppNFT/foundry.toml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->