### PR TITLE
fix: fb mobile auth

### DIFF
--- a/account-kit/signer/src/client/base.ts
+++ b/account-kit/signer/src/client/base.ts
@@ -596,6 +596,8 @@ export abstract class BaseSignerClient<TExportWalletParams = unknown> {
       prompt: "select_account",
       client_id: clientId,
       nonce,
+      // Fixes Facebook mobile login so that `window.opener` doesn't get nullified.
+      ...(authProvider.id === "facebook" ? { sdk: "joey" } : {}),
     };
     if (claims) {
       params.claims = claims;

--- a/account-kit/signer/src/client/base.ts
+++ b/account-kit/signer/src/client/base.ts
@@ -597,7 +597,9 @@ export abstract class BaseSignerClient<TExportWalletParams = unknown> {
       client_id: clientId,
       nonce,
       // Fixes Facebook mobile login so that `window.opener` doesn't get nullified.
-      ...(authProvider.id === "facebook" ? { sdk: "joey" } : {}),
+      ...(mode === "popup" && authProvider.id === "facebook"
+        ? { sdk: "joey" }
+        : {}),
     };
     if (claims) {
       params.claims = claims;


### PR DESCRIPTION

![Simulator Screen Recording - iPhone 16 Plus - 2025-02-27 at 11 35 25](https://github.com/user-attachments/assets/ab529d3c-9447-4ed7-8e5c-993b0b34adb0)


# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the Facebook mobile login issue by ensuring that `window.opener` remains intact when using the popup mode for authentication.

### Detailed summary
- Added a comment explaining the fix for Facebook mobile login regarding `window.opener`.
- Introduced a conditional object that adds `{ sdk: "joey" }` when the `mode` is "popup" and the `authProvider.id` is "facebook".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->