### PR TITLE
feat: improve call efficiency by removing execute wrapper for calls to the account

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/actions/install-validation/installValidation.ts
+++ b/account-kit/smart-contracts/src/ma-v2/actions/install-validation/installValidation.ts
@@ -219,11 +219,7 @@ export const installValidationActions: <
         account,
       });
 
-      return client.sendUserOperation({
-        uo: callData,
-        account,
-        overrides,
-      });
+      return client.sendUserOperation({ uo: callData, overrides });
     },
 
     uninstallValidation: async ({
@@ -242,11 +238,7 @@ export const installValidationActions: <
         account,
       });
 
-      return client.sendUserOperation({
-        uo: callData,
-        account,
-        overrides,
-      });
+      return client.sendUserOperation({ uo: callData, overrides });
     },
   };
 };


### PR DESCRIPTION
Currently, all calls go through `sendUserOperation` that turns the call into an `execute`. This results in a redundant wrapping when calls are made to the account directly. We change `encodeExecute` thats used in `sendUserOperation` to format the calls to not add the wrapping when the call target is the account


# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `sendUserOperation` function call in the `installValidation` method by removing the `account` parameter from the request.

### Detailed summary
- Removed the `account` parameter from the `client.sendUserOperation` call in the `installValidation` method.
- Kept the `uo` and `overrides` parameters in the `sendUserOperation` call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->