### PR TITLE
fix: disconnect signer when session expires

### DIFF
--- a/account-kit/signer/src/session/manager.ts
+++ b/account-kit/signer/src/session/manager.ts
@@ -189,6 +189,7 @@ export class SessionManager {
      * We should revisit this later
      */
     if (session.expirationDateMs < Date.now()) {
+      this.client.disconnect();
       this.clearSession();
       return null;
     }
@@ -319,6 +320,7 @@ export class SessionManager {
     }
 
     this.clearSessionHandle = setTimeout(() => {
+      this.client.disconnect();
       this.clearSession();
     }, Math.min(session.expirationDateMs - Date.now(), Math.pow(2, 31) - 1));
   };

--- a/account-kit/signer/src/session/manager.ts
+++ b/account-kit/signer/src/session/manager.ts
@@ -140,6 +140,7 @@ export class SessionManager {
 
   public clearSession = () => {
     this.store.setState({ session: null });
+    localStorage.removeItem(`${this.sessionKey}:temporary`);
 
     if (this.clearSessionHandle) {
       clearTimeout(this.clearSessionHandle);


### PR DESCRIPTION
When a user manually logs out, `disconnect` is called on the AlchemyWebSigner, which causes the signer client itself to disconnect. This also emits an event which the session manager receives and clears the session.

If a user doesn't manually log out, but their session expires, the session manager handles clearing the session properly. But the underlying client still has the user connected. So if you try to login again as a different user, the original user is still on the client. (You can easily reproduce this by setting your session config to expire in ~30 sec, logging in as one user, waiting for the sesion to expire, then logged in as a new user. Upon doing this, the first user's username is still displayed in the demo app.)

If we call `disconnect` on the underlying client when the session expires, this issue is solved.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `SessionManager` class by ensuring that the client disconnects when a session is cleared or expires.

### Detailed summary
- Added `localStorage.removeItem(`${this.sessionKey}:temporary`)` in the `clearSession` method to remove temporary session data.
- Called `this.client.disconnect()` in the `clearSession` method when a session is expired.
- Added `this.client.disconnect()` in the timeout function for session expiration handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->