### PR TITLE
fix: add a check to migrate store versions

### DIFF
--- a/account-kit/core/src/store/store.test.ts
+++ b/account-kit/core/src/store/store.test.ts
@@ -1,8 +1,13 @@
-import { alchemy, arbitrumSepolia, sepolia } from "@account-kit/infra";
+import {
+  alchemy,
+  arbitrumSepolia,
+  baseSepolia,
+  sepolia,
+} from "@account-kit/infra";
 import { getAlchemyTransport } from "../actions/getAlchemyTransport.js";
 import { setChain } from "../actions/setChain.js";
 import { createConfig } from "../createConfig.js";
-import { createDefaultAccountState } from "./store.js";
+import { createDefaultAccountState, STORAGE_VERSION } from "./store.js";
 import { DEFAULT_STORAGE_KEY } from "./types.js";
 
 describe("createConfig tests", () => {
@@ -43,6 +48,352 @@ describe("createConfig tests", () => {
           "rpcUrl": "/api/arbitrumSepolia",
         }
       `);
+  });
+
+  it("should overwrite the state if the config changed (chain removed)", async () => {
+    await givenConfig();
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            421614,
+            {
+              "chain": {
+                "id": 421614,
+              },
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/arbitrumSepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+
+    const config2 = createConfig({
+      chain: sepolia,
+      chains: [
+        {
+          chain: sepolia,
+          transport: alchemy({ rpcUrl: "/api/sepolia" }),
+          policyId: "test-policy-id",
+        },
+      ],
+      signerConnection: { rpcUrl: "/api/signer" },
+      storage: () => localStorage,
+    });
+
+    await config2.store.persist.rehydrate();
+    config2.store.setState({
+      accounts: createDefaultAccountState([sepolia, arbitrumSepolia]),
+    });
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+  });
+
+  it("should overwrite the state if the config changed (policyId changed)", async () => {
+    await givenConfig();
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            421614,
+            {
+              "chain": {
+                "id": 421614,
+              },
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/arbitrumSepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+
+    const config2 = createConfig({
+      chain: sepolia,
+      chains: [
+        {
+          chain: sepolia,
+          transport: alchemy({ rpcUrl: "/api/sepolia" }),
+          policyId: "test-policy-id2",
+        },
+        {
+          chain: arbitrumSepolia,
+          transport: alchemy({ rpcUrl: "/api/arbitrumSepolia" }),
+        },
+      ],
+      signerConnection: { rpcUrl: "/api/signer" },
+      storage: () => localStorage,
+    });
+
+    await config2.store.persist.rehydrate();
+    config2.store.setState({
+      accounts: createDefaultAccountState([sepolia, arbitrumSepolia]),
+    });
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id2",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            421614,
+            {
+              "chain": {
+                "id": 421614,
+              },
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/arbitrumSepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+  });
+
+  it("should overwrite the state if the config changed (chain swapped out)", async () => {
+    await givenConfig();
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            421614,
+            {
+              "chain": {
+                "id": 421614,
+              },
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/arbitrumSepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+
+    const config2 = createConfig({
+      chain: sepolia,
+      chains: [
+        {
+          chain: sepolia,
+          transport: alchemy({ rpcUrl: "/api/sepolia" }),
+          policyId: "test-policy-id",
+        },
+        {
+          chain: baseSepolia,
+          // this isn't a typo, I'm testing the chain swap out
+          transport: alchemy({ rpcUrl: "/api/arbitrumSepolia" }),
+        },
+      ],
+      signerConnection: { rpcUrl: "/api/signer" },
+      storage: () => localStorage,
+    });
+
+    await config2.store.persist.rehydrate();
+    config2.store.setState({
+      accounts: createDefaultAccountState([sepolia, arbitrumSepolia]),
+    });
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            84532,
+            {
+              "chain": {
+                "id": 84532,
+              },
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/arbitrumSepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+  });
+
+  it("should overwrite the state if the config changed (transport changed out)", async () => {
+    await givenConfig();
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            421614,
+            {
+              "chain": {
+                "id": 421614,
+              },
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/arbitrumSepolia",
+              },
+            },
+          ],
+        ],
+      }
+    `);
+
+    const config2 = createConfig({
+      chain: sepolia,
+      chains: [
+        {
+          chain: sepolia,
+          transport: alchemy({ rpcUrl: "/api/sepolia" }),
+          policyId: "test-policy-id",
+        },
+        {
+          chain: arbitrumSepolia,
+          // this isn't a typo, I'm testing the chain swap out
+          transport: alchemy({ apiKey: "test-api-key" }),
+        },
+      ],
+      signerConnection: { rpcUrl: "/api/signer" },
+      storage: () => localStorage,
+    });
+
+    await config2.store.persist.rehydrate();
+    config2.store.setState({
+      accounts: createDefaultAccountState([sepolia, arbitrumSepolia]),
+    });
+    expect(getStorageItem("connections")).toMatchInlineSnapshot(`
+      {
+        "__type": "Map",
+        "value": [
+          [
+            11155111,
+            {
+              "chain": {
+                "id": 11155111,
+              },
+              "policyId": "test-policy-id",
+              "transport": {
+                "__type": "Transport",
+                "rpcUrl": "/api/sepolia",
+              },
+            },
+          ],
+          [
+            421614,
+            {
+              "chain": {
+                "id": 421614,
+              },
+              "transport": {
+                "__type": "Transport",
+                "apiKey": "test-api-key",
+              },
+            },
+          ],
+        ],
+      }
+    `);
   });
 
   it("should correctly serialize the state to storage", async () => {
@@ -104,7 +455,7 @@ describe("createConfig tests", () => {
               "status": "INITIALIZING",
             },
           },
-          "version": 13,
+          "version": ${STORAGE_VERSION},
         }
       `);
   });
@@ -173,7 +524,7 @@ describe("createConfig tests", () => {
               "status": "INITIALIZING",
             },
           },
-          "version": 13,
+          "version": ${STORAGE_VERSION},
         }
       `);
   });

--- a/account-kit/core/src/store/store.ts
+++ b/account-kit/core/src/store/store.ts
@@ -26,6 +26,8 @@ import {
   type StoreState,
 } from "./types.js";
 
+export const STORAGE_VERSION = 14;
+
 export const createAccountKitStore = (
   params: CreateAccountKitStoreParams
 ): Store => {
@@ -78,6 +80,13 @@ export const createAccountKitStore = (
                 return storeReviver(key, value);
               },
             }),
+            migrate: (persisted, version) => {
+              if (version < STORAGE_VERSION) {
+                return createInitialStoreState(params);
+              }
+
+              return persisted as StoreState;
+            },
             merge: (persisted, current) => {
               const persistedState = persisted as StoreState;
               if (persistedState.chain == null) {
@@ -86,6 +95,22 @@ export const createAccountKitStore = (
 
               const connectionsMap = createConnectionsMap(connections);
               if (!connectionsMap.has(persistedState.chain.id)) {
+                return createInitialStoreState(params);
+              }
+
+              // simple check to ensure the same chains are present
+              if (persistedState.connections.size !== connectionsMap.size) {
+                return createInitialStoreState(params);
+              }
+
+              // check if all of the connections in the config match the persisted connections
+              if (
+                !connections.every(
+                  (c) =>
+                    persistedState.connections.has(c.chain.id) &&
+                    deepEquals(persistedState.connections.get(c.chain.id), c)
+                )
+              ) {
                 return createInitialStoreState(params);
               }
 
@@ -107,9 +132,11 @@ export const createAccountKitStore = (
               };
             },
             skipHydration: ssr,
-            partialize: ({ signer, accounts, ...writeableState }) =>
-              writeableState,
-            version: 13,
+            partialize: (state) => {
+              const { signer, accounts, ...writeableState } = state;
+              return writeableState;
+            },
+            version: STORAGE_VERSION,
           })
         : () => createInitialStoreState(params)
     )
@@ -338,4 +365,18 @@ export const createEmptySmartAccountClientState = (chains: Chain[]) => {
 
     return acc;
   }, {} as StoreState["smartAccountClients"]);
+};
+
+const deepEquals = (obj1: any, obj2: any) => {
+  if (typeof obj1 !== typeof obj2) return false;
+  if (typeof obj1 !== "object") return obj1 === obj2;
+  if (obj1 === null && obj2 === null) return true;
+  if (obj1 === null || obj2 === null) return false;
+  if (obj1.length !== obj2.length) return false;
+
+  for (const key in obj1) {
+    if (!deepEquals(obj1[key], obj2[key])) return false;
+  }
+
+  return true;
 };


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a migration strategy for the `createAccountKitStore` function, updates the storage version, and enhances state management by adding checks for connection consistency. It also adds tests to verify behavior with configuration changes.

### Detailed summary
- Added `STORAGE_VERSION` constant set to 14.
- Implemented a `migrate` function to handle store state migration.
- Enhanced `merge` function to validate connections and ensure consistency.
- Updated `partialize` function to use the new storage version.
- Added a `deepEquals` utility function for object comparison.
- Expanded tests in `store.test.ts` to cover various configuration change scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->