### PR TITLE
feat: add support for email mode toggling

### DIFF
--- a/account-kit/react/src/components/auth/types.ts
+++ b/account-kit/react/src/components/auth/types.ts
@@ -5,11 +5,13 @@ import type {
 import type { WalletConnectParameters } from "wagmi/connectors";
 import { capitalize } from "../../utils.js";
 
+export type EmailMode = "magicLink" | "otp";
+
 export type AuthType =
   | {
       // TODO: this should support setting redirectParams which will be added to the email redirect
       type: "email";
-      emailMode?: "magicLink" | "otp";
+      emailMode?: EmailMode;
       hideButton?: boolean;
       buttonLabel?: string;
       placeholder?: string;

--- a/examples/ui-demo/src/app/config.tsx
+++ b/examples/ui-demo/src/app/config.tsx
@@ -1,7 +1,7 @@
 import { AuthCardHeader } from "@/components/shared/AuthCardHeader";
 import { odyssey, splitOdysseyTransport } from "@/hooks/7702/transportSetup";
 import { alchemy, arbitrumSepolia } from "@account-kit/infra";
-import { cookieStorage, createConfig } from "@account-kit/react";
+import { cookieStorage, createConfig, EmailMode } from "@account-kit/react";
 import { AccountKitTheme } from "@account-kit/react/tailwind";
 import { type KnownAuthProvider } from "@account-kit/signer";
 import { QueryClient } from "@tanstack/react-query";
@@ -10,6 +10,7 @@ import { walletConnect } from "wagmi/connectors";
 export type Config = {
   auth: {
     showEmail: boolean;
+    emailMode: EmailMode;
     showExternalWallets: boolean;
     showPasskey: boolean;
     addPasskey: boolean;
@@ -49,6 +50,7 @@ export type AccountMode = "default" | "7702";
 export const DEFAULT_CONFIG: Config = {
   auth: {
     showEmail: true,
+    emailMode: "otp",
     showExternalWallets: true,
     showPasskey: true,
     addPasskey: false,
@@ -107,7 +109,7 @@ export const alchemyConfig = () =>
       illustrationStyle: DEFAULT_CONFIG.ui.illustrationStyle,
       auth: {
         sections: [
-          [{ type: "email", emailMode: "otp" }],
+          [{ type: "email", emailMode: DEFAULT_CONFIG.auth.emailMode }],
           [
             { type: "passkey" },
             { type: "social", authProviderId: "google", mode: "popup" },

--- a/examples/ui-demo/src/app/sections.ts
+++ b/examples/ui-demo/src/app/sections.ts
@@ -12,6 +12,7 @@ export function getSectionsForConfig(
 ): AuthType[][] {
   const {
     showEmail,
+    emailMode,
     showPasskey,
     showOAuth,
     oAuthMethods,
@@ -20,7 +21,7 @@ export function getSectionsForConfig(
   const sections: AuthType[][] = [];
   const midSection: AuthType[] = [];
   if (showEmail) {
-    sections.push([{ type: "email", emailMode: "otp" }]);
+    sections.push([{ type: "email", emailMode }]);
   }
   if (showPasskey) {
     midSection.push({ type: "passkey" });

--- a/examples/ui-demo/src/components/configuration/Authentication.tsx
+++ b/examples/ui-demo/src/components/configuration/Authentication.tsx
@@ -14,17 +14,26 @@ import { WalletIcon } from "../icons/wallet";
 import ExternalLink from "../shared/ExternalLink";
 import { Switch } from "../ui/switch";
 import { links } from "@/utils/links";
+import { EmailModeSwitch } from "../shared/EmailModeSwitch";
 
 export const Authentication = ({ className }: { className?: string }) => {
   const { auth, setAuth } = useConfigStore(({ auth, setAuth }) => ({
     auth,
     setAuth,
   }));
-  const setEmailAuth = (active: boolean) => {
+  const setEmailActive = (active: boolean) => {
     setAuth({ showEmail: active });
     Metrics.trackEvent({
       name: "authentication_toggled",
       data: { auth_type: "email", enabled: active },
+    });
+  };
+  const toggleEmailMode = () => {
+    const newMode = auth.emailMode === "otp" ? "magicLink" : "otp";
+    setAuth({ emailMode: newMode });
+    Metrics.trackEvent({
+      name: "email_mode_changed",
+      data: { mode: newMode },
     });
   };
 
@@ -140,7 +149,14 @@ export const Authentication = ({ className }: { className?: string }) => {
             icon={<MailIcon />}
             name="Email"
             active={auth.showEmail}
-            setActive={setEmailAuth}
+            setActive={setEmailActive}
+            iconClassName="mt-[2px] self-start"
+            details={
+              <EmailModeSwitch
+                checked={auth.emailMode === "magicLink"}
+                onCheckedChange={toggleEmailMode}
+              />
+            }
           />
           <AuthMethod
             icon={<SocialIcon />}

--- a/examples/ui-demo/src/components/shared/EmailModeSwitch.tsx
+++ b/examples/ui-demo/src/components/shared/EmailModeSwitch.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Root, Thumb } from "@radix-ui/react-switch";
+import { forwardRef, ElementRef, ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+const selectedStyles = "text-[#475569]";
+const unselectedStyles = "text-[#020617]";
+
+const EmailModeSwitch = forwardRef<
+  ElementRef<typeof Root>,
+  ComponentPropsWithoutRef<typeof Root>
+>(({ className, checked, ...props }, ref) => (
+  <Root
+    className={cn(
+      "relative peer inline-flex w-full h-9 shrink-0 cursor-pointer items-center rounded-[8px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 bg-active border border-[#94A3B8]",
+      className
+    )}
+    checked={checked}
+    {...props}
+    ref={ref}
+  >
+    <Thumb
+      className={cn(
+        "pointer-events-none block h-full w-2/4 rounded-[7px] bg-background ring-0 transition-transform data-[state=checked]:translate-x-[100%] data-[state=unchecked]:translate-x-[0%] border border-active"
+      )}
+    ></Thumb>
+    <div className="absolute flex text-xs items-center z-10 justify-between bg-transparent w-full">
+      <div className="flex items-center justify-center flex-1 basis-0">
+        <p
+          className={`${
+            checked ? selectedStyles : unselectedStyles
+          } font-normal`}
+        >
+          One Time Password (OTP)
+        </p>
+      </div>
+      <div className="flex items-center justify-center flex-1 basis-0">
+        <p
+          className={`${
+            checked ? unselectedStyles : selectedStyles
+          } font-normal`}
+        >
+          Magic Link
+        </p>
+      </div>
+    </div>
+  </Root>
+));
+EmailModeSwitch.displayName = Root.displayName;
+
+export { EmailModeSwitch };

--- a/examples/ui-demo/src/metrics.ts
+++ b/examples/ui-demo/src/metrics.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@account-kit/logging";
+import { EmailMode } from "@account-kit/react";
 
 type DemoEvents = [
   {
@@ -9,6 +10,12 @@ type DemoEvents = [
     EventData: {
       auth_type: string;
       enabled: boolean;
+    };
+  },
+  {
+    EventName: "email_mode_changed";
+    EventData: {
+      mode: EmailMode;
     };
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `EmailMode` type and refines the handling of email authentication modes in the application. It enhances the configuration and UI components to allow toggling between "magicLink" and "otp" modes.

### Detailed summary
- Added `EmailMode` type with values "magicLink" and "otp".
- Updated `DemoEvents` to include an event for `email_mode_changed`.
- Modified `AuthType` to use `EmailMode` instead of string literals.
- Adjusted sections in `getSectionsForConfig` to use dynamic `emailMode`.
- Updated `DEFAULT_CONFIG` to initialize `emailMode` to "otp".
- Refined `Authentication` component to include `toggleEmailMode` for switching modes.
- Created `EmailModeSwitch` component for UI toggling between modes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->