### PR TITLE
fix: invalidate state if the local signer config changes

### DIFF
--- a/account-kit/core/src/store/store.test.ts
+++ b/account-kit/core/src/store/store.test.ts
@@ -305,6 +305,53 @@ describe("createConfig tests", () => {
     `);
   });
 
+  it("should overwrite the state if the config changed (signer config)", async () => {
+    await givenConfig();
+    expect(getStorageItem("config")).toMatchInlineSnapshot(`
+      {
+        "client": {
+          "connection": {
+            "rpcUrl": "/api/signer",
+          },
+        },
+      }
+    `);
+
+    const config2 = createConfig({
+      chain: sepolia,
+      chains: [
+        {
+          chain: sepolia,
+          transport: alchemy({ rpcUrl: "/api/sepolia" }),
+          policyId: "test-policy-id",
+        },
+        {
+          chain: baseSepolia,
+          // this isn't a typo, I'm testing the chain swap out
+          transport: alchemy({ rpcUrl: "/api/arbitrumSepolia" }),
+        },
+      ],
+      signerConnection: { rpcUrl: "/api/signer" },
+      oauthCallbackUrl: "https://example.com",
+      storage: () => localStorage,
+    });
+
+    await config2.store.persist.rehydrate();
+    config2.store.setState({
+      accounts: createDefaultAccountState([sepolia, arbitrumSepolia]),
+    });
+    expect(getStorageItem("config")).toMatchInlineSnapshot(`
+      {
+        "client": {
+          "connection": {
+            "rpcUrl": "/api/signer",
+          },
+          "oauthCallbackUrl": "https://example.com",
+        },
+      }
+    `);
+  });
+
   it("should overwrite the state if the config changed (transport changed out)", async () => {
     await givenConfig();
     expect(getStorageItem("connections")).toMatchInlineSnapshot(`

--- a/account-kit/core/src/store/store.ts
+++ b/account-kit/core/src/store/store.ts
@@ -114,6 +114,11 @@ export const createAccountKitStore = (
                 return createInitialStoreState(params);
               }
 
+              // handle the case where the signer config changes
+              if (!deepEquals(current.config, persistedState.config)) {
+                return createInitialStoreState(params);
+              }
+
               return {
                 // this is the default merge behavior
                 ...current,


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling changes in the signer configuration for the store state management in the `account-kit`. It introduces logic to reset the store state when the configuration changes and adds corresponding tests to verify this behavior.

### Detailed summary
- Added logic to reset the store state if the `signer` configuration changes.
- Implemented a test case to check state overwriting when the configuration changes.
- Created a new configuration object for testing with specific properties.
- Verified that the state updates correctly in response to configuration changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->