### PR TITLE
fix: darkmode eoa wallet bg color

### DIFF
--- a/examples/ui-demo/src/components/eoa-post-login/EOAPostLogin.tsx
+++ b/examples/ui-demo/src/components/eoa-post-login/EOAPostLogin.tsx
@@ -5,8 +5,8 @@ import {
 
 export function EOAPostLogin() {
   return (
-    <div className="px-10 py-11 flex flex-col border-none lg:border-solid border border-border rounded-lg overflow-hidden overflow-y-auto scrollbar-none">
-      <div className="max-w-[486px] w-full bg-bg-surface-default">
+    <div className="px-10 py-11 flex flex-col border-none lg:border-solid border border-border rounded-lg overflow-hidden overflow-y-auto scrollbar-none bg-bg-surface-default">
+      <div className="max-w-[486px] w-full">
         <EOAPostLoginContents />
         <div className="hidden lg:block">
           <EOAPostLoginActions />


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

BG color was on incorrect element.

Before:
![Screenshot 2025-03-14 at 10 02 41 AM](https://github.com/user-attachments/assets/a0dfc0bb-89ed-42d0-92d0-1fdaa831968b)

After:
![Screenshot 2025-03-14 at 10 02 25 AM](https://github.com/user-attachments/assets/6c03e57f-4a96-423c-b5c5-14ed77bf83d5)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the structure of the `EOAPostLogin` component's JSX by adjusting the placement of CSS classes for styling.

### Detailed summary
- Moved the `bg-bg-surface-default` class from the inner `div` to the outer `div` in the `EOAPostLogin` component.
- The outer `div` now includes both padding and background styling.
- The inner `div` retains its width styling without additional classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->