### PR TITLE
DO NOT MERGE: new auth method

### DIFF
--- a/account-kit/signer/src/base.ts
+++ b/account-kit/signer/src/base.ts
@@ -323,8 +323,12 @@ export abstract class BaseAlchemySigner<TClient extends BaseSignerClient>
               return this.authenticateWithEmailNew(params);
             case "otp":
               return this.authenticateWithOtpNew(params);
+            case "passkey":
+            case "oauth":
+            case "oauthReturn":
+              throw new Error(`Unsupported auth step type: ${type}`);
             default:
-              throw new Error("type not implemented");
+              assertNever(type, `Unknown auth step type: ${type}`);
           }
         })();
 
@@ -875,10 +879,6 @@ export abstract class BaseAlchemySigner<TClient extends BaseSignerClient>
       };
     }
 
-    if (!("email" in params)) {
-      throw new Error("Email is required");
-    }
-
     const { orgId, otpId, multiFactors, isNewUser } =
       await this.initOrCreateEmailUser(
         params.email,
@@ -930,7 +930,7 @@ export abstract class BaseAlchemySigner<TClient extends BaseSignerClient>
         params.redirectParams
       );
 
-    const isMfaRequired = multiFactors ? multiFactors?.length > 0 : false;
+    const isMfaRequired = multiFactors ? multiFactors.length > 0 : false;
 
     this.sessionManager.setTemporarySession({
       orgId,

--- a/account-kit/signer/src/signer.ts
+++ b/account-kit/signer/src/signer.ts
@@ -7,8 +7,27 @@ import {
 import type {
   CredentialCreationOptionOverrides,
   VerifyMfaParams,
+  User,
+  MfaFactor,
 } from "./client/types.js";
 import { SessionManagerParamsSchema } from "./session/manager.js";
+import type { AlchemySignerStatus } from "./types.js";
+
+export type AuthStepResult =
+  | {
+      status: AlchemySignerStatus.CONNECTED;
+      user: User;
+    }
+  | {
+      status: AlchemySignerStatus.AWAITING_EMAIL_AUTH;
+      user: undefined;
+    }
+  | {
+      status: AlchemySignerStatus.AWAITING_MFA_AUTH;
+      user: undefined;
+      multiFactors: MfaFactor[];
+      // encryptedPayload: string; // I don't think we want to expose this to the user
+    };
 
 export type AuthParams =
   | {

--- a/account-kit/signer/src/signer.ts
+++ b/account-kit/signer/src/signer.ts
@@ -72,6 +72,12 @@ export type AuthParams =
       type: "otp";
       otpCode: string;
       multiFactors?: VerifyMfaParams[];
+    }
+  | {
+      type: "mfa";
+      mode: "totp";
+      multiFactorId: string;
+      multiFactorCode: string;
     };
 
 export type OauthProviderConfig =


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the authentication flow by introducing support for multi-factor authentication (MFA) and refining the handling of different authentication steps in the `BaseAlchemySigner` class.

### Detailed summary
- Added `AuthStepResult` type to represent various authentication states.
- Extended `AuthParams` type to include MFA parameters.
- Implemented `authenticateStep` method to handle different auth types, including MFA.
- Created `authenticateWithOtpNew` and `authenticateWithEmailNew` methods for improved OTP and email handling.
- Updated error handling for unsupported auth step types.
- Modified `validateMultiFactors` to return `AuthStepResult` instead of `User`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

# Goal:

We’ve updated our API to improve multi-factor authentication (MFA) flows by adding a new validate-mfa endpoint. Previously, you had to submit all MFA credentials (e.g., TOTP) with your primary credentials (like email + otp) in a single call, which meant you couldn’t provide incremental feedback to the user if one step failed.

Now that we have a new endpoint for MFA, it makes sense to refine the SDK’s authentication flow by introducing a authenticateStep method that returns a status after each step—rather than always returning a final User or throwing an error. This is especially important for multi-step flows like email + otp + totp.

Currently, the existing authenticate method returns a User or throws an error. This approach can lead to unresolved Promises across multiple steps in an MFA flow, forcing developers to rely on events to figure out which step the user is on.

## Possible MFA flow with the current `authenticate` method

```typescript
// 1) Returns a promise that won’t resolve until the user eventually enters the OTP and TOTP:
const user1 = signer.authenticate({ type: "email", email });
// The developer must listen for an event to know we’re “awaiting OTP.” The promise remains unresolved.

// 2) Similarly, returns a promise that only resolves after TOTP is submitted:
const user2 = signer.authenticate({ type: "otp", otpCode });
// Developer must again rely on events to detect “awaiting MFA.”

// 3) Finally resolves with a user:
const user3 = signer.authenticate({ type: "mfa", mode: "totp", multiFactorCode: "asdf" });
// At the end, user1, user2, and user3 all resolve to the same final user.
```
This sequence can be confusing because each call to authenticate returns a promise that waits for future steps, rather than returning partial information at each step.

## Proposed Flow with `authenticateStep`

```typescript
// 1) Immediate return with `AWAITING_EMAIL_AUTH` but no final user:
const { status, user } = signer.authenticateStep({
  type: "email",
  email,
});
// status = AWAITING_EMAIL_AUTH
// user = undefined or "partial" if you choose

// 2) Next step returns `AWAITING_MFA_AUTH` along with the allowed MFA factors:
const { status, user, multiFactors } = signer.authenticateStep({
  type: "otp",
  otpCode,
});
// status = AWAITING_MFA_AUTH
// multiFactors = e.g., totp
// user = undefined or partial

// 3) Finally returns a fully authenticated user:
const { status, user } = signer.authenticateStep({
  type: "mfa",
  mode: "totp",
  multiFactorCode: "asdf",
});
// status = CONNECTED
// user = the final, fully authenticated user
```
Each call returns immediate feedback about the current status (AWAITING_EMAIL_AUTH, AWAITING_MFA_AUTH, etc.) rather than suspending the promise until all steps are complete. This means you can handle errors or partial progress more cleanly.

Note: We won’t break backward compatibility. The existing authenticate method continues to work as before, but we recommend switching to authenticateStep for multi-step flows.