### PR TITLE
fix: onSignup not call for new user after logging out and back in

### DIFF
--- a/account-kit/react/src/hooks/internal/useNewUserSignup.ts
+++ b/account-kit/react/src/hooks/internal/useNewUserSignup.ts
@@ -11,6 +11,14 @@ export function useNewUserSignup(onSignup: () => void, enabled?: boolean) {
     });
     return stopListening;
   }, [signer]);
+
+  useEffect(() => {
+    const stopListening = signer?.on("disconnected", () => {
+      hasHandled.current = false;
+    });
+    return stopListening;
+  }, [signer]);
+
   useEffect(() => {
     if (!enabled) return;
     if (!signer) return;


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

## Description:
If you sign out and then sign in with a new user (without refreshing the page) the `useNewUserSignup` hook didn't run the onSignup function.  This resets the hasHandled value so it works