### PR TITLE
fix: resolve import path immediately for tailwind plugin

### DIFF
--- a/account-kit/react/src/tailwind/plugin.ts
+++ b/account-kit/react/src/tailwind/plugin.ts
@@ -17,6 +17,8 @@ import { apply, getColorVariableName } from "./utils.js";
 
 type TailWindPlugin = ReturnType<typeof plugin>;
 
+const pathToMe = require.resolve("@account-kit/react");
+
 /**
  * Get the path to the @account-kit/react package and the tailwind content.
  * This is used within the tailwind.config.js to include the @account-kit content.
@@ -41,7 +43,6 @@ type TailWindPlugin = ReturnType<typeof plugin>;
  * @returns {string} The resolved path to the @account-kit/react package and the tailwind content
  */
 export const getAccountKitContentPath = () => {
-  const pathToMe = require.resolve("@account-kit/react");
   const contentPath = `${pathToMe.replace(
     "index.js",
     ""


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `getAccountKitContentPath` function in the `tailwind/plugin.ts` file by moving the declaration of `pathToMe` to the top of the function and removing its previous declaration from within the function.

### Detailed summary
- Moved the declaration of `const pathToMe` to the top of the `getAccountKitContentPath` function.
- Removed the duplicate declaration of `const pathToMe` from within the function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->