### PR TITLE
fix(demo): signer address should not be explorer link

### DIFF
--- a/examples/ui-demo/src/components/user-connection-avatar/UserConnectionDetails.tsx
+++ b/examples/ui-demo/src/components/user-connection-avatar/UserConnectionDetails.tsx
@@ -145,7 +145,7 @@ export function UserConnectionDetails({
               </div>
             </a>
 
-            <UserAddressTooltip address={signerAddress ?? null} linkEnabled />
+            <UserAddressTooltip address={signerAddress ?? null} />
           </div>
 
           <SolanaAddressDetails />


### PR DESCRIPTION
ASANA TASK: https://app.asana.com/0/1205598840815267/1209890364393290/f

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `UserAddressTooltip` component usage by removing the `linkEnabled` prop.

### Detailed summary
- The `linkEnabled` prop was removed from the `<UserAddressTooltip>` component in `UserConnectionDetails.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->