### PR TITLE
fix: ci status issues

### DIFF
--- a/.github/actions/publish-fern/action.yml
+++ b/.github/actions/publish-fern/action.yml
@@ -77,7 +77,7 @@ runs:
       if: always()
       with:
         script: |
-          const status = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+          const status = '${{ steps.generate-docs.outcome }}' === 'success' ? 'success' : 'failure';
           const envUrl = '${{ steps.generate-docs.outputs.url }}';
           
           await github.rest.repos.createDeploymentStatus({

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -134,4 +134,3 @@ jobs:
       - name: Build example for iOS
         run: |
           yarn turbo run build:ios
-

--- a/.github/workflows/preview-fern-docs.yml
+++ b/.github/workflows/preview-fern-docs.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Comment Preview URL in PR
         uses: actions/github-script@v7
+        if: always()
         with:
           script: |
             const workspace = process.env.GITHUB_WORKSPACE;

--- a/.github/workflows/preview-fern-docs.yml
+++ b/.github/workflows/preview-fern-docs.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout aa-sdk
         uses: actions/checkout@v4
 
+      - name: Setup Docs
+        uses: ./.github/actions/setup-docs
+        with:
+          docs-github-token: ${{ secrets.DOCS_GITHUB_TOKEN }}
+
       - name: Set Build Comment to In Progress
         uses: actions/github-script@v7
         with:
@@ -29,11 +34,6 @@ jobs:
               context,
               status: 'building',
             });
-
-      - name: Setup Docs
-        uses: ./.github/actions/setup-docs
-        with:
-          docs-github-token: ${{ secrets.DOCS_GITHUB_TOKEN }}
 
       - name: Generate Fern Docs Preview
         id: preview

--- a/.github/workflows/preview-fern-docs.yml
+++ b/.github/workflows/preview-fern-docs.yml
@@ -17,6 +17,19 @@ jobs:
       - name: Checkout aa-sdk
         uses: actions/checkout@v4
 
+      - name: Set Build Comment to In Progress
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workspace = process.env.GITHUB_WORKSPACE;
+            const { updatePreviewComment } = await import(`${workspace}/docs-site/scripts/preview-comment.js`);
+
+            await updatePreviewComment({
+              github,
+              context,
+              status: 'building',
+            });
+
       - name: Setup Docs
         uses: ./.github/actions/setup-docs
         with:


### PR DESCRIPTION
# Context

I noticed two issues in existing CI:

- I forgot to add the "In Progress" step in CI 🤷 
- Failed builds never update the PR comment
- Github Deployments succeed even when builds fail.

These changes fix all

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the GitHub Actions workflows for building and publishing Fern documentation. It introduces a new build status handling mechanism and adds a step to comment on the PR with the build status.

### Detailed summary
- Updated `status` handling in `.github/actions/publish-fern/action.yml` to use `steps.generate-docs.outcome`.
- Added a new step to set the build comment to "In Progress" in `.github/workflows/preview-fern-docs.yml`.
- Included `if: always()` condition for the "Comment Preview URL in PR" step.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->