### PR TITLE
chore: add monad testnet block explorer url

### DIFF
--- a/account-kit/infra/src/chains.ts
+++ b/account-kit/infra/src/chains.ts
@@ -494,6 +494,12 @@ export const monadTestnet: Chain = defineChain({
       http: ["https://monad-testnet.g.alchemy.com/v2"],
     },
   },
+  blockExplorers: {
+    default: {
+      name: "Block Explorer",
+      url: "https://testnet.monadexplorer.com",
+    },
+  },
   testnet: true,
 });
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `blockExplorers` configuration for the blockchain setup, specifically for a testnet environment.

### Detailed summary
- Added a `blockExplorers` object.
- Defined a `default` explorer with:
  - `name`: "Block Explorer"
  - `url`: "https://testnet.monadexplorer.com"
- Confirmed that the `testnet` flag is set to `true`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->