### PR TITLE
feat: remove execute and executebatch from account functions

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/client/client.test.ts
@@ -377,9 +377,9 @@ describe("MA v2 Tests", async () => {
         })
         .addPermission({
           permission: {
-            type: PermissionType.ACCOUNT_FUNCTIONS,
+            type: PermissionType.CONTRACT_ACCESS,
             data: {
-              functions: ["0xb61d27f6"], // execute selector
+              address: target,
             },
           },
         })

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
@@ -32,6 +32,7 @@ import {
   MultipleNativeTokenTransferError,
   NoFunctionsProvidedError,
   RootPermissionOnlyError,
+  SelectorNotAllowed,
   UnsupportedPermissionTypeError,
   ValidationConfigUnsetError,
   ZeroAddressError,
@@ -317,6 +318,13 @@ export class PermissionBuilder {
     if (permission.type === PermissionType.ACCOUNT_FUNCTIONS) {
       if (permission.data.functions.length === 0) {
         throw new NoFunctionsProvidedError(permission);
+      }
+      if (permission.data.functions.includes(ACCOUNT_EXECUTE_SELECTOR)) {
+        throw new SelectorNotAllowed(ACCOUNT_EXECUTE_SELECTOR);
+      } else if (
+        permission.data.functions.includes(ACCOUNT_EXECUTEBATCH_SELECTOR)
+      ) {
+        throw new SelectorNotAllowed(ACCOUNT_EXECUTEBATCH_SELECTOR);
       }
       this.selectors = [...this.selectors, ...permission.data.functions];
     }

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
@@ -321,11 +321,11 @@ export class PermissionBuilder {
       }
       // Explicitly disallow adding execute & executeBatch
       if (permission.data.functions.includes(ACCOUNT_EXECUTE_SELECTOR)) {
-        throw new SelectorNotAllowed(ACCOUNT_EXECUTE_SELECTOR);
+        throw new SelectorNotAllowed("execute");
       } else if (
         permission.data.functions.includes(ACCOUNT_EXECUTEBATCH_SELECTOR)
       ) {
-        throw new SelectorNotAllowed(ACCOUNT_EXECUTEBATCH_SELECTOR);
+        throw new SelectorNotAllowed("executeBatch");
       }
       this.selectors = [...this.selectors, ...permission.data.functions];
     }

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
@@ -319,6 +319,7 @@ export class PermissionBuilder {
       if (permission.data.functions.length === 0) {
         throw new NoFunctionsProvidedError(permission);
       }
+      // Explicitly disallow adding execute & executeBatch
       if (permission.data.functions.includes(ACCOUNT_EXECUTE_SELECTOR)) {
         throw new SelectorNotAllowed(ACCOUNT_EXECUTE_SELECTOR);
       } else if (

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
@@ -151,3 +151,16 @@ export class UnsupportedPermissionTypeError extends BaseError {
     super(`Unsupported permission type`);
   }
 }
+
+export class SelectorNotAllowed extends BaseError {
+  override name = "SelectorNotAllowed";
+
+  /**
+   * Constructor for initializing an error message indicating that the selector being added is not allowed.
+   *
+   * @param {string} selector The selector that is being added.
+   */
+  constructor(selector: string) {
+    super(`Cannot add ${selector} on the account`);
+  }
+}

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
@@ -158,9 +158,9 @@ export class SelectorNotAllowed extends BaseError {
   /**
    * Constructor for initializing an error message indicating that the selector being added is not allowed.
    *
-   * @param {string} selector The selector that is being added.
+   * @param {string} functionName The function name of the selector that is being added.
    */
-  constructor(selector: string) {
-    super(`Cannot add ${selector} on the account`);
+  constructor(functionName: string) {
+    super(`Cannot add ${functionName} on the account`);
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating permission handling in the smart contracts by changing the permission type, adding a new error class for disallowed selectors, and enforcing restrictions on specific function selectors.

### Detailed summary
- Changed permission type from `ACCOUNT_FUNCTIONS` to `CONTRACT_ACCESS`.
- Introduced `SelectorNotAllowed` error class for disallowed selectors.
- Added checks to prevent adding `execute` and `executeBatch` selectors, throwing `SelectorNotAllowed` if attempted.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->