### PR TITLE
fix(demo): disable mfa for passkey users

### DIFF
--- a/examples/ui-demo/src/components/small-cards/MFACard.tsx
+++ b/examples/ui-demo/src/components/small-cards/MFACard.tsx
@@ -58,7 +58,7 @@ export function MFACard() {
       buttons={
         isPasskeyUser ? (
           <p className="text-fg-secondary text-xs bg-bg-surface-inset py-2 px-3 rounded-md font-medium mt-auto">
-            MFA is not supported when using a passkey.
+            MFA is not supported when logged in using passkey.
           </p>
         ) : (
           <MFAModal

--- a/examples/ui-demo/src/components/small-cards/MFACard.tsx
+++ b/examples/ui-demo/src/components/small-cards/MFACard.tsx
@@ -58,7 +58,7 @@ export function MFACard() {
       buttons={
         isPasskeyUser ? (
           <p className="text-fg-secondary text-xs bg-bg-surface-inset py-2 px-3 rounded-md font-medium mt-auto">
-            MFA is not supported when logged in using passkey.
+            MFA is not supported when logged in using a passkey.
           </p>
         ) : (
           <MFAModal

--- a/examples/ui-demo/src/components/small-cards/MFACard.tsx
+++ b/examples/ui-demo/src/components/small-cards/MFACard.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from "react";
 import { ThreeStarsIcon } from "../icons/three-stars";
 import { MFAModal } from "../modals/MFA/MFAModal";
-import { useMFA } from "@account-kit/react";
+import { useMFA, useUser } from "@account-kit/react";
 import { Card } from "./Card";
 
 export function MFACard() {
   const [isMfaActive, setIsMfaActive] = useState(false);
   const { getMFAFactors, isReady } = useMFA();
+  const user = useUser();
+  const isPasskeyUser = !!user?.credentialId;
 
   useEffect(() => {
-    if (isReady) {
+    if (isReady && !isPasskeyUser) {
       getMFAFactors.mutate(undefined, {
         onSuccess: (factors) => {
           setIsMfaActive(
@@ -54,11 +56,17 @@ export function MFACard() {
         </p>
       }
       buttons={
-        <MFAModal
-          isMfaActive={isMfaActive}
-          onMfaEnabled={() => setIsMfaActive(true)}
-          onMfaRemoved={() => setIsMfaActive(false)}
-        />
+        isPasskeyUser ? (
+          <p className="text-fg-secondary text-xs bg-bg-surface-inset py-2 px-3 rounded-md font-medium mt-auto">
+            MFA is not supported when using a passkey.
+          </p>
+        ) : (
+          <MFAModal
+            isMfaActive={isMfaActive}
+            onMfaEnabled={() => setIsMfaActive(true)}
+            onMfaRemoved={() => setIsMfaActive(false)}
+          />
+        )
       }
     />
   );


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `MFACard` component by integrating user context to conditionally render MFA options based on whether the user is a passkey user.

### Detailed summary
- Added `useUser` hook to retrieve user information.
- Introduced `isPasskeyUser` variable to check if the user is logged in with a passkey.
- Updated the conditional rendering logic to display a message instead of the `MFAModal` for passkey users.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->