### PR TITLE
feat: create common base error for permission builder errors

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
@@ -1,7 +1,9 @@
 import { BaseError, type Address } from "@aa-sdk/core";
 import type { Permission } from "./permissionBuilder";
 
-export class RootPermissionOnlyError extends BaseError {
+export abstract class PermissionBuilderError extends BaseError {}
+
+export class RootPermissionOnlyError extends PermissionBuilderError {
   override name = "PermissionBuilder: RootPermissionOnlyError";
 
   /**
@@ -14,7 +16,7 @@ export class RootPermissionOnlyError extends BaseError {
   }
 }
 
-export class AccountAddressAsTargetError extends BaseError {
+export class AccountAddressAsTargetError extends PermissionBuilderError {
   override name = "PermissionBuilder: AccountAddressAsTargetError";
 
   /**
@@ -29,7 +31,7 @@ export class AccountAddressAsTargetError extends BaseError {
   }
 }
 
-export class DuplicateTargetAddressError extends BaseError {
+export class DuplicateTargetAddressError extends PermissionBuilderError {
   override name = "PermissionBuilder: DuplicateTargetAddressError";
 
   /**
@@ -45,7 +47,7 @@ export class DuplicateTargetAddressError extends BaseError {
   }
 }
 
-export class NoFunctionsProvidedError extends BaseError {
+export class NoFunctionsProvidedError extends PermissionBuilderError {
   override name = "PermissionBuilder: NoFunctionsProvidedError";
 
   /**
@@ -58,7 +60,7 @@ export class NoFunctionsProvidedError extends BaseError {
   }
 }
 
-export class ExpiredDeadlineError extends BaseError {
+export class ExpiredDeadlineError extends PermissionBuilderError {
   override name = "PermissionBuilder: ExpiredDeadlineError";
 
   /**
@@ -74,7 +76,7 @@ export class ExpiredDeadlineError extends BaseError {
   }
 }
 
-export class DeadlineOverLimitError extends BaseError {
+export class DeadlineOverLimitError extends PermissionBuilderError {
   override name = "PermissionBuilder: DeadlineOverLimitError";
 
   /**
@@ -89,7 +91,7 @@ export class DeadlineOverLimitError extends BaseError {
   }
 }
 
-export class ValidationConfigUnsetError extends BaseError {
+export class ValidationConfigUnsetError extends PermissionBuilderError {
   override name = "PermissionBuilder: ValidationConfigUnsetError";
 
   /**
@@ -100,7 +102,7 @@ export class ValidationConfigUnsetError extends BaseError {
   }
 }
 
-export class MultipleNativeTokenTransferError extends BaseError {
+export class MultipleNativeTokenTransferError extends PermissionBuilderError {
   override name = "PermissionBuilder: MultipleNativeTokenTransferError";
 
   /**
@@ -115,7 +117,7 @@ export class MultipleNativeTokenTransferError extends BaseError {
   }
 }
 
-export class ZeroAddressError extends BaseError {
+export class ZeroAddressError extends PermissionBuilderError {
   override name = "PermissionBuilder: ZeroAddressError";
 
   /**
@@ -128,7 +130,7 @@ export class ZeroAddressError extends BaseError {
   }
 }
 
-export class MultipleGasLimitError extends BaseError {
+export class MultipleGasLimitError extends PermissionBuilderError {
   override name = "PermissionBuilder: MultipleGasLimitError";
 
   /**
@@ -141,7 +143,7 @@ export class MultipleGasLimitError extends BaseError {
   }
 }
 
-export class UnsupportedPermissionTypeError extends BaseError {
+export class UnsupportedPermissionTypeError extends PermissionBuilderError {
   override name = "PermissionBuilder: UnsupportedPermissionTypeError";
 
   /**
@@ -152,7 +154,7 @@ export class UnsupportedPermissionTypeError extends BaseError {
   }
 }
 
-export class SelectorNotAllowed extends BaseError {
+export class SelectorNotAllowed extends PermissionBuilderError {
   override name = "SelectorNotAllowed";
 
   /**


### PR DESCRIPTION
To be able to group these errors in a catch clause via `instaceof`

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors error handling in the `permissionBuilderErrors.ts` file by introducing a new abstract class `PermissionBuilderError` that extends `BaseError`. All existing error classes are updated to extend from this new class, promoting better organization and consistency.

### Detailed summary
- Introduced `PermissionBuilderError` as an abstract class extending `BaseError`.
- Updated `RootPermissionOnlyError`, `AccountAddressAsTargetError`, `DuplicateTargetAddressError`, `NoFunctionsProvidedError`, `ExpiredDeadlineError`, `DeadlineOverLimitError`, `ValidationConfigUnsetError`, `MultipleNativeTokenTransferError`, `ZeroAddressError`, `MultipleGasLimitError`, `UnsupportedPermissionTypeError`, and `SelectorNotAllowed` to extend `PermissionBuilderError` instead of `BaseError`.
- Each class now overrides the `name` property to reflect the new error hierarchy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->