### PR TITLE
test: add expiry test

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
@@ -2,14 +2,17 @@ import {
   erc7677Middleware,
   LocalAccountSigner,
   type SmartAccountSigner,
+  type UserOperationRequest_v7,
 } from "@aa-sdk/core";
 import {
+  concat,
   custom,
+  fromHex,
+  isAddress,
   parseEther,
   publicActions,
   testActions,
   toHex,
-  zeroAddress,
   type Address,
   type Hex,
 } from "viem";
@@ -30,6 +33,11 @@ import { local070Instance } from "~test/instances.js";
 import { setBalance } from "viem/actions";
 import { accounts } from "~test/constants.js";
 import { alchemyGasAndPaymasterAndDataMiddleware } from "@account-kit/infra";
+import { entryPoint07Abi } from "viem/account-abstraction";
+import {
+  packAccountGasLimits,
+  packPaymasterData,
+} from "../../../../../aa-sdk/core/src/entrypoint/0.7";
 
 // Note: These tests maintain a shared state to not break the local-running rundler by desyncing the chain.
 describe("MA v2 deferral actions tests", async () => {
@@ -268,7 +276,7 @@ describe("MA v2 deferral actions tests", async () => {
       isGlobalValidation: false,
     });
 
-    const deadline = Date.now() / 2 / 1000;
+    const deadline = Math.round(Date.now() / 2 / 1000);
 
     expect(async () => {
       await new PermissionBuilder({
@@ -291,6 +299,138 @@ describe("MA v2 deferral actions tests", async () => {
         })
         .compileDeferred();
     }).rejects.toThrow(new ExpiredDeadlineError(deadline, Date.now() / 1000));
+  });
+
+  it("PermissionBuilder: Cannot install expired deferred action", async () => {
+    const client = instance
+      .getClient()
+      .extend(publicActions)
+      .extend(testActions({ mode: "anvil" }));
+    const provider = await givenConnectedProvider({ signer });
+
+    const serverClient = (
+      await createModularAccountV2Client({
+        chain: instance.chain,
+        accountAddress: provider.getAddress(),
+        signer: new LocalAccountSigner(accounts.fundedAccountOwner),
+        transport: custom(instance.getClient()),
+      })
+    ).extend(deferralActions);
+
+    const { entityId, nonce } = await serverClient.getEntityIdAndNonce({
+      isGlobalValidation: false,
+    });
+
+    const deadline = Math.round(Date.now() / 1000 + 10);
+
+    const { typedData, fullPreSignatureDeferredActionDigest } =
+      await new PermissionBuilder({
+        client: serverClient,
+        key: {
+          publicKey: await sessionKey.getAddress(),
+          type: "secp256k1",
+        },
+        entityId,
+        nonce,
+        deadline,
+      })
+        .addPermission({
+          permission: {
+            type: PermissionType.CONTRACT_ACCESS,
+            data: {
+              address: target,
+            },
+          },
+        })
+        .compileDeferred();
+
+    // Sign the typed data using the owner (fallback) validation, this must be done via the account to skip 6492
+    const deferredValidationSig = await provider.account.signTypedData(
+      typedData
+    );
+
+    // Build the full hex to prepend to the UO signature
+    const deferredActionDigest = buildDeferredActionDigest({
+      fullPreSignatureDeferredActionDigest,
+      sig: deferredValidationSig,
+    });
+
+    // Initialize the session key client corresponding to the session key we will install in the deferred action
+    const sessionKeyClient = await createModularAccountV2Client({
+      transport: custom(instance.getClient()),
+      chain: instance.chain,
+      accountAddress,
+      signer: sessionKey,
+      initCode,
+      deferredAction: deferredActionDigest,
+    });
+
+    const uo = await sessionKeyClient.buildUserOperation({
+      uo: {
+        target: target,
+        value: sendAmount,
+        data: "0x",
+      },
+    });
+
+    const signedUO = (await sessionKeyClient.signUserOperation({
+      uoStruct: uo,
+    })) as UserOperationRequest_v7;
+
+    // Advance time
+    await client.setNextBlockTimestamp({
+      timestamp: BigInt(deadline) + 1000n,
+    });
+
+    await client.mine({
+      blocks: 1,
+    });
+
+    expect(async () => {
+      return await client.simulateContract({
+        address: serverClient.account.getEntryPoint().address,
+        abi: entryPoint07Abi,
+        functionName: "handleOps",
+        args: [
+          [
+            {
+              sender: serverClient.account.address,
+              nonce: fromHex(signedUO.nonce, "bigint"),
+              initCode:
+                signedUO.factory && signedUO.factoryData
+                  ? concat([signedUO.factory, signedUO.factoryData])
+                  : "0x",
+              callData: signedUO.callData,
+              accountGasLimits: packAccountGasLimits({
+                verificationGasLimit: signedUO.verificationGasLimit,
+                callGasLimit: signedUO.callGasLimit,
+              }),
+              preVerificationGas: fromHex(
+                signedUO.preVerificationGas,
+                "bigint"
+              ),
+              gasFees: packAccountGasLimits({
+                maxPriorityFeePerGas: signedUO.maxPriorityFeePerGas,
+                maxFeePerGas: signedUO.maxFeePerGas,
+              }),
+              paymasterAndData:
+                signedUO.paymaster && isAddress(signedUO.paymaster)
+                  ? packPaymasterData({
+                      paymaster: signedUO.paymaster,
+                      paymasterVerificationGasLimit:
+                        signedUO.paymasterVerificationGasLimit,
+                      paymasterPostOpGasLimit: signedUO.paymasterPostOpGasLimit,
+                      paymasterData: signedUO.paymasterData,
+                    })
+                  : "0x",
+              signature: signedUO.signature,
+            },
+          ],
+          provider.account.address,
+        ],
+        account: await sessionKeyClient.account.getSigner().getAddress(),
+      });
+    }).rejects.toThrow("AA22 expired or not due");
   });
 
   it("PermissionBuilder: Cannot add root after any permission", async () => {

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
@@ -135,73 +135,68 @@ type RawHooks = {
     | undefined;
 };
 
-type OneOf<T extends {}[]> = T[number];
-
 type Key = {
   publicKey: Hex;
   type: "secp256k1" | "contract";
 };
 
-export type Permission = OneOf<
-  [
-    {
+export type Permission =
+  | {
       // this permission allows transfer of native tokens from the account
       type: PermissionType.NATIVE_TOKEN_TRANSFER;
       data: {
         allowance: Hex;
       };
-    },
-    {
+    }
+  | {
       // this permission allows transfer or approval of erc20 tokens from the account
       type: PermissionType.ERC20_TOKEN_TRANSFER;
       data: {
         address: Address; // erc20 token contract address
         allowance: Hex;
       };
-    },
-    {
+    }
+  | {
       // this permissions allows the key to spend gas for UOs
       type: PermissionType.GAS_LIMIT;
       data: {
         limit: Hex;
       };
-    },
-    {
+    }
+  | {
       // this permission grants access to all functions in a contract
       type: PermissionType.CONTRACT_ACCESS;
       data: {
         address: Address;
       };
-    },
-    {
+    }
+  | {
       // this permission grants access to functions in the account
       type: PermissionType.ACCOUNT_FUNCTIONS;
       data: {
         functions: Hex[]; // function signatures
       };
-    },
-    {
+    }
+  | {
       // this permission grants access to a function selector in any address or contract
       type: PermissionType.FUNCTIONS_ON_ALL_CONTRACTS;
       data: {
         functions: Hex[]; // function signatures
       };
-    },
-    {
+    }
+  | {
       // this permission grants access to specified functions on a specific contract
       type: PermissionType.FUNCTIONS_ON_CONTRACT;
       data: {
         address: Address;
         functions: Hex[];
       };
-    },
-    {
+    }
+  | {
       // this permission grants full access to everything
       type: PermissionType.ROOT;
       data?: never;
-    }
-  ]
->;
+    };
 
 type Hook = {
   hookConfig: HookConfig;

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
@@ -12,7 +12,9 @@ export class RootPermissionOnlyError extends PermissionBuilderError {
    * @param {Permission} permission The permission trying to be added atop the root permission
    */
   constructor(permission: Permission) {
-    super(`Adding ${permission}: Cannot add permissions with ROOT permission`);
+    super(
+      `Adding ${permission.type}: Cannot add permissions with ROOT permission`
+    );
   }
 }
 


### PR DESCRIPTION
# Summary

This PR adds a simple test to ensure the expiry is correctly handled in deferred actions. 

An improvement could be to add a test to ensure the UO fails on chain, this has to be done via calling the handleOps function directly since the revert happens in handleOps.

Also includes a small fix to a permissionBuilder error.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the `PermissionBuilder` functionality and enhancing error handling related to permission management in a smart contract context.

### Detailed summary
- Updated error message in `permissionBuilderErrors.ts` to include `permission.type`.
- Refactored `Permission` type in `permissionBuilder.ts` to use union types for better clarity.
- Added tests in `deferralActions.test.ts` for handling expired permissions and actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->