### PR TITLE
chore: update allowlist module address

### DIFF
--- a/.vitest/src/instances.ts
+++ b/.vitest/src/instances.ts
@@ -23,7 +23,7 @@ export const local060Instance = defineInstance({
 
 export const local070Instance = defineInstance({
   chain: localhost,
-  forkBlockNumber: 7303015,
+  forkBlockNumber: 8168190,
   forkUrl:
     process.env.VITEST_SEPOLIA_FORK_URL ??
     "https://ethereum-sepolia-rpc.publicnode.com",

--- a/account-kit/smart-contracts/src/ma-v2/modules/utils.ts
+++ b/account-kit/smart-contracts/src/ma-v2/modules/utils.ts
@@ -213,6 +213,6 @@ export const getDefaultAllowlistModuleAddress = (chain: Chain): Address => {
     case arbitrumSepolia.id:
     case base.id:
     default:
-      return "0x0000000000002311EEE9A2B887af1F144dbb4F6e";
+      return "0x00000000003e826473a313e600b5b9b791f5a59a";
   }
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates certain values in the smart contract utility functions and adjusts the block number for a local instance configuration.

### Detailed summary
- In `account-kit/smart-contracts/src/ma-v2/modules/utils.ts`, the return value for the `base.id` case has been changed from `"0x0000000000002311EEE9A2B887af1F144dbb4F6e"` to `"0x00000000003e826473a313e600b5b9b791f5a59a"`.
- In `.vitest/src/instances.ts`, the `forkBlockNumber` has been updated from `7303015` to `8168190`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->