### PR TITLE
Simple markdown fix, add `SmartAccountClient` type link to keyword

### DIFF
--- a/docs/pages/concepts/smart-account-client.mdx
+++ b/docs/pages/concepts/smart-account-client.mdx
@@ -5,7 +5,7 @@ description: What is the Smart Account Client?
 
 # Smart Account Client
 
-The **SmartAccountClient** is an extension of `viem`'s [Client](https://viem.sh/docs/clients/custom#build-your-own-client) which allows you to interact
+The [`SmartAccountClient`](https://github.com/alchemyplatform/aa-sdk/blob/main/aa-sdk/core/src/account/smartContractAccount.ts#L102-L128) is an extension of `viem`'s [Client](https://viem.sh/docs/clients/custom#build-your-own-client) which allows you to interact
 with [Smart Contract Accounts](/wallets/concepts/smart-contract-account). You can use the Smart Account Client to send User Operations, sign messages with your account, sponsor gas,
 and other account-related actions.
 

--- a/docs/pages/concepts/smart-account-client.mdx
+++ b/docs/pages/concepts/smart-account-client.mdx
@@ -5,7 +5,7 @@ description: What is the Smart Account Client?
 
 # Smart Account Client
 
-The [`SmartAccountClient`](#TODO/link-to-type) is an extension of `viem`'s [Client](https://viem.sh/docs/clients/custom#build-your-own-client) which allows you to interact
+The **SmartAccountClient** is an extension of `viem`'s [Client](https://viem.sh/docs/clients/custom#build-your-own-client) which allows you to interact
 with [Smart Contract Accounts](/wallets/concepts/smart-contract-account). You can use the Smart Account Client to send User Operations, sign messages with your account, sponsor gas,
 and other account-related actions.
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the `SmartAccountClient` to provide a direct link to its implementation in the codebase, enhancing accessibility for users seeking more information.

### Detailed summary
- Updated the link for the `SmartAccountClient` from a placeholder (`#TODO/link-to-type`) to a direct URL pointing to its implementation in the GitHub repository.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->