### PR TITLE
docs: fix method used for privateKeyToAccountSigner

### DIFF
--- a/docs/pages/reference/aa-sdk/core/classes/LocalAccountSigner/privateKeyToAccountSigner.mdx
+++ b/docs/pages/reference/aa-sdk/core/classes/LocalAccountSigner/privateKeyToAccountSigner.mdx
@@ -19,7 +19,7 @@ import { LocalAccountSigner } from "@aa-sdk/core";
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { generatePrivateKey } from "viem";
 
-const signer = LocalAccountSigner.mnemonicToAccountSigner(generatePrivateKey());
+const signer = LocalAccountSigner.privateKeyToAccountSigner(generatePrivateKey());
 ```
 
 ## Parameters


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the method used to create an account signer in the `LocalAccountSigner` class from `mnemonicToAccountSigner` to `privateKeyToAccountSigner`, reflecting a change in how the signer is instantiated.

### Detailed summary
- Changed the method from `LocalAccountSigner.mnemonicToAccountSigner(generatePrivateKey())` 
- Updated to `LocalAccountSigner.privateKeyToAccountSigner(generatePrivateKey())`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->