### PR TITLE
chore: make createSigner optionally async

### DIFF
--- a/account-kit/core/src/actions/reconnect.ts
+++ b/account-kit/core/src/actions/reconnect.ts
@@ -24,7 +24,8 @@ export async function reconnect(config: AlchemyAccountsConfig) {
   // If signer isn't already set, create a new signer.
   // If the createSigner function isn't provided from the config,
   const signer =
-    store.getState().signer ?? config._internal.createSigner(signerConfig);
+    store.getState().signer ??
+    (await config._internal.createSigner(signerConfig));
 
   if (!store.getState().signer) {
     store.setState({

--- a/account-kit/core/src/types.ts
+++ b/account-kit/core/src/types.ts
@@ -55,7 +55,9 @@ export type AlchemyAccountsConfig = {
   store: Store;
   _internal: {
     // if not provided, the default signer will be used
-    createSigner: (config: ClientStoreConfig) => AlchemySigner;
+    createSigner: (
+      config: ClientStoreConfig
+    ) => Promise<AlchemySigner> | AlchemySigner;
     wagmiConfig: WagmiConfig;
     ssr?: boolean;
     storageKey: string;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `createSigner` function in the `_internal` object to return a `Promise` or an `AlchemySigner`. It also modifies how the `signer` is retrieved in the `reconnect.ts` file to await the `createSigner` function.

### Detailed summary
- Changed the return type of `createSigner` in `_internal` from `AlchemySigner` to `Promise<AlchemySigner> | AlchemySigner`.
- Updated the `signer` assignment in `reconnect.ts` to await the `createSigner` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->