### PR TITLE
chore: revert signTypeData change

### DIFF
--- a/aa-sdk/core/src/client/smartAccountClient.ts
+++ b/aa-sdk/core/src/client/smartAccountClient.ts
@@ -259,10 +259,7 @@ export function createSmartAccountClient(
                 );
               }
               try {
-                return client.signTypedData({
-                  typedData: JSON.parse(dataParams),
-                  account: client.account,
-                });
+                return client.signTypedData(dataParams);
               } catch {
                 throw new Error("invalid JSON data params");
               }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on simplifying the `signTypedData` method call in the `smartAccountClient.ts` file by removing the JSON parsing of `dataParams`.

### Detailed summary
- Removed the JSON parsing of `dataParams` in the `signTypedData` method.
- Updated the error handling to throw a new `Error` with the message "invalid JSON data params" if an error occurs during the `try` block.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->