### PR TITLE
fix: use rawtoken for permit, token value for erc20Context

### DIFF
--- a/account-kit/infra/src/gas-manager.ts
+++ b/account-kit/infra/src/gas-manager.ts
@@ -85,6 +85,7 @@ export const PermitTypes = {
 
 export const EIP712NoncesAbi = [
   "function nonces(address owner) external view returns (uint)",
+  "function decimals() public view returns (uint8)",
 ] as const;
 
 export type PermitMessage = {

--- a/account-kit/infra/src/middleware/gasManager.ts
+++ b/account-kit/infra/src/middleware/gasManager.ts
@@ -405,8 +405,21 @@ const generateSignedPermit = async <
   if (!policyToken.erc20Name || !policyToken.version) {
     throw new Error("erc20Name or version is missing");
   }
-  // get a paymaster address
-  const maxAmountToken = policyToken.maxTokenAmount || maxUint256;
+
+  let maxAmountToken = maxUint256;
+
+  if (policyToken.maxTokenAmount) {
+    let { data } = await client.call({
+      to: policyToken.address,
+      data: encodeFunctionData({
+        abi: parseAbi(EIP712NoncesAbi),
+        functionName: "decimals",
+        args: [],
+      }),
+    });
+    let decimals = 10n ** (data ? BigInt(data) : 18n);
+    maxAmountToken = policyToken.maxTokenAmount * decimals;
+  }
   const paymasterData = await (client as Erc7677Client).request({
     method: "pm_getPaymasterStubData",
     params: [

--- a/account-kit/infra/src/middleware/gasManager.ts
+++ b/account-kit/infra/src/middleware/gasManager.ts
@@ -417,7 +417,7 @@ const generateSignedPermit = async <
         args: [],
       }),
     });
-    let decimals = 10n ** (data ? BigInt(data) : 18n);
+    const decimals = 10n ** (data ? BigInt(data) : 18n);
     maxAmountToken = policyToken.maxTokenAmount * decimals;
   }
   const paymasterData = await (client as Erc7677Client).request({


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function to the `EIP712NoncesAbi` and updates the `gasManager.ts` middleware to handle the `maxAmountToken` calculation based on `policyToken.maxTokenAmount`, incorporating the token's `decimals`.

### Detailed summary
- Added `function decimals() public view returns (uint8)` to `EIP712NoncesAbi`.
- Changed `maxAmountToken` from a constant to a variable.
- Updated logic to calculate `maxAmountToken` using `policyToken.maxTokenAmount` and the token's `decimals`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->