### PR TITLE
fix: eip1193 compatible eth_signTypedData_v4 calls + ethers compatibility

### DIFF
--- a/aa-sdk/core/src/client/smartAccountClient.ts
+++ b/aa-sdk/core/src/client/smartAccountClient.ts
@@ -259,11 +259,13 @@ export function createSmartAccountClient(
                 );
               }
               try {
-                return client.signTypedData(
-                  typeof dataParams === "string"
-                    ? JSON.parse(dataParams)
-                    : dataParams
-                );
+                return client.signTypedData({
+                  account: client.account,
+                  typedData:
+                    typeof dataParams === "string"
+                      ? JSON.parse(dataParams)
+                      : dataParams,
+                });
               } catch {
                 throw new Error("invalid JSON data params");
               }

--- a/aa-sdk/core/src/client/smartAccountClient.ts
+++ b/aa-sdk/core/src/client/smartAccountClient.ts
@@ -259,7 +259,11 @@ export function createSmartAccountClient(
                 );
               }
               try {
-                return client.signTypedData(dataParams);
+                return client.signTypedData(
+                  typeof dataParams === "string"
+                    ? JSON.parse(dataParams)
+                    : dataParams
+                );
               } catch {
                 throw new Error("invalid JSON data params");
               }

--- a/aa-sdk/core/src/client/smartAccountClient.ts
+++ b/aa-sdk/core/src/client/smartAccountClient.ts
@@ -259,10 +259,7 @@ export function createSmartAccountClient(
                 );
               }
               try {
-                return client.signTypedData({
-                  typedData: JSON.parse(dataParams),
-                  account: client.account,
-                });
+                return client.signTypedData(dataParams);
               } catch {
                 throw new Error("invalid JSON data params");
               }


### PR DESCRIPTION
Our `eth_signTypedData_v4` implementation previously did not conform to the standard (defined in EIP712). This PR fixes that and adds conditional parsing to ensure ethers support.

Script used to test:
```ts
import { createMultiOwnerModularAccount } from "@alchemy/aa-accounts";
import {
  LocalAccountSigner,
  SmartAccountSigner,
  createSmartAccountClient,
} from "@aa-sdk/core";
import { http } from "viem";
import { polygonAmoy } from "viem/chains";
import { BrowserProvider, Eip1193Provider, TypedDataDomain } from "ethers";
import { generatePrivateKey } from "viem/accounts";

const domain: TypedDataDomain = {
  name: "MyDapp",
  version: "1",
  chainId: 80001,
  verifyingContract: "0x1111222233334444555566667777888899990000",
};

const types: Record<string, TypedDataField[]> = {
  Permit: [
    { name: "owner", type: "address" },
    { name: "spender", type: "address" },
  ],
};

const value = {
  owner: "0x1111222233334444555566667777888899990000",
  spender: "0x1111222233334444555566667777888899990000",
};

async function main() {
  const chain = polygonAmoy;
  const signer: SmartAccountSigner =
    LocalAccountSigner.privateKeyToAccountSigner(generatePrivateKey());
  const rpcTransport = http(
    "https://polygon-amoy.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY
  );

  const smartAccountClient = createSmartAccountClient({
    transport: rpcTransport,
    chain,
    account: await createMultiOwnerModularAccount({
      transport: rpcTransport,
      chain,
      signer,
    }),
  });

  const providerV6 = new BrowserProvider(
    smartAccountClient as unknown as Eip1193Provider
  );

  const ethersSigner = await providerV6.getSigner();
  const responseEthers = await ethersSigner.signTypedData(domain, types, value);

  console.log("Response ethers", responseEthers);

  const responseRaw = await smartAccountClient.request({
    method: "eth_signTypedData_v4",
    params: [
      smartAccountClient.account.address,
      {
        types: types,
        primaryType: "Permit",
        domain: domain,
        message: value,
      },
    ],
  });

  console.log(responseRaw);
}

main();
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `signTypedData` method in the `smartAccountClient.ts` file to enhance error handling and input processing for `dataParams`.

### Detailed summary
- Updated the call to `client.signTypedData` to include an object with `account` and `typedData`.
- Added a check to determine if `dataParams` is a string, parsing it if true; otherwise, it uses `dataParams` directly.
- Improved error handling by throwing a specific error message for invalid JSON data params.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->