### PR TITLE
docs: fix docs to accurately explain when the authenticate method resolves

### DIFF
--- a/docs/pages/react/login-methods/email-magic-link.mdx
+++ b/docs/pages/react/login-methods/email-magic-link.mdx
@@ -112,7 +112,8 @@ const handleSendMagicLink = (email: string) => {
     },
     {
       onSuccess: () => {
-        // Success - inform user to check their email
+        // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+        // It still runs even if the final step completes in another tab/window.
       },
       onError: (error) => {
         // Handle error

--- a/docs/pages/react/login-methods/email-magic-link.mdx
+++ b/docs/pages/react/login-methods/email-magic-link.mdx
@@ -148,7 +148,8 @@ useEffect(() => {
         },
         {
           onSuccess: () => {
-            // Authentication successful!
+            // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+            // It still runs even if the final step completes in another tab/window.
           },
           onError: (error) => {
             // Handle error

--- a/docs/pages/react/login-methods/email-otp.mdx
+++ b/docs/pages/react/login-methods/email-otp.mdx
@@ -124,20 +124,19 @@ const handleSendCode = (email: string) => {
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 
 ```tsx twoslash
-import { useEffect } from "react";
 import { useSignerStatus } from "@account-kit/react";
 import { AlchemySignerStatus } from "@account-kit/signer";
 
-const trackingStatus = () => {
+const TrackStatus = () => {
   const { status } = useSignerStatus();
 
-  useEffect(() => {
-    if (status === AlchemySignerStatus.AWAITING_EMAIL_AUTH) {
-      // Show your OTP input UI
-    }
-  }, [status]);
-
-  return null;
+  return (
+    <>
+      {status === AlchemySignerStatus.AWAITING_EMAIL_AUTH && (
+        <div>Prompt the user to enter the OTP code</div>
+      )}
+    </>
+  );
 };
 ```
 

--- a/docs/pages/react/login-methods/email-otp.mdx
+++ b/docs/pages/react/login-methods/email-otp.mdx
@@ -124,6 +124,7 @@ const handleSendCode = (email: string) => {
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 
 ```tsx twoslash
+import React from "react";
 import { useSignerStatus } from "@account-kit/react";
 import { AlchemySignerStatus } from "@account-kit/signer";
 

--- a/docs/pages/react/login-methods/email-otp.mdx
+++ b/docs/pages/react/login-methods/email-otp.mdx
@@ -119,7 +119,7 @@ const handleSendCode = (email: string) => {
 };
 ```
 
-### Step 2: Track Authentication Status to know when to show the OTP input form
+### Step 2: Show OTP Input on Status Change
 
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 

--- a/docs/pages/react/login-methods/email-otp.mdx
+++ b/docs/pages/react/login-methods/email-otp.mdx
@@ -124,6 +124,7 @@ const handleSendCode = (email: string) => {
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 
 ```tsx twoslash
+import { useEffect } from "react";
 import { useSignerStatus } from "@account-kit/react";
 import { AlchemySignerStatus } from "@account-kit/signer";
 

--- a/docs/pages/react/login-methods/email-otp.mdx
+++ b/docs/pages/react/login-methods/email-otp.mdx
@@ -108,7 +108,8 @@ const handleSendCode = (email: string) => {
     },
     {
       onSuccess: () => {
-        // Success - now show the OTP input form
+        // onSuccess only fires once the entire flow is done (email OTP + optional MFA).
+        // It still runs even if the final step completes in another tab/window.
       },
       onError: (error) => {
         // Handle error
@@ -118,7 +119,28 @@ const handleSendCode = (email: string) => {
 };
 ```
 
-### Step 2: Verify the OTP
+### Step 2: Track Authentication Status to know when to show the OTP input form
+
+Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
+
+```tsx twoslash
+import { useSignerStatus } from "@account-kit/react";
+import { AlchemySignerStatus } from "@account-kit/signer";
+
+const trackingStatus = () => {
+  const { status } = useSignerStatus();
+
+  useEffect(() => {
+    if (status === AlchemySignerStatus.AWAITING_EMAIL_AUTH) {
+      // Show your OTP input UI
+    }
+  }, [status]);
+
+  return null;
+};
+```
+
+### Step 3: Verify the OTP
 
 Once the user receives the code, they'll enter it in your application:
 
@@ -137,7 +159,8 @@ const handleVerifyCode = (otpCode: string) => {
     },
     {
       onSuccess: () => {
-        // Authentication successful!
+        // onSuccess only fires once the entire flow is done (email OTP + optional MFA).
+        // It still runs even if the final step completes in another tab/window.
       },
       onError: (error) => {
         // Handle invalid code error
@@ -147,7 +170,7 @@ const handleVerifyCode = (otpCode: string) => {
 };
 ```
 
-### Step 3: Track Authentication Status
+### Step 4: Check authentication status
 
 Use the `useSignerStatus` hook to determine if the user is authenticated:
 

--- a/docs/pages/react/mfa/email-magic-link.mdx
+++ b/docs/pages/react/mfa/email-magic-link.mdx
@@ -146,7 +146,8 @@ function MagicLinkRedirect() {
       },
       {
         onSuccess: () => {
-          // Authentication successful!
+          // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+          // It still runs even if the final step completes in another tab/window.
         },
         onError: (error) => {
           // Handle error

--- a/docs/pages/signer/authentication/email-magic-link.mdx
+++ b/docs/pages/signer/authentication/email-magic-link.mdx
@@ -27,6 +27,7 @@ For setting up the OTP flow, see [Email OTP Authentication](/wallets/signer/auth
 import { signer } from "./signer";
 
 // send the email
+// resolves when the user is fully authenticated (magic link + optional MFA), even if completion happens in another tab/window
 await signer.authenticate({
   type: "email",
   emailMode: "magicLink",
@@ -40,9 +41,39 @@ if (!bundle) {
   throw new Error("No bundle found in URL");
 }
 
+// resolves when the user is fully authenticated (magic link + optional MFA), even if completion happens in another tab/window
 await signer.authenticate({
   type: "email",
   bundle,
+});
+```
+
+<Markdown src="../../../shared/signer/signer.mdx" />
+
+</CodeBlocks>
+
+### Track Authentication Status
+
+Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to respond to OTP/MFA prompts and completion:
+
+<CodeBlocks>
+
+```ts twoslash [example.ts]
+import { signer } from "./signer";
+import { AlchemySignerStatus } from "@account-kit/signer";
+
+signer.on("statusChanged", (status) => {
+  switch (status) {
+    case AlchemySignerStatus.AWAITING_EMAIL_AUTH:
+      // show OTP input UI
+      break;
+    case AlchemySignerStatus.AWAITING_MFA_AUTH:
+      // show TOTP input UI
+      break;
+    case AlchemySignerStatus.CONNECTED:
+      // authentication complete
+      break;
+  }
 });
 ```
 

--- a/docs/pages/signer/authentication/email-otp.mdx
+++ b/docs/pages/signer/authentication/email-otp.mdx
@@ -20,7 +20,8 @@ Email OTP authentication allows you to log in and sign up users using an email a
 import { signer } from "./signer";
 
 // send the email
-// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
+// Promise resolves when the user is fully authenticated (OTP + optional MFA),
+// even if final step completes in another tab/window
 await signer.authenticate({
   type: "email",
   emailMode: "otp",
@@ -28,7 +29,8 @@ await signer.authenticate({
 });
 
 // later once the user has entered the code from their email
-// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
+// Promise resolves when the user is fully authenticated (OTP + optional MFA),
+// even if final step completes in another tab/window
 await signer.authenticate({
   type: "otp",
   otpCode: "123456",

--- a/docs/pages/signer/authentication/email-otp.mdx
+++ b/docs/pages/signer/authentication/email-otp.mdx
@@ -20,6 +20,7 @@ Email OTP authentication allows you to log in and sign up users using an email a
 import { signer } from "./signer";
 
 // send the email
+// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
 await signer.authenticate({
   type: "email",
   emailMode: "otp",
@@ -27,9 +28,39 @@ await signer.authenticate({
 });
 
 // later once the user has entered the code from their email
+// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
 await signer.authenticate({
   type: "otp",
   otpCode: "123456",
+});
+```
+
+<Markdown src="../../../shared/signer/signer.mdx" />
+
+</CodeBlocks>
+
+### Track Authentication Status
+
+Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to respond to OTP/MFA prompts and completion:
+
+<CodeBlocks>
+
+```ts twoslash [example.ts]
+import { signer } from "./signer";
+import { AlchemySignerStatus } from "@account-kit/signer";
+
+signer.on("statusChanged", (status) => {
+  switch (status) {
+    case AlchemySignerStatus.AWAITING_EMAIL_AUTH:
+      // show OTP input UI
+      break;
+    case AlchemySignerStatus.AWAITING_MFA_AUTH:
+      // show TOTP input UI
+      break;
+    case AlchemySignerStatus.CONNECTED:
+      // authentication complete
+      break;
+  }
 });
 ```
 

--- a/docs/pages/signer/authentication/mfa.mdx
+++ b/docs/pages/signer/authentication/mfa.mdx
@@ -163,6 +163,8 @@ const promptUserForCode = async () => {
 };
 
 try {
+  // Promise resolves when the user is fully authenticated (email magic link + optional MFA),
+  // even if completion happens in another tab/window
   await signer.authenticate({
     type: "email",
     email: "user@mail.com",
@@ -174,6 +176,9 @@ try {
     const totpCode = await promptUserForCode();
 
     const { multiFactorId } = err.multiFactors[0];
+
+    // Promise resolves when the user is fully authenticated (email magic link + optional MFA),
+    // even if completion happens in another tab/window
     await signer.authenticate({
       type: "email",
       emailMode: "magicLink",

--- a/site/pages/react/login-methods/email-magic-link.mdx
+++ b/site/pages/react/login-methods/email-magic-link.mdx
@@ -113,7 +113,8 @@ const handleSendMagicLink = (email: string) => {
     },
     {
       onSuccess: () => {
-        // Success - inform user to check their email
+        // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+        // It still runs even if the final step completes in another tab/window.
       },
       onError: (error) => {
         // Handle error

--- a/site/pages/react/login-methods/email-magic-link.mdx
+++ b/site/pages/react/login-methods/email-magic-link.mdx
@@ -149,7 +149,8 @@ useEffect(() => {
         },
         {
           onSuccess: () => {
-            // Authentication successful!
+            // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+            // It still runs even if the final step completes in another tab/window.
           },
           onError: (error) => {
             // Handle error

--- a/site/pages/react/login-methods/email-otp.mdx
+++ b/site/pages/react/login-methods/email-otp.mdx
@@ -111,7 +111,8 @@ const handleSendCode = (email: string) => {
     },
     {
       onSuccess: () => {
-        // Success - now show the OTP input form
+        // onSuccess only fires once the entire flow is done (email OTP + optional MFA).
+        // It still runs even if the final step completes in another tab/window.
       },
       onError: (error) => {
         // Handle error
@@ -121,7 +122,28 @@ const handleSendCode = (email: string) => {
 };
 ```
 
-### Step 2: Verify the OTP
+### Step 2: Track Authentication Status to know when to show the OTP input form
+
+Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
+
+```tsx twoslash
+import { useSignerStatus } from "@account-kit/react";
+import { AlchemySignerStatus } from "@account-kit/signer";
+
+const trackingStatus = () => {
+  const { status } = useSignerStatus();
+
+  useEffect(() => {
+    if (status === AlchemySignerStatus.AWAITING_EMAIL_AUTH) {
+      // Show your OTP input UI
+    }
+  }, [status]);
+
+  return null;
+};
+```
+
+### Step 3: Verify the OTP
 
 Once the user receives the code, they'll enter it in your application:
 
@@ -140,7 +162,8 @@ const handleVerifyCode = (otpCode: string) => {
     },
     {
       onSuccess: () => {
-        // Authentication successful!
+        // onSuccess only fires once the entire flow is done (email OTP + optional MFA).
+        // It still runs even if the final step completes in another tab/window.
       },
       onError: (error) => {
         // Handle invalid code error
@@ -150,7 +173,7 @@ const handleVerifyCode = (otpCode: string) => {
 };
 ```
 
-### Step 3: Track Authentication Status
+### Step 4: Check authentication status
 
 Use the `useSignerStatus` hook to determine if the user is authenticated:
 

--- a/site/pages/react/login-methods/email-otp.mdx
+++ b/site/pages/react/login-methods/email-otp.mdx
@@ -122,7 +122,7 @@ const handleSendCode = (email: string) => {
 };
 ```
 
-### Step 2: Track Authentication Status to know when to show the OTP input form
+### Step 2: Show OTP Input on Status Change
 
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 

--- a/site/pages/react/login-methods/email-otp.mdx
+++ b/site/pages/react/login-methods/email-otp.mdx
@@ -127,6 +127,7 @@ const handleSendCode = (email: string) => {
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 
 ```tsx twoslash
+import { useEffect } from "react";
 import { useSignerStatus } from "@account-kit/react";
 import { AlchemySignerStatus } from "@account-kit/signer";
 

--- a/site/pages/react/login-methods/email-otp.mdx
+++ b/site/pages/react/login-methods/email-otp.mdx
@@ -127,6 +127,7 @@ const handleSendCode = (email: string) => {
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 
 ```tsx twoslash
+import React from "react";
 import { useSignerStatus } from "@account-kit/react";
 import { AlchemySignerStatus } from "@account-kit/signer";
 

--- a/site/pages/react/login-methods/email-otp.mdx
+++ b/site/pages/react/login-methods/email-otp.mdx
@@ -127,20 +127,19 @@ const handleSendCode = (email: string) => {
 Use the `useSignerStatus` hook and `AlchemySignerStatus` enum to react to status changes:
 
 ```tsx twoslash
-import { useEffect } from "react";
 import { useSignerStatus } from "@account-kit/react";
 import { AlchemySignerStatus } from "@account-kit/signer";
 
-const trackingStatus = () => {
+const TrackStatus = () => {
   const { status } = useSignerStatus();
 
-  useEffect(() => {
-    if (status === AlchemySignerStatus.AWAITING_EMAIL_AUTH) {
-      // Show your OTP input UI
-    }
-  }, [status]);
-
-  return null;
+  return (
+    <>
+      {status === AlchemySignerStatus.AWAITING_EMAIL_AUTH && (
+        <div>Prompt the user to enter the OTP code</div>
+      )}
+    </>
+  );
 };
 ```
 

--- a/site/pages/react/mfa/email-magic-link.mdx
+++ b/site/pages/react/mfa/email-magic-link.mdx
@@ -106,7 +106,8 @@ function MagicLinkWithMFA() {
       },
       {
         onSuccess: () => {
-          // This callback will only fire after the user has clicked the magic link and the email has been verified
+          // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+          // It still runs even if the final step completes in another tab/window.
         },
         onError: (error) => {
           // Handle error
@@ -145,7 +146,8 @@ function MagicLinkRedirect() {
       },
       {
         onSuccess: () => {
-          // Authentication successful!
+          // onSuccess only fires once the entire flow is done (email magic link + optional MFA).
+          // It still runs even if the final step completes in another tab/window.
         },
         onError: (error) => {
           // Handle error

--- a/site/pages/signer/authentication/email-magic-link.mdx
+++ b/site/pages/signer/authentication/email-magic-link.mdx
@@ -25,6 +25,7 @@ For setting up an account config, see the [Signer Quickstart](/signer/quickstart
 import { signer } from "./signer";
 
 // send the email
+// resolves when the user is fully authenticated (magic link + optional MFA), even if completion happens in another tab/window
 await signer.authenticate({
   type: "email",
   emailMode: "magicLink",
@@ -38,9 +39,39 @@ if (!bundle) {
   throw new Error("No bundle found in URL");
 }
 
+// resolves when the user is fully authenticated (magic link + optional MFA), even if completion happens in another tab/window
 await signer.authenticate({
   type: "email",
   bundle,
+});
+```
+
+```ts twoslash [signer] filename="signer.ts"
+// [!include ~/shared/signer/signer.ts]
+```
+
+:::
+
+### Track Authentication Status
+
+Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to respond to magic link/MFA prompts and completion:
+
+```ts twoslash [example.ts]
+import { signer } from "./signer";
+import { AlchemySignerStatus } from "@account-kit/signer";
+
+signer.on("statusChanged", (status) => {
+  switch (status) {
+    case AlchemySignerStatus.AWAITING_EMAIL_AUTH:
+      // show waiting for magic link confirmation UI
+      break;
+    case AlchemySignerStatus.AWAITING_MFA_AUTH:
+      // show TOTP input UI
+      break;
+    case AlchemySignerStatus.CONNECTED:
+      // authentication complete
+      break;
+  }
 });
 ```
 

--- a/site/pages/signer/authentication/email-magic-link.mdx
+++ b/site/pages/signer/authentication/email-magic-link.mdx
@@ -56,6 +56,8 @@ await signer.authenticate({
 
 Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to respond to magic link/MFA prompts and completion:
 
+:::code-group
+
 ```ts twoslash [example.ts]
 import { signer } from "./signer";
 import { AlchemySignerStatus } from "@account-kit/signer";

--- a/site/pages/signer/authentication/email-otp.mdx
+++ b/site/pages/signer/authentication/email-otp.mdx
@@ -19,6 +19,7 @@ For setting up an account config, see the [Signer Quickstart](/signer/quickstart
 import { signer } from "./signer";
 
 // send the email
+// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
 await signer.authenticate({
   type: "email",
   emailMode: "otp",
@@ -26,9 +27,39 @@ await signer.authenticate({
 });
 
 // later once the user has entered the code from their email
+// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
 await signer.authenticate({
   type: "otp",
   otpCode: "123456",
+});
+```
+
+```ts twoslash [signer] filename="signer.ts"
+// [!include ~/shared/signer/signer.ts]
+```
+
+:::
+
+### Track Authentication Status
+
+Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to respond to OTP/MFA prompts and completion:
+
+```ts twoslash [example.ts]
+import { signer } from "./signer";
+import { AlchemySignerStatus } from "@account-kit/signer";
+
+signer.on("statusChanged", (status) => {
+  switch (status) {
+    case AlchemySignerStatus.AWAITING_EMAIL_AUTH:
+      // show OTP input UI
+      break;
+    case AlchemySignerStatus.AWAITING_MFA_AUTH:
+      // show TOTP input UI
+      break;
+    case AlchemySignerStatus.CONNECTED:
+      // authentication complete
+      break;
+  }
 });
 ```
 

--- a/site/pages/signer/authentication/email-otp.mdx
+++ b/site/pages/signer/authentication/email-otp.mdx
@@ -19,7 +19,8 @@ For setting up an account config, see the [Signer Quickstart](/signer/quickstart
 import { signer } from "./signer";
 
 // send the email
-// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
+// Promise resolves when the user is fully authenticated (OTP + optional MFA),
+// even if final step completes in another tab/window
 await signer.authenticate({
   type: "email",
   emailMode: "otp",
@@ -27,7 +28,9 @@ await signer.authenticate({
 });
 
 // later once the user has entered the code from their email
-// resolves when the user is fully authenticated (OTP + optional MFA), even if final step completes in another tab/window
+
+// Promise resolves when the user is fully authenticated (OTP + optional MFA),
+// even if final step completes in another tab/window
 await signer.authenticate({
   type: "otp",
   otpCode: "123456",
@@ -43,6 +46,8 @@ await signer.authenticate({
 ### Track Authentication Status
 
 Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to respond to OTP/MFA prompts and completion:
+
+:::code-group
 
 ```ts twoslash [example.ts]
 import { signer } from "./signer";

--- a/site/pages/signer/authentication/mfa.mdx
+++ b/site/pages/signer/authentication/mfa.mdx
@@ -176,6 +176,8 @@ const promptUserForCode = async () => {
 };
 
 try {
+  // Promise resolves when the user is fully authenticated (email magic link + optional MFA),
+  // even if completion happens in another tab/window
   await signer.authenticate({
     type: "email",
     email: "user@mail.com",
@@ -187,6 +189,9 @@ try {
     const totpCode = await promptUserForCode();
 
     const { multiFactorId } = err.multiFactors[0];
+
+    // Promise resolves when the user is fully authenticated (email magic link + optional MFA),
+    // even if completion happens in another tab/window
     await signer.authenticate({
       type: "email",
       emailMode: "magicLink",


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances documentation regarding the authentication flow using email magic links and OTPs, clarifying that the `onSuccess` callback only triggers after the entire process is complete, even if it occurs in another tab/window.

### Detailed summary
- Updated comments in `email-magic-link.mdx` to clarify `onSuccess` behavior.
- Added explanations in `mfa.mdx` for promise resolution after full authentication.
- Introduced a section on tracking authentication status using `signer.on("statusChanged", callback)`.
- Adjusted comments in `email-otp.mdx` for clarity on OTP flow completion.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->