### PR TITLE
fix: parallel eth_calls, make maxTokenAmount requried

### DIFF
--- a/account-kit/infra/src/client/smartAccountClient.ts
+++ b/account-kit/infra/src/client/smartAccountClient.ts
@@ -50,8 +50,8 @@ export type AlchemySmartAccountClientConfig<
   policyId?: string | string[];
   policyToken?: {
     address: Address;
+    maxTokenAmount: bigint;
     approvalMode?: "NONE" | "PERMIT";
-    maxTokenAmount?: bigint;
     erc20Name?: string;
     version?: string;
   };

--- a/account-kit/infra/src/gas-manager.ts
+++ b/account-kit/infra/src/gas-manager.ts
@@ -86,6 +86,8 @@ export const PermitTypes = {
 export const EIP712NoncesAbi = [
   "function nonces(address owner) external view returns (uint)",
   "function decimals() public view returns (uint8)",
+  "function balanceOf(address owner) external view returns (uint256)",
+  "function allowance(address owner, address spender) external view returns (uint256)",
 ] as const;
 
 export type PermitMessage = {

--- a/account-kit/infra/src/middleware/gasManager.ts
+++ b/account-kit/infra/src/middleware/gasManager.ts
@@ -91,9 +91,7 @@ export function alchemyGasManagerMiddleware(
       const userOp = await deepHexlify(await resolveProperties(uo));
       context.erc20Context = {
         tokenAddress: policyToken.address,
-        ...(policyToken.maxTokenAmount
-          ? { maxTokenAmount: policyToken.maxTokenAmount }
-          : {}),
+        maxTokenAmount: policyToken.maxTokenAmount,
       };
 
       if (policyToken.approvalMode === "PERMIT") {
@@ -134,7 +132,7 @@ interface AlchemyGasAndPaymasterAndDataMiddlewareParams {
 
 export type PolicyToken = {
   address: Address;
-  maxTokenAmount?: bigint;
+  maxTokenAmount: bigint;
   approvalMode?: "NONE" | "PERMIT";
   erc20Name?: string;
   version?: string;
@@ -279,9 +277,7 @@ export function alchemyGasAndPaymasterAndDataMiddleware(
       if (policyToken !== undefined) {
         erc20Context = {
           tokenAddress: policyToken.address,
-          ...(policyToken.maxTokenAmount
-            ? { maxTokenAmount: policyToken.maxTokenAmount }
-            : {}),
+          maxTokenAmount: policyToken.maxTokenAmount,
         };
         if (policyToken.approvalMode === "PERMIT") {
           erc20Context.permit = await generateSignedPermit(
@@ -393,7 +389,7 @@ const generateSignedPermit = async <
   policyId: string | string[],
   policyToken: {
     address: Address;
-    maxTokenAmount?: bigint;
+    maxTokenAmount: bigint;
     approvalMode?: "NONE" | "PERMIT";
     erc20Name?: string;
     version?: string;
@@ -406,21 +402,25 @@ const generateSignedPermit = async <
     throw new Error("erc20Name or version is missing");
   }
 
-  let maxAmountToken = maxUint256;
+  let decimals_future = client.call({
+    to: policyToken.address,
+    data: encodeFunctionData({
+      abi: parseAbi(EIP712NoncesAbi),
+      functionName: "decimals",
+      args: [],
+    }),
+  });
 
-  if (policyToken.maxTokenAmount) {
-    let { data } = await client.call({
-      to: policyToken.address,
-      data: encodeFunctionData({
-        abi: parseAbi(EIP712NoncesAbi),
-        functionName: "decimals",
-        args: [],
-      }),
-    });
-    const decimals = 10n ** (data ? BigInt(data) : 18n);
-    maxAmountToken = policyToken.maxTokenAmount * decimals;
-  }
-  const paymasterData = await (client as Erc7677Client).request({
+  let nonce_future = client.call({
+    to: policyToken.address,
+    data: encodeFunctionData({
+      abi: parseAbi(EIP712NoncesAbi),
+      functionName: "nonces",
+      args: [account.address],
+    }),
+  });
+
+  let paymasterData_future = (client as Erc7677Client).request({
     method: "pm_getPaymasterStubData",
     params: [
       userOp,
@@ -432,6 +432,23 @@ const generateSignedPermit = async <
     ],
   });
 
+  const [decimals_response, nonce_response, paymasterData] = await Promise.all([
+    decimals_future,
+    nonce_future,
+    paymasterData_future,
+  ]);
+  if (!decimals_response.data) {
+    throw new Error("No decimals returned from erc20 contract call");
+  }
+  if (!nonce_response.data) {
+    throw new Error("No nonces returned from erc20 contract call");
+  }
+
+  const decimals =
+    10n ** (decimals_response.data ? BigInt(decimals_response.data) : 18n);
+  const maxAmountToken = policyToken.maxTokenAmount * decimals;
+  const nonce = BigInt(nonce_response.data);
+
   const paymasterAddress = paymasterData.paymaster
     ? paymasterData.paymaster
     : paymasterData.paymasterAndData
@@ -441,18 +458,8 @@ const generateSignedPermit = async <
   if (paymasterAddress === undefined || paymasterAddress === "0x") {
     throw new Error("no paymaster contract address available");
   }
+  // TODO: set a shorter deadline
   const deadline = maxUint256;
-  const { data } = await client.call({
-    to: policyToken.address,
-    data: encodeFunctionData({
-      abi: parseAbi(EIP712NoncesAbi),
-      functionName: "nonces",
-      args: [account.address],
-    }),
-  });
-  if (!data) {
-    throw new Error("No nonces returned from erc20 contract call");
-  }
 
   const typedPermitData = {
     types: PermitTypes,
@@ -467,7 +474,7 @@ const generateSignedPermit = async <
       owner: account.address,
       spender: paymasterAddress,
       value: maxAmountToken,
-      nonce: BigInt(data),
+      nonce: nonce,
       deadline,
     } satisfies PermitMessage,
   } as const;


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of the `maxTokenAmount` property in the `policyToken` object and improving the retrieval of token information via contract calls, ensuring that values are properly assigned and utilized.

### Detailed summary
- Changed `maxTokenAmount` in `policyToken` from optional to required.
- Refactored code to directly assign `maxTokenAmount` without conditional spreading.
- Added new function `balanceOf` and `allowance` in the contract ABI.
- Introduced `Promise.all` for concurrent fetching of `decimals`, `nonces`, and `paymasterData`.
- Improved error handling for missing contract call responses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->