### PR TITLE
feat: support chain agnostic rpc url override

### DIFF
--- a/aa-sdk/core/src/client/schema.ts
+++ b/aa-sdk/core/src/client/schema.ts
@@ -19,28 +19,34 @@ export const createPublicErc4337ClientSchema = <
   });
 
 // [!region ConnectionConfigSchema]
-export const ConnectionConfigSchema = z.union([
+// TODO: in v5 either remove this or simplify it (either way this should be moved out of aa-sdk/core)
+export const ConnectionConfigSchema = z.intersection(
+  z.union([
+    z.object({
+      rpcUrl: z.never().optional(),
+      apiKey: z.string(),
+      jwt: z.never().optional(),
+    }),
+    z.object({
+      rpcUrl: z.never().optional(),
+      apiKey: z.never().optional(),
+      jwt: z.string(),
+    }),
+    z.object({
+      rpcUrl: z.string(),
+      apiKey: z.never().optional(),
+      jwt: z.never().optional(),
+    }),
+    z.object({
+      rpcUrl: z.string(),
+      apiKey: z.never().optional(),
+      jwt: z.string(),
+    }),
+  ]),
   z.object({
-    rpcUrl: z.never().optional(),
-    apiKey: z.string(),
-    jwt: z.never().optional(),
-  }),
-  z.object({
-    rpcUrl: z.never().optional(),
-    apiKey: z.never().optional(),
-    jwt: z.string(),
-  }),
-  z.object({
-    rpcUrl: z.string(),
-    apiKey: z.never().optional(),
-    jwt: z.never().optional(),
-  }),
-  z.object({
-    rpcUrl: z.string(),
-    apiKey: z.never().optional(),
-    jwt: z.string(),
-  }),
-]);
+    chainAgnosticUrl: z.string().optional(),
+  })
+);
 // [!endregion ConnectionConfigSchema]
 
 export const UserOperationFeeOptionsFieldSchema =

--- a/account-kit/infra/src/alchemyTransport.ts
+++ b/account-kit/infra/src/alchemyTransport.ts
@@ -26,8 +26,10 @@ type Never<T> = T extends object
     }
   : never;
 
+type AlchemyConnectionConfig = ConnectionConfig;
+
 type SplitTransportConfig = {
-  alchemyConnection: ConnectionConfig;
+  alchemyConnection: AlchemyConnectionConfig;
   nodeRpcUrl: string;
 };
 
@@ -54,8 +56,8 @@ const chainAgnosticMethods = [
 ];
 
 export type AlchemyTransportConfig = (
-  | (ConnectionConfig & Never<SplitTransportConfig>)
-  | (SplitTransportConfig & Never<ConnectionConfig>)
+  | (AlchemyConnectionConfig & Never<SplitTransportConfig>)
+  | (SplitTransportConfig & Never<AlchemyConnectionConfig>)
 ) & {
   /** The max number of times to retry. */
   retryCount?: TransportConfig["retryCount"] | undefined;
@@ -179,7 +181,7 @@ export function alchemy(config: AlchemyTransportConfig): AlchemyTransport {
     const chainAgnosticRpcUrl =
       connectionConfig.rpcUrl == null
         ? "https://api.g.alchemy.com/v2/"
-        : connectionConfig.rpcUrl;
+        : connectionConfig.chainAgnosticUrl ?? connectionConfig.rpcUrl;
 
     const innerTransport = (() => {
       mutateRemoveTrackingHeaders(config?.fetchOptions?.headers);


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the type definitions and schemas related to `ConnectionConfig` and `AlchemyTransportConfig`, enhancing type safety and clarity in the code.

### Detailed summary
- Introduced `AlchemyConnectionConfig` as an alias for `ConnectionConfig`.
- Updated `SplitTransportConfig` to use `AlchemyConnectionConfig`.
- Modified `AlchemyTransportConfig` type to incorporate the new alias.
- Changed `rpcUrl` retrieval logic to prefer `chainAgnosticUrl`.
- Refactored `ConnectionConfigSchema` to use `z.intersection` and include a new `chainAgnosticUrl` field.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->