### PR TITLE
feat: compute light account counterfactual address locally

### DIFF
--- a/account-kit/smart-contracts/src/light-account/abis/OZ_ERC1967Proxy.ts
+++ b/account-kit/smart-contracts/src/light-account/abis/OZ_ERC1967Proxy.ts
@@ -1,0 +1,19 @@
+// Trimmed ABI containing only the constructor for the OpenZeppelin ERC1967Proxy contract.
+export const OZ_ERC1967Proxy_ConstructorAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "_logic",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+] as const;

--- a/account-kit/smart-contracts/src/light-account/accounts/account.ts
+++ b/account-kit/smart-contracts/src/light-account/accounts/account.ts
@@ -1,6 +1,5 @@
 import {
   createBundlerClient,
-  getAccountAddress,
   getEntryPoint,
   type Address,
   type EntryPointDef,
@@ -32,6 +31,7 @@ import {
   type CreateLightAccountBaseParams,
   type LightAccountBase,
 } from "./base.js";
+import { predictLightAccountAddress } from "./predictAddress.js";
 
 export type LightAccount<
   TSigner extends SmartAccountSigner = SmartAccountSigner,
@@ -126,31 +126,35 @@ export async function createLightAccount({
       ? LightAccountFactoryAbi_v1
       : LightAccountFactoryAbi_v2;
 
+  const signerAddress = await signer.getAddress();
+
+  const salt = LightAccountUnsupported1271Factories.has(
+    factoryAddress.toLowerCase() as Address
+  )
+    ? 0n
+    : salt_;
+
   const getAccountInitCode = async () => {
     if (initCode) return initCode;
-
-    const salt = LightAccountUnsupported1271Factories.has(
-      factoryAddress.toLowerCase() as Address
-    )
-      ? 0n
-      : salt_;
 
     return concatHex([
       factoryAddress,
       encodeFunctionData({
         abi: factoryAbi,
         functionName: "createAccount",
-        args: [await signer.getAddress(), salt],
+        args: [signerAddress, salt],
       }),
     ]);
   };
 
-  const address = await getAccountAddress({
-    client,
-    entryPoint,
-    accountAddress,
-    getAccountInitCode,
-  });
+  const address =
+    accountAddress ??
+    predictLightAccountAddress({
+      factoryAddress,
+      salt,
+      signerAddress,
+      version,
+    });
 
   const account = await createLightAccountBase<
     "LightAccount",

--- a/account-kit/smart-contracts/src/light-account/accounts/predictAddress.ts
+++ b/account-kit/smart-contracts/src/light-account/accounts/predictAddress.ts
@@ -1,0 +1,95 @@
+import {
+  encodeAbiParameters,
+  encodeDeployData,
+  keccak256,
+  getContractAddress,
+  type Address,
+  type Hex,
+  toHex,
+  encodeFunctionData,
+} from "viem";
+import type { LightAccountVersionConfigs } from "../types";
+import { OZ_ERC1967Proxy_ConstructorAbi } from "../abis/OZ_ERC1967Proxy.js";
+import { AccountVersionRegistry } from "../utils.js";
+import { LightAccountAbi_v1 } from "../abis/LightAccountAbi_v1.js";
+
+export type PredictLightAccountAddressParams = {
+  factoryAddress: Address;
+  salt: bigint;
+  signerAddress: Address;
+  version: keyof LightAccountVersionConfigs["LightAccount"];
+};
+
+export function predictLightAccountAddress({
+  factoryAddress,
+  salt,
+  signerAddress,
+  version,
+}: PredictLightAccountAddressParams): Address {
+  const implementationAddress =
+    // If we aren't using the default factory address, we compute the implementation address from the factory's `create` deployment.
+    // This is accurate for both LA v1 and v2 factories. If we are using the default factory address, we use the implementation address from the registry.
+    factoryAddress !==
+    AccountVersionRegistry.LightAccount[version].addresses.default.factory
+      ? getContractAddress({
+          from: factoryAddress,
+          nonce: 1n,
+        })
+      : AccountVersionRegistry.LightAccount[version].addresses.default.impl;
+
+  switch (version) {
+    case "v1.0.1":
+    case "v1.0.2":
+    case "v1.1.0":
+      // Same proxy initcode for all LA v1 factories
+      const LAv1_proxy_bytecode: Hex =
+        "0x60406080815261042c908138038061001681610218565b93843982019181818403126102135780516001600160a01b038116808203610213576020838101516001600160401b0394919391858211610213570186601f820112156102135780519061007161006c83610253565b610218565b918083528583019886828401011161021357888661008f930161026e565b813b156101b9577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc80546001600160a01b031916841790556000927fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b8480a28051158015906101b2575b61010b575b855160e790816103458239f35b855194606086019081118682101761019e578697849283926101889952602788527f416464726573733a206c6f772d6c6576656c2064656c65676174652063616c6c87890152660819985a5b195960ca1b8a8901525190845af4913d15610194573d9061017a61006c83610253565b91825281943d92013e610291565b508038808080806100fe565b5060609250610291565b634e487b7160e01b84526041600452602484fd5b50826100f9565b855162461bcd60e51b815260048101859052602d60248201527f455243313936373a206e657720696d706c656d656e746174696f6e206973206e60448201526c1bdd08184818dbdb9d1c9858dd609a1b6064820152608490fd5b600080fd5b6040519190601f01601f191682016001600160401b0381118382101761023d57604052565b634e487b7160e01b600052604160045260246000fd5b6001600160401b03811161023d57601f01601f191660200190565b60005b8381106102815750506000910152565b8181015183820152602001610271565b919290156102f357508151156102a5575090565b3b156102ae5790565b60405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e74726163740000006044820152606490fd5b8251909150156103065750805190602001fd5b6044604051809262461bcd60e51b825260206004830152610336815180928160248601526020868601910161026e565b601f01601f19168101030190fdfe60806040523615605f5773ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc54166000808092368280378136915af43d82803e15605b573d90f35b3d90fd5b73ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc54166000808092368280378136915af43d82803e15605b573d90f3fea26469706673582212205da2750cd2b0cadfd354d8a1ca4752ed7f22214c8069d852f7dc6b8e9e5ee66964736f6c63430008150033";
+
+      return getContractAddress({
+        from: factoryAddress,
+        opcode: "CREATE2",
+        salt: toHex(salt, { size: 32 }),
+        bytecode: encodeDeployData({
+          bytecode: LAv1_proxy_bytecode,
+          abi: OZ_ERC1967Proxy_ConstructorAbi,
+          args: [
+            implementationAddress,
+            encodeFunctionData({
+              abi: LightAccountAbi_v1,
+              functionName: "initialize",
+              args: [signerAddress],
+            }),
+          ],
+        }),
+      });
+
+    case "v2.0.0":
+      // Logic ported from LA factory v2.0.0
+      const combinedSalt = keccak256(
+        encodeAbiParameters(
+          [{ type: "address" }, { type: "uint256" }],
+          [signerAddress, salt]
+        )
+      );
+
+      // Bytecode from https://github.com/Vectorized/solady/blob/c6e5238e5f3b621789c59e1a443f43b6606394b2/src/utils/LibClone.sol#L721
+
+      const initCode: Hex = `0x603d3d8160223d3973${implementationAddress.slice(
+        2
+      )}60095155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3`;
+
+      return getContractAddress({
+        from: factoryAddress,
+        opcode: "CREATE2",
+        salt: combinedSalt,
+        bytecode: initCode,
+      });
+
+    default:
+      assertNeverLightAccountVersion(version);
+  }
+}
+
+function assertNeverLightAccountVersion(version: never): never {
+  throw new Error(`Unknown light account version: ${version}`);
+}

--- a/account-kit/smart-contracts/src/light-account/accounts/predictAddresses.test.ts
+++ b/account-kit/smart-contracts/src/light-account/accounts/predictAddresses.test.ts
@@ -1,0 +1,122 @@
+import {
+  getAccountAddress,
+  getEntryPoint,
+  LocalAccountSigner,
+} from "@aa-sdk/core";
+import { concatHex, custom, encodeFunctionData, publicActions } from "viem";
+import { predictLightAccountAddress } from "./predictAddress.js";
+import { local060Instance, local070Instance } from "~test/instances.js";
+import { createLightAccount } from "./account.js";
+import { generatePrivateKey } from "viem/accounts";
+import { LightAccountFactoryAbi_v1 } from "../abis/LightAccountFactoryAbi_v1.js";
+import type { LightAccountVersion } from "../types.js";
+
+describe("Light Account Counterfactual Address Tests", () => {
+  const instanceV060 = local060Instance;
+  const instanceV070 = local070Instance;
+
+  it.each([
+    "v1.0.1",
+    "v1.0.2",
+    "v1.1.0",
+  ] as LightAccountVersion<"LightAccount">[])(
+    "LAv1 should match the entrypoint generated counterfactual address",
+    async (version) => {
+      // Repeat 20 times, with a randomized address and salt. Pseudo-fuzzing.
+
+      for (let i = 0; i < 20; i++) {
+        const localSigner = LocalAccountSigner.privateKeyToAccountSigner(
+          generatePrivateKey()
+        );
+
+        // Generate a random salt. The same generator function for private keys can be used, because it is also a 32 byte value.
+        const salt = BigInt(generatePrivateKey());
+
+        const chain = instanceV060.chain;
+        const entryPoint = getEntryPoint(chain, {
+          version: "0.6.0", // EP version, not LA version
+        });
+
+        const lightAccountV1 = await createLightAccount({
+          transport: custom(instanceV060.getClient()),
+          signer: localSigner,
+          chain,
+          salt,
+          version,
+        });
+
+        // First, compute the address using the EntryPoint utility function:
+        const entryPointComputedAddress = await getAccountAddress({
+          client: instanceV060.getClient().extend(publicActions),
+          entryPoint,
+          // cannot use lightAccountV1.getInitCode, because it silently replaces salt with 0n for non-replay-safe-1271 account versions.
+          getAccountInitCode: async () => {
+            return concatHex([
+              await lightAccountV1.getFactoryAddress(),
+              encodeFunctionData({
+                abi: LightAccountFactoryAbi_v1,
+                functionName: "createAccount",
+                args: [await localSigner.getAddress(), salt],
+              }),
+            ]);
+          },
+        });
+
+        // Then, compute the address using the predictLightAccountAddress function:
+
+        const locallyComputedAddress = await predictLightAccountAddress({
+          factoryAddress: await lightAccountV1.getFactoryAddress(),
+          salt,
+          signerAddress: await localSigner.getAddress(),
+          version,
+        });
+
+        expect(entryPointComputedAddress).toEqual(locallyComputedAddress);
+      }
+    }
+  );
+
+  it("LAv2 should match the entrypoint generated counterfactual address", async () => {
+    // Repeat 20 times, with a randomized address and salt. Pseudo-fuzzing.
+
+    for (let i = 0; i < 20; i++) {
+      const localSigner = LocalAccountSigner.privateKeyToAccountSigner(
+        generatePrivateKey()
+      );
+
+      // Generate a random salt. The same generator function for private keys can be used, because it is also a 32 byte value.
+      const salt = BigInt(generatePrivateKey());
+
+      const chain = instanceV070.chain;
+      const entryPoint = getEntryPoint(chain, {
+        version: "0.7.0", // EP version, not LA version
+      });
+
+      const lightAccountV2 = await createLightAccount({
+        transport: custom(instanceV070.getClient()),
+        signer: localSigner,
+        chain,
+        salt,
+        version: "v2.0.0",
+      });
+
+      // First, compute the address using the EntryPoint utility function:
+      const entryPointComputedAddress = await getAccountAddress({
+        client: instanceV070.getClient().extend(publicActions),
+        entryPoint,
+        // Can use the lightAccountV2.getInitCode, because it is replay-safe.
+        getAccountInitCode: lightAccountV2.getInitCode,
+      });
+
+      // Then, compute the address using the predictLightAccountAddress function:
+      const locallyComputedAddress = await predictLightAccountAddress({
+        factoryAddress: await lightAccountV2.getFactoryAddress(),
+        salt,
+        signerAddress: await localSigner.getAddress(),
+        version: "v2.0.0",
+      });
+
+      expect(entryPointComputedAddress).toEqual(locallyComputedAddress);
+    }
+  });
+});


### PR DESCRIPTION
To avoid the round-trip time of the `eth_call` based counterfactual address computation, just locally compute the `create2` predicted address during account creation.

This is implemented just for LightAccount now. I will implement MultiOwnerLightAccount and ModularAccount v1 and v2 later.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality related to predicting light account addresses in a smart contract environment. It introduces a constructor ABI for the OpenZeppelin `ERC1967Proxy`, updates address prediction logic, and adds tests for counterfactual addresses.

### Detailed summary
- Added a trimmed ABI for the `OpenZeppelin ERC1967Proxy` contract in `OZ_ERC1967Proxy.ts`.
- Introduced the `predictLightAccountAddress` function in `predictAddress.ts` to compute addresses based on the factory and salt.
- Updated the `createLightAccount` function in `account.ts` to use the new `predictLightAccountAddress` logic.
- Added tests in `predictAddresses.test.ts` to verify counterfactual address predictions for different light account versions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->