### PR TITLE
docs: updated links to point to new docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ There are currently 2 SDKs that are part of the `aa-sdk` suite:
 
 The core SDK also implements an EIP-1193 provider interface to easily plug into any popular dapp or wallet connect libraries such as RainbowKit, Wagmi, and Web3Modal. It also includes [`ethers.js`](https://docs.ethers.org/v5/) adapters to provide full support for `ethers.js`` apps.
 
-The `aa-sdk` is modular at every layer of the stack and can be easily extended to fit your custom needs. You can plug in any [smart account](https://accountkit.alchemy.com/smart-accounts/custom/using-your-own) implementation, [Signer](https://accountkit.alchemy.com/what-is-a-signer), [Gas Manager API](https://accountkit.alchemy.com/react/sponsor-gas) and RPC Provider.
+The `aa-sdk` is modular at every layer of the stack and can be easily extended to fit your custom needs. You can plug in any [smart account](https://www.alchemy.com/docs/wallets/smart-contracts/choosing-a-smart-account#bring-your-own-smart-account) implementation, [Signer](https://www.alchemy.com/docs/wallets/signer/what-is-a-signer), [Gas Manager API](https://www.alchemy.com/docs/wallets/react/sponsor-gas) and RPC Provider.
 
 ## Getting started
 
-Check out this [quickstart guide](https://accountkit.alchemy.com/react/quickstart) to get started.
+Check out this [quickstart guide](https://www.alchemy.com/docs/wallets/react/quickstart) to get started.
 
 ## Contributing
 

--- a/aa-sdk/core/src/errors/base.ts
+++ b/aa-sdk/core/src/errors/base.ts
@@ -39,7 +39,7 @@ export class BaseError extends ViemBaseError {
       ...(args.metaMessages ? [...args.metaMessages, ""] : []),
       ...(docsPath
         ? [
-            `Docs: https://accountkit.alchemy.com${docsPath}${
+            `Docs: https://www.alchemy.com/docs/wallets${docsPath}${
               args.docsSlug ? `#${args.docsSlug}` : ""
             }`,
           ]

--- a/aa-sdk/ethers/README.md
+++ b/aa-sdk/ethers/README.md
@@ -2,13 +2,13 @@
 
 This package contains `EthersProviderAdapter` and `AccountSigner`, respective extensions of the [`JsonRpcProvider`](https://docs.ethers.org/v5/api/providers/jsonrpc-provider/) and [`Signer`](https://docs.ethers.org/v5/api/signer/) classes defined in [`ethers.js`](https://docs.ethers.org/v5/) external library.
 
-If you currently rely `ethers.js` for web3 development, you can use these `ethers.js`-compatible `JsonRpcProvider` and `Signer` to integrate Account Abstraction into your dApp. You may also find the [`util`](https://accountkit.alchemy.com/packages/aa-ethers/utils/introduction.html) methods helpful.
+If you currently rely `ethers.js` for web3 development, you can use these `ethers.js`-compatible `JsonRpcProvider` and `Signer` to integrate Account Abstraction into your dApp. You may also find the [`util`](https://www.alchemy.com/docs/wallets/packages/aa-ethers/utils/introduction) methods helpful.
 
 This repo is community maintained and we welcome contributions!
 
 ## Getting started
 
-If you are already using the `@aa-sdk/core` package, you can simply install this package and start using the `EthersProviderAdapter` and `AccountSigner`. If you are not using `@aa-sdk/core`, you can install it and follow the instructions in the ["Getting started"](https://accountkit.alchemy.com/packages/aa-ethers/) docs to get started.
+If you are already using the `@aa-sdk/core` package, you can simply install this package and start using the `EthersProviderAdapter` and `AccountSigner`. If you are not using `@aa-sdk/core`, you can install it and follow the instructions in the ["Getting started"](https://www.alchemy.com/docs/wallets/packages/aa-ethers/) docs to get started.
 
 ```bash [yarn]
 yarn add @aa-sdk/ethers

--- a/account-kit/core/src/errors.ts
+++ b/account-kit/core/src/errors.ts
@@ -48,7 +48,8 @@ export class ChainNotFoundError extends BaseError {
    */
   constructor(chain: Chain) {
     super(`Chain (${chain.name}) not found in connections config object`, {
-      docsPath: "https://accountkit.alchemy.com/react/createConfig",
+      docsPath:
+        "https://www.alchemy.com/docs/wallets/reference/account-kit/react/functions/createConfig",
     });
   }
 }

--- a/account-kit/react/src/hooks/useChain.ts
+++ b/account-kit/react/src/hooks/useChain.ts
@@ -8,8 +8,8 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import { useSyncExternalStore } from "react";
 import type { Chain } from "viem";
-import { useAlchemyAccountContext } from "./useAlchemyAccountContext.js";
 import type { BaseHookMutationArgs } from "../types.js";
+import { useAlchemyAccountContext } from "./useAlchemyAccountContext.js";
 
 export type UseChainParams = BaseHookMutationArgs<void, { chain: Chain }>;
 
@@ -24,7 +24,7 @@ export interface UseChainResult {
  * Note: when calling `setChain` the chain that's passed in must be defined in
  * your initial `createConfig` call. Calling `setChain` causes the chain to change across the board. For example, if you use set chain then use `useSmartAccountClient`, the client will flip to the loading state and address for the account on the changed chain.
  *
- * For switching chains, you can also use [createBundlerClient](https://accountkit.alchemy.com/reference/aa-sdk/core/functions/createBundlerClient#createbundlerclient) or [createSmartAccoutClient](https://accountkit.alchemy.com/reference/aa-sdk/core/functions/createSmartAccountClient) directly and create a different client for each chain. You would have to manage different clients, but you wouldn't have to wait for any hooks to complete and can run these queries in parallel. This way the chain set in the config that the smart account client and other hooks inherit is not also affected.
+ * For switching chains, you can also use [createBundlerClient](https://www.alchemy.com/docs/wallets/reference/aa-sdk/core/functions/createBundlerClient#createbundlerclient) or [createSmartAccoutClient](https://www.alchemy.com/docs/wallets/reference/aa-sdk/core/functions/createSmartAccountClient) directly and create a different client for each chain. You would have to manage different clients, but you wouldn't have to wait for any hooks to complete and can run these queries in parallel. This way the chain set in the config that the smart account client and other hooks inherit is not also affected.
  *
  * @param {UseChainParams} mutationArgs optional properties which contain mutation arg overrides. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useChain.ts#L14)
  * @returns {UseChainResult} an object containing the current chain and a function to set the chain as well as loading state of setting the chain. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useChain.ts#L16)

--- a/account-kit/react/src/hooks/useUser.ts
+++ b/account-kit/react/src/hooks/useUser.ts
@@ -12,7 +12,7 @@ export type UseUserResult = (User & { type: "eoa" | "sca" }) | null;
  * A React [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUser.ts) that returns the current user information, either from an External Owned Account (EOA) or from the client store. It uses the Alchemy account context and synchronizes with external store updates.
  * The best way to check if user is logged in for both smart account contract users and EOA.
  *
- * If using smart contract account, returns address of the signer. If only using smart account contracts then you can use [useSignerStatus](https://accountkit.alchemy.com/reference/account-kit/react/hooks/useSignerStatus#usesignerstatus) or [useAccount](https://accountkit.alchemy.com/reference/account-kit/react/hooks/useAccount#useaccount) to see if the account is defined.
+ * If using smart contract account, returns address of the signer. If only using smart account contracts then you can use [useSignerStatus](https://www.alchemy.com/docs/wallets/reference/account-kit/react/hooks/useSignerStatus#usesignerstatus) or [useAccount](https://www.alchemy.com/docs/wallets/reference/account-kit/react/hooks/useAccount#useaccount) to see if the account is defined.
  *
  * @returns {UseUserResult} The user information, including address, orgId, userId, and type. If the user is not connected, it returns null. [ref](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUser.ts#L9)
  *

--- a/docs/pages/react/getting-started.mdx
+++ b/docs/pages/react/getting-started.mdx
@@ -54,9 +54,9 @@ export const config = createConfig(
   {
     transport: alchemy({ apiKey: "ALCHEMY_API_KEY" }), // TODO: add your Alchemy API key - https://dashboard.alchemy.com/accounts
     chain: sepolia,
-    ssr: true, // more about ssr: https://accountkit.alchemy.com/react/ssr
+    ssr: true, // more about ssr: https://www.alchemy.com/docs/wallets/react/ssr
     enablePopupOauth: true, // must be set to "true" if you plan on using popup rather than redirect in the social login flow
-    // For more about persisting state with cookies, see: https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
+    // For more about persisting state with cookies, see: https://www.alchemy.com/docs/wallets/react/ssr#persisting-the-account-state
     // storage: cookieStorage,
   },
   uiConfig

--- a/docs/pages/react/quickstart.mdx
+++ b/docs/pages/react/quickstart.mdx
@@ -60,8 +60,8 @@ export const config = createConfig(
   {
     transport: alchemy({ apiKey: "ALCHEMY_API_KEY" }), // TODO: add your Alchemy API key - https://dashboard.alchemy.com/accounts
     chain: sepolia,
-    ssr: true, // more about ssr: https://accountkit.alchemy.com/react/ssr
-    storage: cookieStorage, // more about persisting state with cookies: https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
+    ssr: true, // more about ssr: https://www.alchemy.com/docs/wallets/react/ssr
+    storage: cookieStorage, // more about persisting state with cookies: https://www.alchemy.com/docs/wallets/react/ssr#persisting-the-account-state
     enablePopupOauth: true, // must be set to "true" if you plan on using popup rather than redirect in the social login flow
   },
   uiConfig
@@ -236,8 +236,8 @@ export const config = createConfig(
     // alchemy config
     transport: alchemy({ apiKey: "your_api_key" }), // TODO: add your Alchemy API key - setup your app and embedded account config in the alchemy dashboard (https://dashboard.alchemy.com/accounts)
     chain: sepolia, // TODO: specify your preferred chain here and update imports from @account-kit/infra
-    ssr: true, // Defers hydration of the account state to the client after the initial mount solving any inconsistencies between server and client state (read more here: https://accountkit.alchemy.com/react/ssr)
-    storage: cookieStorage, // persist the account state using cookies (read more here: https://accountkit.alchemy.com/react/ssr#persisting-the-account-state)
+    ssr: true, // Defers hydration of the account state to the client after the initial mount solving any inconsistencies between server and client state (read more here: https://www.alchemy.com/docs/wallets/react/ssr)
+    storage: cookieStorage, // persist the account state using cookies (read more here: https://www.alchemy.com/docs/wallets/react/ssr#persisting-the-account-state)
     enablePopupOauth: true, // must be set to "true" if you plan on using popup rather than redirect in the social login flow
     // optional config to override default session manager config
     sessionConfig: {
@@ -336,7 +336,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // This will allow us to persist state across page boundaries (read more here: https://accountkit.alchemy.com/react/ssr#persisting-the-account-state)
+  // This will allow us to persist state across page boundaries (read more here: https://www.alchemy.com/docs/wallets/react/ssr#persisting-the-account-state)
   const initialState = cookieToInitialState(
     config,
     headers().get("cookie") ?? undefined

--- a/docs/pages/reference/account-kit/react/hooks/useChain.mdx
+++ b/docs/pages/reference/account-kit/react/hooks/useChain.mdx
@@ -10,7 +10,7 @@ A [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/s
 Note: when calling `setChain` the chain that's passed in must be defined in
 your initial `createConfig` call. Calling `setChain` causes the chain to change across the board. For example, if you use set chain then use `useSmartAccountClient`, the client will flip to the loading state and address for the account on the changed chain.
 
-For switching chains, you can also use [createBundlerClient](https://accountkit.alchemy.com/reference/aa-sdk/core/functions/createBundlerClient#createbundlerclient) or [createSmartAccoutClient](https://accountkit.alchemy.com/reference/aa-sdk/core/functions/createSmartAccountClient) directly and create a different client for each chain. You would have to manage different clients, but you wouldn't have to wait for any hooks to complete and can run these queries in parallel. This way the chain set in the config that the smart account client and other hooks inherit is not also affected.
+For switching chains, you can also use [createBundlerClient](https://www.alchemy.com/docs/wallets/reference/aa-sdk/core/functions/createBundlerClient#createbundlerclient) or [createSmartAccoutClient](https://www.alchemy.com/docs/wallets/reference/aa-sdk/core/functions/createSmartAccountClient) directly and create a different client for each chain. You would have to manage different clients, but you wouldn't have to wait for any hooks to complete and can run these queries in parallel. This way the chain set in the config that the smart account client and other hooks inherit is not also affected.
 
 ## Import
 

--- a/docs/pages/reference/account-kit/react/hooks/useUser.mdx
+++ b/docs/pages/reference/account-kit/react/hooks/useUser.mdx
@@ -8,7 +8,7 @@ slug: wallets/reference/account-kit/react/hooks/useUser
 A React [hook](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/react/src/hooks/useUser.ts) that returns the current user information, either from an External Owned Account (EOA) or from the client store. It uses the Alchemy account context and synchronizes with external store updates.
 The best way to check if user is logged in for both smart account contract users and EOA.
 
-If using smart contract account, returns address of the signer. If only using smart account contracts then you can use [useSignerStatus](https://accountkit.alchemy.com/reference/account-kit/react/hooks/useSignerStatus#usesignerstatus) or [useAccount](https://accountkit.alchemy.com/reference/account-kit/react/hooks/useAccount#useaccount) to see if the account is defined.
+If using smart contract account, returns address of the signer. If only using smart account contracts then you can use [useSignerStatus](https://www.alchemy.com/docs/wallets/reference/account-kit/react/hooks/useSignerStatus#usesignerstatus) or [useAccount](https://www.alchemy.com/docs/wallets/reference/account-kit/react/hooks/useAccount#useaccount) to see if the account is defined.
 
 ## Import
 

--- a/examples/react-native-expo-example/README.md
+++ b/examples/react-native-expo-example/README.md
@@ -68,7 +68,7 @@ import "react-native-get-random-values";
 // rest of _layout.tsx
 ```
 
-6. Install [Account Kit](https://accountkit.alchemy.com) Packages. At this point you're ready to use the aa-sdk in your project.
+6. Install [Account Kit](https://www.alchemy.com/docs/wallets) Packages. At this point you're ready to use the aa-sdk in your project.
 
 ```bash
 yarn add @account-kit/react-native-signer @account-kit/signer @account-kit/smart-contracts @account-kit/infra

--- a/examples/ui-demo/e2e/helpers/mintWorkflow.ts
+++ b/examples/ui-demo/e2e/helpers/mintWorkflow.ts
@@ -42,7 +42,7 @@ export async function mintWithGoogleAuthWorkflow(
   await expect(page.locator("a[aria-label='View transaction']")).toBeVisible();
   await expect(page.getByRole("link", { name: "Quickstart" })).toHaveAttribute(
     "href",
-    "https://accountkit.alchemy.com/react/quickstart"
+    "https://www.alchemy.com/docs/wallets/react/quickstart"
   );
   await expect(page.locator("a[aria-label='GitHub']")).toHaveAttribute(
     "href",

--- a/examples/ui-demo/e2e/ui-demo-config.spec.ts
+++ b/examples/ui-demo/e2e/ui-demo-config.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import path from "path";
 test.beforeEach(async ({ page, baseURL }) => {
   await page.goto(baseURL!);
@@ -167,7 +167,7 @@ test("code preview", async ({ page }) => {
     page.getByRole("link", { name: "Fully customize styling here." })
   ).toHaveAttribute(
     "href",
-    "https://accountkit.alchemy.com/react/customization/theme"
+    "https://www.alchemy.com/docs/wallets/react/customization/theme"
   );
   await codePreviewSwitch.click();
   await expect(codePreviewSwitch).not.toBeChecked();

--- a/examples/ui-demo/src/components/eoa-post-login/EOAPostLoginContents.tsx
+++ b/examples/ui-demo/src/components/eoa-post-login/EOAPostLoginContents.tsx
@@ -35,7 +35,7 @@ export const EOAPostLoginActions = () => {
           Switch Login
         </button>
         <a
-          href="https://accountkit.alchemy.com/"
+          href="https://www.alchemy.com/docs/wallets/"
           target="_blank"
           className="akui-btn akui-btn-secondary w-full lg:w-auto flex-1 m-0 lg:ml-2"
         >

--- a/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
+++ b/examples/ui-demo/src/components/preview/MobileSplashPage.tsx
@@ -60,7 +60,7 @@ export function MobileSplashPage() {
             Try it
           </button>
           <a
-            href="https://accountkit.alchemy.com/"
+            href="https://www.alchemy.com/docs/wallets/"
             target="_blank"
             className="akui-btn akui-btn-secondary mb-6 h-10 w-full lg:w-auto flex-1 m-0"
           >

--- a/examples/ui-demo/src/components/preview/PreviewNav.tsx
+++ b/examples/ui-demo/src/components/preview/PreviewNav.tsx
@@ -1,9 +1,9 @@
-import { cn } from "@/lib/utils";
-import { RenderUserConnectionAvatar } from "../user-connection-avatar/RenderUserConnectionAvatar";
-import { useUser } from "@account-kit/react";
-import ExternalLink from "@/components/shared/ExternalLink";
-import { Metrics } from "@/metrics";
 import { CodePreviewSwitch } from "@/components/shared/CodePreviewSwitch";
+import ExternalLink from "@/components/shared/ExternalLink";
+import { cn } from "@/lib/utils";
+import { Metrics } from "@/metrics";
+import { useUser } from "@account-kit/react";
+import { RenderUserConnectionAvatar } from "../user-connection-avatar/RenderUserConnectionAvatar";
 
 export function PreviewNav({
   showCode,
@@ -46,7 +46,7 @@ export function PreviewNav({
                 name: "codepreview_theme_customization_clicked",
               })
             }
-            href="https://accountkit.alchemy.com/react/customization/theme"
+            href="https://www.alchemy.com/docs/wallets/react/customization/theme"
             className="font-semibold text-blue-600"
           >
             Fully customize styling here.

--- a/examples/ui-demo/src/components/user-connection-avatar/UserConnectionDetails.tsx
+++ b/examples/ui-demo/src/components/user-connection-avatar/UserConnectionDetails.tsx
@@ -3,6 +3,7 @@ import { LogoutIcon } from "@/components/icons/logout";
 import { DeploymentStatusIndicator } from "@/components/user-connection-avatar/DeploymentStatusIndicator";
 import { useSignerAddress } from "@/hooks/useSignerAddress";
 import { useConfigStore } from "@/state";
+import { baseSepolia } from "@account-kit/infra";
 import {
   useAccount,
   useLogout,
@@ -13,7 +14,6 @@ import {
 import { useMemo } from "react";
 import { Hex } from "viem";
 import { UserAddressTooltip } from "./UserAddressLink";
-import { baseSepolia } from "@account-kit/infra";
 
 type UserConnectionDetailsProps = {
   deploymentStatus: boolean;
@@ -134,7 +134,7 @@ export function UserConnectionDetails({
           <div className="flex flex-row justify-between items-center mt-[17px]">
             <a
               target="_blank"
-              href="https://accountkit.alchemy.com/concepts/smart-account-signer"
+              href="https://www.alchemy.com/docs/wallets/concepts/smart-account-signer"
               className="flex justify-center items-center"
             >
               <span className="text-md md:text-sm text-fg-secondary mr-1">

--- a/examples/ui-demo/src/utils/links.ts
+++ b/examples/ui-demo/src/utils/links.ts
@@ -1,11 +1,11 @@
 export const links = {
-  docs: "https://accountkit.alchemy.com",
+  docs: "https://www.alchemy.com/docs/wallets",
   github: "https://github.com/alchemyplatform/aa-sdk/tree/v4.x.x",
   integrationCall:
     "https://calendly.com/d/cp7s-3yx-2yh/alchemy-account-kit-ui-alpha",
   // TODO: update once we have final links
-  quickstartGuide: "https://accountkit.alchemy.com/react/quickstart",
+  quickstartGuide: "https://www.alchemy.com/docs/wallets/react/quickstart",
   dashboard: `https://dashboard.alchemy.com/accounts?utm_source=demo_alchemy_com&utm_medium=referral&utm_campaign=demo_to_dashboard`,
-  passkey: "https://accountkit.alchemy.com/core/add-passkey",
-  auth0: "https://accountkit.alchemy.com/signer/authentication/auth0",
+  passkey: "https://www.alchemy.com/docs/wallets/core/add-passkey",
+  auth0: "https://www.alchemy.com/docs/wallets/signer/authentication/auth0",
 };


### PR DESCRIPTION
This fixes a handful of broken links to old pages (that were broken pre-migration) and makes it so we're not reliant on redirects going forward.

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various links in the codebase to point to the new documentation site for Alchemy, replacing references to `accountkit.alchemy.com` with `alchemy.com/docs/wallets`.

### Detailed summary
- Updated documentation links in `base.ts`, `MobileSplashPage.tsx`, `EOAPostLoginContents.tsx`, and others to `alchemy.com/docs/wallets`.
- Changed links in `useUser.mdx`, `useChain.mdx`, and `README.md` to the new documentation URLs.
- Adjusted links in `links.ts` for various guides and references.
- Modified `ui-demo-config.spec.ts` to reflect new URLs for testing.
- Updated comments and links in `quickstart.mdx` and `RootLayout` for consistency with new documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->