### PR TITLE
test: fix usage of Date.now()

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
@@ -276,8 +276,8 @@ describe("MA v2 deferral actions tests", async () => {
       isGlobalValidation: false,
     });
 
-    const now = Date.now();
-    const deadline = Math.round(now / 2 / 1000);
+    const now = Date.now() / 1000;
+    const deadline = Math.round(now / 2);
 
     expect(async () => {
       await new PermissionBuilder({
@@ -299,7 +299,7 @@ describe("MA v2 deferral actions tests", async () => {
           },
         })
         .compileDeferred();
-    }).rejects.toThrow(new ExpiredDeadlineError(deadline, now / 1000));
+    }).rejects.toThrow(new ExpiredDeadlineError(deadline, now));
   });
 
   it("PermissionBuilder: Cannot install expired deferred action", async () => {

--- a/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
@@ -276,7 +276,8 @@ describe("MA v2 deferral actions tests", async () => {
       isGlobalValidation: false,
     });
 
-    const deadline = Math.round(Date.now() / 2 / 1000);
+    const now = Date.now();
+    const deadline = Math.round(now / 2 / 1000);
 
     expect(async () => {
       await new PermissionBuilder({
@@ -298,7 +299,7 @@ describe("MA v2 deferral actions tests", async () => {
           },
         })
         .compileDeferred();
-    }).rejects.toThrow(new ExpiredDeadlineError(deadline, Date.now() / 1000));
+    }).rejects.toThrow(new ExpiredDeadlineError(deadline, now / 1000));
   });
 
   it("PermissionBuilder: Cannot install expired deferred action", async () => {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the calculation of the `deadline` variable in the `deferralActions.test.ts` file to improve clarity and accuracy in the tests related to the `PermissionBuilder`.

### Detailed summary
- Replaced the calculation of `deadline` using `Math.round(Date.now() / 2 / 1000)` with a clearer approach using `const now = Date.now() / 1000` and then calculating `deadline` as `Math.round(now / 2)`.
- Updated the expected error check to use the new `now` variable instead of recalculating `Date.now() / 1000`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->