### PR TITLE
test: fix test being too strict on time

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
@@ -250,7 +250,7 @@ describe("MA v2 deferral actions tests", async () => {
     });
   });
 
-  it("PermissionBuilder: Cannot compile post expiry ", async () => {
+  it("PermissionBuilder: Cannot compile post expiry", async () => {
     const provider = await givenConnectedProvider({ signer });
 
     const serverClient = (
@@ -299,7 +299,9 @@ describe("MA v2 deferral actions tests", async () => {
           },
         })
         .compileDeferred();
-    }).rejects.toThrow(new ExpiredDeadlineError(deadline, now));
+    }).rejects.toThrowError(
+      /compileDeferred\(\): deadline \d+ cannot be before now \(\d+(\.\d+)?\)/
+    );
   });
 
   it("PermissionBuilder: Cannot install expired deferred action", async () => {


### PR DESCRIPTION
Fixes a test that expected a very strict deadline by hardcoding the error string and using regex to match any time.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the test case for the `PermissionBuilder` in the `deferralActions.test.ts` file to improve error handling and formatting.

### Detailed summary
- Changed the test description for clarity by removing an unnecessary space.
- Updated the error assertion to use `toThrowError` with a regex pattern for more flexible error checking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->