### PR TITLE
fix: permission builder validation error

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilderErrors.ts
@@ -100,7 +100,9 @@ export class ValidationConfigUnsetError extends PermissionBuilderError {
    * Constructor for initializing an error message indicating the validation config is unset.
    */
   constructor() {
-    super("Validation config unset, use permissionBuilder.configure(...)");
+    super(
+      "Missing permission among: functions on contract, functions on all contracts, account functions, contract access, or erc20 token transfer"
+    );
   }
 }
 


### PR DESCRIPTION
This PR addresses a permission builder error which does not reveal enough information to act upon for users.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the error message in the constructor of the `permissionBuilderErrors` class to provide a more detailed explanation of the validation configuration issue.

### Detailed summary
- Updated the error message in the `constructor` of `permissionBuilderErrors` from "Validation config unset, use permissionBuilder.configure(...)" to a more descriptive message indicating missing permissions related to various contract functions and token transfers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->