### PR TITLE
test: create webauthn mock helper

### DIFF
--- a/.vitest/package.json
+++ b/.vitest/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "devDependencies": {
     "@types/is-ci": "^3.0.4",
+    "cbor": "^10.0.3",
     "is-ci": "^3.0.1",
     "prool": "^0.0.15",
     "tar": "^7.4.1",

--- a/.vitest/src/webauthn.ts
+++ b/.vitest/src/webauthn.ts
@@ -1,0 +1,169 @@
+import * as cbor from "cbor";
+import * as crypto from "crypto";
+import { createHash, createSign, generateKeyPairSync } from "crypto";
+
+export class SoftWebauthnDevice {
+  credentialId: Buffer | null = null;
+  privateKey: crypto.KeyObject | null = null;
+  publicKey: crypto.KeyObject | null = null;
+  rpId: string | null = null;
+  userHandle: Buffer | null = null;
+  signCount = 0;
+  aaguid = Buffer.alloc(16); // 16 zero bytes
+
+  async credInit(rpId: string, userHandle: Buffer) {
+    this.credentialId = Buffer.from(crypto.randomBytes(32));
+    const { privateKey, publicKey } = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+    });
+    this.privateKey = privateKey;
+    this.publicKey = publicKey;
+    this.rpId = rpId;
+    this.userHandle = userHandle;
+  }
+
+  async create(options: any, origin: string) {
+    if (
+      !options.publicKey.pubKeyCredParams.some(
+        (p: any) => p.alg === -7 && p.type === "public-key",
+      )
+    ) {
+      throw new Error(
+        "Requested pubKeyCredParams does not contain supported type",
+      );
+    }
+
+    if (
+      options.publicKey.attestation &&
+      options.publicKey.attestation !== "none"
+    ) {
+      throw new Error('Only "none" attestation supported');
+    }
+
+    await this.credInit(
+      options.publicKey.rp.id,
+      Buffer.from(options.publicKey.user.id),
+    );
+
+    const clientData = {
+      type: "webauthn.create",
+      challenge: this.base64urlEncode(Buffer.from(options.publicKey.challenge)),
+      origin,
+    };
+
+    const rpIdHash = this.sha256(Buffer.from(this.rpId!, "ascii"));
+    const flags = Buffer.from([0x41]); // attested_data + user_present
+    const signCount = this.packUInt32BE(this.signCount);
+    const credentialId = this.credentialId!;
+    const credentialIdLength = Buffer.alloc(2);
+    credentialIdLength.writeUInt16BE(credentialId.length, 0);
+
+    const coseKey = this.buildCosePublicKey();
+
+    const authData = Buffer.concat([
+      rpIdHash,
+      flags,
+      signCount,
+      this.aaguid,
+      credentialIdLength,
+      credentialId,
+      coseKey,
+    ]);
+
+    const attestationObject = {
+      fmt: "none",
+      attStmt: {},
+      authData,
+    };
+
+    return {
+      id: this.base64urlEncode(credentialId),
+      rawId: credentialId,
+      response: {
+        clientDataJSON: Buffer.from(JSON.stringify(clientData), "utf-8"),
+        attestationObject: cbor.encode(attestationObject),
+      },
+      type: "public-key",
+      getClientExtensionResults: () => ({}),
+    };
+  }
+
+  async get(options: any, origin: string) {
+    if (this.rpId !== options.publicKey.rpId) {
+      throw new Error("Requested rpID does not match current credential");
+    }
+
+    this.signCount += 1;
+
+    const clientData = JSON.stringify({
+      type: "webauthn.get",
+      challenge: this.base64urlEncode(Buffer.from(options.publicKey.challenge)),
+      origin,
+    });
+    const clientDataBuffer = Buffer.from(clientData, "utf-8");
+    const clientDataHash = this.sha256(clientDataBuffer);
+
+    const rpIdHash = this.sha256(Buffer.from(this.rpId!, "ascii"));
+    const flags = Buffer.from([0x01]);
+    const signCount = this.packUInt32BE(this.signCount);
+    const authenticatorData = Buffer.concat([rpIdHash, flags, signCount]);
+
+    const sign = createSign("SHA256");
+    sign.update(Buffer.concat([authenticatorData, clientDataHash]));
+    const signature = sign.sign(this.privateKey!);
+
+    return {
+      id: this.base64urlEncode(this.credentialId!),
+      rawId: this.credentialId!,
+      response: {
+        authenticatorData,
+        clientDataJSON: clientDataBuffer,
+        signature,
+        userHandle: this.userHandle,
+      },
+      type: "public-key",
+      getClientExtensionResults: () => ({}),
+    };
+  }
+
+  private base64urlEncode(buf: Buffer): string {
+    return buf
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  }
+
+  private sha256(data: Buffer): Buffer {
+    return createHash("sha256").update(data).digest();
+  }
+
+  private packUInt32BE(value: number): Buffer {
+    const buf = Buffer.alloc(4);
+    buf.writeUInt32BE(value, 0);
+    return buf;
+  }
+
+  private buildCosePublicKey(): Buffer {
+    // Extract x and y from the public key
+    const spki = this.publicKey!.export({
+      type: "spki",
+      format: "der",
+    }) as Buffer;
+
+    // P-256 public key x and y coordinates are in the BIT STRING at the end of the DER
+    const pubKeyBytes = spki.slice(-65); // 0x04 + 32 bytes x + 32 bytes y
+    const x = pubKeyBytes.slice(1, 33);
+    const y = pubKeyBytes.slice(33, 65);
+
+    const coseKey = new Map<number, any>([
+      [1, 2], // kty: EC2
+      [3, -7], // alg: ES256
+      [-1, 1], // crv: P-256
+      [-2, x], // x
+      [-3, y], // y
+    ]);
+
+    return Buffer.from(cbor.encode(coseKey));
+  }
+}

--- a/.vitest/tsconfig.json
+++ b/.vitest/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "typescript-template/base.json"
+  "extends": "typescript-template/base.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9483,6 +9483,13 @@ caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.300017
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz#dae13a9c80d517c30c6197515a96131c194d8f82"
   integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
 
+cbor@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-10.0.3.tgz#202d79cd696f408700af51b0c9771577048a860e"
+  integrity sha512-72Jnj81xMsqepqdcSdf2+fflz/UDsThOHy5hj2MW5F5xzHL8Oa0KQ6I6V9CwVUPxg5pf+W9xp6W2KilaRXWWtw==
+  dependencies:
+    nofilter "^3.0.2"
+
 "cbw-sdk@npm:@coinbase/wallet-sdk@3.9.3":
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-3.9.3.tgz#daf10cb0c85d0363315b7270cb3f02bedc408aab"
@@ -17179,6 +17186,11 @@ node-stream-zip@^1.9.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.15.0.tgz#158adb88ed8004c6c49a396b50a6a5de3bca33ea"
   integrity sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==
+
+nofilter@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@^7.0.0, nopt@^7.2.1:
   version "7.2.1"


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new class, `SoftWebauthnDevice`, for handling WebAuthn credential creation and retrieval, utilizing the `cbor` library for encoding. It enhances the TypeScript configuration and adds necessary dependencies.

### Detailed summary
- Added `cbor` as a dependency in `.vitest/package.json`.
- Updated TypeScript configuration in `.vitest/tsconfig.json` to include `compilerOptions`.
- Implemented `SoftWebauthnDevice` class in `.vitest/src/webauthn.ts` with methods for credential initialization and creation.
- Added methods for signing and handling WebAuthn data.
- Introduced private utility methods for encoding and hashing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->