### PR TITLE
feat: add use send calls hook

### DIFF
--- a/account-kit/core/package.json
+++ b/account-kit/core/package.json
@@ -59,7 +59,7 @@
     "@account-kit/react-native-signer": "^4.40.0",
     "@account-kit/signer": "^4.40.0",
     "@account-kit/smart-contracts": "^4.40.0",
-    "@account-kit/wallet-client": "^0.1.0-alpha.4",
+    "@account-kit/wallet-client": "^0.1.0-alpha.6",
     "@solana/web3.js": "^1.98.0",
     "js-cookie": "^3.0.5",
     "zod": "^3.22.4",

--- a/account-kit/core/src/createConfig.ts
+++ b/account-kit/core/src/createConfig.ts
@@ -116,6 +116,7 @@ export const createConfig = (
   const config: AlchemyAccountsConfig = {
     store: store,
     accountCreationHint: params.accountCreationHint,
+    mode: params.mode ?? "local",
     _internal: {
       ssr,
       createSigner: createSigner ?? createWebSigner, // <-- Default to web signer if not provided

--- a/account-kit/core/src/experimental/actions/getSmartWalletClient.ts
+++ b/account-kit/core/src/experimental/actions/getSmartWalletClient.ts
@@ -2,7 +2,7 @@ import {
   createSmartWalletClient,
   type SmartWalletClient,
 } from "@account-kit/wallet-client";
-import type { Address, IsUndefined, JsonRpcAccount } from "viem";
+import type { Address } from "viem";
 import { getAlchemyTransport } from "../../actions/getAlchemyTransport.js";
 import { getConnection } from "../../actions/getConnection.js";
 import { getSigner } from "../../actions/getSigner.js";
@@ -11,23 +11,15 @@ import { SignerNotConnectedError } from "../../errors.js";
 import type { AlchemyAccountsConfig } from "../../types.js";
 
 export type GetSmartWalletClientResult<
-  TAccount extends JsonRpcAccount<Address> | undefined =
-    | JsonRpcAccount<`0x${string}`>
-    | undefined,
+  TAccount extends Address | undefined = Address | undefined,
 > = SmartWalletClient<TAccount>;
 
 export type GetSmartWalletClientParams<
-  TAccount extends JsonRpcAccount<Address> | undefined =
-    | JsonRpcAccount<Address>
-    | undefined,
-> = { mode?: "local" | "remote" } & (IsUndefined<TAccount> extends true
-  ? { account?: never }
-  : { account: Address });
+  TAccount extends Address | undefined = Address | undefined,
+> = { account?: TAccount };
 
 export function getSmartWalletClient<
-  TAccount extends JsonRpcAccount<Address> | undefined =
-    | JsonRpcAccount<Address>
-    | undefined,
+  TAccount extends Address | undefined = Address | undefined,
 >(
   config: AlchemyAccountsConfig,
   params?: GetSmartWalletClientParams<TAccount>,
@@ -56,16 +48,12 @@ export function getSmartWalletClient(
     return smartWalletClient;
   }
 
-  // TODO: should we still cache the client like we used to?
-  // honestly that probably caused more problems than it solved
-  // TBD actually, we might store it in the store so we don't run into issues
-  // with react
   const client = createSmartWalletClient({
     transport,
     chain: connection.chain,
     signer,
     account: params?.account,
-    mode: params?.mode ?? "local",
+    mode: config.mode,
   });
 
   config.store.setState((state) => ({

--- a/account-kit/core/src/types.ts
+++ b/account-kit/core/src/types.ts
@@ -55,6 +55,7 @@ export type SupportedAccount<T extends SupportedAccountTypes> =
 export type AlchemyAccountsConfig = {
   store: Store;
   accountCreationHint?: CreateConfigProps["accountCreationHint"];
+  mode: "local" | "remote";
   _internal: {
     // if not provided, the default signer will be used
     createSigner: (config: ClientStoreConfig) => AlchemySigner;
@@ -142,6 +143,7 @@ export type BaseCreateConfigProps = RpcConnectionConfig & {
   accountCreationHint?: NonNullable<
     Parameters<SmartWalletClient["requestAccount"]>[0]
   >["creationHint"];
+  mode?: "local" | "remote";
 
   /**
    * If set, calls `preparePopupOauth` immediately upon initializing the signer.

--- a/account-kit/react/src/experimental/hooks/useSendCalls.ts
+++ b/account-kit/react/src/experimental/hooks/useSendCalls.ts
@@ -1,0 +1,140 @@
+import {
+  clientHeaderTrack,
+  type EntryPointVersion,
+  type UserOperationRequest,
+} from "@aa-sdk/core";
+import type { GetSmartWalletClientResult } from "@account-kit/core/experimental";
+import type { SmartWalletClient } from "@account-kit/wallet-client";
+import {
+  useMutation,
+  type UseMutateAsyncFunction,
+  type UseMutateFunction,
+} from "@tanstack/react-query";
+import { sendTransaction as wagmi_sendTransaction } from "@wagmi/core";
+import { fromHex, type Address, type Hex } from "viem";
+import { useAccount as wagmi_useAccount } from "wagmi";
+import {
+  ClientUndefinedHookError,
+  UnsupportedEOAActionError,
+} from "../../errors.js";
+import { useAlchemyAccountContext } from "../../hooks/useAlchemyAccountContext.js";
+import { ReactLogger } from "../../metrics.js";
+
+export type UseSendCallsParams = {
+  client?: GetSmartWalletClientResult<Address>;
+};
+
+type MutationResult<
+  TEntryPointVersion extends EntryPointVersion = EntryPointVersion,
+> = {
+  ids: Hex[];
+  // TODO: deprecate this
+  request?: UserOperationRequest<TEntryPointVersion>;
+};
+
+export type UseSendCallsResult<
+  TEntryPointVersion extends EntryPointVersion = EntryPointVersion,
+> = {
+  sendCalls: UseMutateFunction<
+    MutationResult<TEntryPointVersion>,
+    Error,
+    Parameters<SmartWalletClient<Address>["prepareCalls"]>[0],
+    unknown
+  >;
+  sendCallsAsync: UseMutateAsyncFunction<
+    MutationResult<TEntryPointVersion>,
+    Error,
+    Parameters<SmartWalletClient<Address>["prepareCalls"]>[0],
+    unknown
+  >;
+  sendCallsResult: MutationResult | undefined;
+  isSendingCalls: boolean;
+  sendCallsError: Error | null;
+};
+
+// TODO: remove the entrypoint version generic when we don't need it anymore
+export function useSendCalls<
+  TEntryPointVersion extends EntryPointVersion = EntryPointVersion,
+>(params: UseSendCallsParams): UseSendCallsResult<TEntryPointVersion> {
+  const { client: _client } = params;
+  const {
+    queryClient,
+    config: {
+      _internal: { wagmiConfig },
+    },
+  } = useAlchemyAccountContext();
+  const { isConnected } = wagmi_useAccount({ config: wagmiConfig });
+
+  const {
+    mutate: sendCalls,
+    mutateAsync: sendCallsAsync,
+    data: sendCallsResult,
+    isPending: isSendingCalls,
+    error: sendCallsError,
+  } = useMutation(
+    {
+      mutationFn: async (
+        params: Parameters<SmartWalletClient<Address>["prepareCalls"]>[0],
+      ): Promise<MutationResult<TEntryPointVersion>> => {
+        if (isConnected) {
+          console.warn(
+            "useSendCalls: connected to an EOA, sending as a transaction instead",
+          );
+          if (params.calls.length !== 1) {
+            throw new UnsupportedEOAActionError(
+              "useSendCalls",
+              "batch execute",
+            );
+          }
+
+          const [call] = params.calls;
+
+          const tx = await wagmi_sendTransaction(wagmiConfig, {
+            to: call.to,
+            data: call.data,
+            value: call.value ? fromHex(call.value, "bigint") : undefined,
+          });
+
+          return {
+            ids: [tx],
+          };
+        }
+
+        if (!_client) {
+          throw new ClientUndefinedHookError("useSendCalls");
+        }
+
+        const client = clientHeaderTrack(_client, "reactUseSendCalls");
+
+        const preparedCalls = await client.prepareCalls(params);
+
+        const signedCalls = await client.signPreparedCalls(preparedCalls);
+
+        const { preparedCallIds } = await client.sendPreparedCalls(signedCalls);
+
+        const signature = (
+          signedCalls.type === "array"
+            ? signedCalls.data[0].signature
+            : signedCalls.signature
+        ).data;
+
+        return {
+          ids: preparedCallIds,
+          request: {
+            ...preparedCalls.data,
+            signature,
+          } as UserOperationRequest<TEntryPointVersion>,
+        };
+      },
+    },
+    queryClient,
+  );
+
+  return {
+    sendCalls: ReactLogger.profiled("sendCalls", sendCalls),
+    sendCallsAsync: ReactLogger.profiled("sendCallsAsync", sendCallsAsync),
+    sendCallsResult,
+    isSendingCalls,
+    sendCallsError,
+  };
+}

--- a/account-kit/react/src/experimental/hooks/useSmartWalletClient.ts
+++ b/account-kit/react/src/experimental/hooks/useSmartWalletClient.ts
@@ -4,10 +4,13 @@ import {
   type GetSmartWalletClientParams,
 } from "@account-kit/core/experimental";
 import { useMemo, useSyncExternalStore } from "react";
+import type { Address } from "viem";
 import { useAccount as wagmi_useAccount } from "wagmi";
 import { useAlchemyAccountContext } from "../../hooks/useAlchemyAccountContext.js";
 
-export function useSmartWalletClient(params: GetSmartWalletClientParams) {
+export function useSmartWalletClient<
+  TAccount extends Address | undefined = Address | undefined,
+>(params: GetSmartWalletClientParams<TAccount>) {
   const {
     config: {
       _internal: { wagmiConfig },

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,10 +67,10 @@
     jwt-decode "^4.0.0"
     zod "^3.22.4"
 
-"@account-kit/wallet-client@^0.1.0-alpha.4":
-  version "0.1.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@account-kit/wallet-client/-/wallet-client-0.1.0-alpha.4.tgz#569933cf8900c90425922438313b11b002a21671"
-  integrity sha512-Tw06XdYYjozrpX4o4nwrZvnfReY6ubMNE70EdYFaZRfP+PtxsrXQPM83cGv0ZCRKNC0jJuYBo2/TiNuHCUIEtA==
+"@account-kit/wallet-client@^0.1.0-alpha.6":
+  version "0.1.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@account-kit/wallet-client/-/wallet-client-0.1.0-alpha.6.tgz#31cf0a39078a8419760cea5f216549629fd75486"
+  integrity sha512-QaxRRI3da0qnVl1jfMWOHal1sV9QiTmLI8w98JPJp2Cm1/AXxyj/u6JRaN01znmriT1tlFi0rTj/ZYiqd/7QiA==
   dependencies:
     "@aa-sdk/core" "^4.34.0"
     "@account-kit/infra" "^4.34.0"


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `mode` property for configuration, updates the `@account-kit/wallet-client` version, and refines the `useSmartWalletClient` and `useSendUserOperation` hooks to support the new mode. It also enhances type definitions and error handling in user operations.

### Detailed summary
- Added `mode` property in `createConfig.ts` with a default value of `"local"`.
- Updated `@account-kit/wallet-client` version from `0.1.0-alpha.4` to `0.1.0-alpha.6`.
- Modified `useSmartWalletClient` to accept a generic type for accounts.
- Enhanced `getSmartWalletClient` to utilize the new `mode` parameter.
- Refined `useSendUserOperation` to handle new logic for user operations.
- Introduced `useSendCalls` hook for handling calls with Smart Wallet.
- Updated type definitions to include `mode` as either `"local"` or `"remote"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->