### PR TITLE
[DO NOT MERGE] feat: allow middleware overrides when preparing user op

### DIFF
--- a/aa-sdk/core/src/actions/smartAccount/types.ts
+++ b/aa-sdk/core/src/actions/smartAccount/types.ts
@@ -14,6 +14,7 @@ import type {
   UserOperationStruct,
 } from "../../types";
 import type { IsUndefined } from "../../utils";
+import type { ClientMiddlewareFn } from "../../middleware/types";
 
 // [!region UpgradeAccountParams]
 export type UpgradeAccountParams<
@@ -43,7 +44,11 @@ export type SendUserOperationParameters<
   uo: UserOperationCallData | BatchUserOperationCallData;
 } & GetAccountParameter<TAccount> &
   GetContextParameter<TContext> &
-  UserOperationOverridesParameter<TEntryPointVersion>;
+  UserOperationOverridesParameter<TEntryPointVersion> & {
+    middlewareOverrides?: {
+      gasEstimator?: ClientMiddlewareFn;
+    };
+  };
 // [!endregion SendUserOperationParameters]
 
 // [!region BuildUserOperationParameters]


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `UpgradeAccountParams` and `_runMiddlewareStack` functions by adding support for middleware overrides, specifically for a `gasEstimator`. This allows for more flexible middleware handling during user operation processing.

### Detailed summary
- Added `middlewareOverrides` property to `UpgradeAccountParams`, allowing customization of middleware.
- Introduced `gasEstimator` of type `ClientMiddlewareFn` in `middlewareOverrides`.
- Updated `_runMiddlewareStack` to accept `middlewareOverrides` and use it for `gasEstimator`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->