### PR TITLE
feat: add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tsconfig*.tsbuildinfo
 yarn-error.log
 lerna-debug.log
 .tool-versions
+.direnv/
 
 # example ignores
 examples/contracts/**/out

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744096231,
+        "narHash": "sha256-kUfx3FKU1Etnua3EaKvpeuXs7zoFiAcli1gBwkPvGSs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b2b0718004cc9a5bca610326de0a82e6ea75920b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "AA-SDK Flake";
+
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "aarch64-darwin";
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [ nodejs yarn ];
+
+        shellHook = ''
+          echo "Node.js development environment activated!"
+          echo "Node version: $(node --version)"
+          echo "Yarn version: $(yarn --version)"
+        '';
+      };
+    };
+}


### PR DESCRIPTION
# Motivation

Nix flakes allow deterministic environments across development, in this case, freezing node & yarn versions. The goal is to avoid "it works on my machine" situations related to node/yarn versions.

This also includes an `.envrc` file, which, if `direnv` is installed, allows developers to automatically enter into the nix dev shell with the appropriate package versions upon navigating into the aa-sdk directory (after `direnv allow` ing in the root dir).

Using Nix is optional, but practical.

This freezes node to `v22.14.0` and yarn to `v1.22.22`, and will echo the node & yarn versions upon entering the nix shell.

Without `direnv`, one can simply run `nix develop`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `.direnv` configuration and a `flake.nix` file to set up a Node.js development environment using Nix. It includes necessary dependencies and provides shell hooks for version display upon activation.

### Detailed summary
- Added `.direnv/` directory to project.
- Introduced `flake.nix` with:
  - Description for AA-SDK Flake.
  - Input from `nixpkgs` pointing to `nixpkgs-unstable`.
  - Configuration for a development shell with `nodejs` and `yarn`.
  - Shell hooks to display Node.js and Yarn versions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->