### PR TITLE
docs: fix private key to acct signer in 7702 quick start

### DIFF
--- a/docs/pages/smart-wallets/7702-quickstart.mdx
+++ b/docs/pages/smart-wallets/7702-quickstart.mdx
@@ -58,7 +58,7 @@ import { createSmartWalletClient } from "@account-kit/wallet-client";
 import { alchemy, arbitrumSepolia } from "@account-kit/infra";
 import { LocalAccountSigner } from "@aa-sdk/core";
 
-const signer = LocalAccountSigner.fromPrivateKey(PRIVATE_KEY); // we use a private key signer as an example here
+const signer = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY); // we use a private key signer as an example here
 
 const transport = alchemy({
   apiKey: ALCHEMY_API_KEY, // use your Alchemy app api key here!


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the method used to create a signer from a private key in the `docs/pages/smart-wallets/7702-quickstart.mdx` file.

### Detailed summary
- Changed the method for creating a signer from `LocalAccountSigner.fromPrivateKey(PRIVATE_KEY)` to `LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->