### PR TITLE
feat: add useGetCallsStatus

### DIFF
--- a/account-kit/react/src/experimental/hooks/useGetCallsStatus.ts
+++ b/account-kit/react/src/experimental/hooks/useGetCallsStatus.ts
@@ -1,0 +1,71 @@
+import { BaseError, clientHeaderTrack } from "@aa-sdk/core";
+import type { GetSmartWalletClientResult } from "@account-kit/core/experimental";
+import type { getCallsStatus } from "@account-kit/wallet-client";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { type Address, type Hex } from "viem";
+import { ClientUndefinedHookError } from "../../errors.js";
+import { useAlchemyAccountContext } from "../../hooks/useAlchemyAccountContext.js";
+import { ReactLogger } from "../../metrics.js";
+
+export type UseGetCallsStatusParams = {
+  client?: GetSmartWalletClientResult<Address>;
+  callId?: Hex;
+};
+
+type QueryResult = Awaited<ReturnType<typeof getCallsStatus>>;
+
+export type UseCallsStatusResult = UseQueryResult<QueryResult>;
+
+/**
+ * Hook to retrieve the status of prepared calls from the Wallet API.
+ *
+ * This hook queries the status of a specific call ID that was returned from `wallet_sendPreparedCalls`.
+ * The status indicates whether the batch of calls has been processed, confirmed, or failed on-chain.
+ *
+ * @example
+ * ```tsx
+ * import { useCallsStatus } from "@account-kit/react/experimental";
+ *
+ * function MyComponent() {
+ *   const { data: callsStatus, isLoading, error } = useCallsStatus({
+ *     client: smartWalletClient,
+ *     callId: "0x1234...", // The call ID from sendPreparedCalls
+ *   });
+ * }
+ * ```
+ *
+ * @param {UseGetCallsStatusParams} params - Parameters for the hook
+ * @param {GetSmartWalletClientResult<Address> | undefined} params.client - Smart wallet client instance. The hook will not fetch until this is defined.
+ * @param {Hex | undefined} params.callId - A call ID (hex string) returned from `sendPreparedCalls`. The hook will not fetch until this is defined.
+ *
+ * @returns {UseCallsStatusResult} Query result
+ */
+export function useCallsStatus(
+  params: UseGetCallsStatusParams,
+): UseCallsStatusResult {
+  const { client, callId } = params;
+  const { queryClient } = useAlchemyAccountContext();
+
+  return useQuery(
+    {
+      queryKey: ["useCallsStatus", params.callId],
+      queryFn: ReactLogger.profiled(
+        "useCallsStatus",
+        async (): Promise<QueryResult> => {
+          if (!client) {
+            throw new ClientUndefinedHookError("useCallsStatus");
+          }
+          if (!callId) {
+            throw new BaseError("Expected callId to be defined");
+          }
+
+          const _client = clientHeaderTrack(client, "reactUseCallsStatus");
+
+          return await _client.getCallsStatus(callId);
+        },
+      ),
+      enabled: !!client && !!params.callId,
+    },
+    queryClient,
+  );
+}

--- a/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts
+++ b/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts
@@ -1,13 +1,20 @@
 "use client";
 
-import type { WaitForUserOperationTxParameters } from "@aa-sdk/core";
+import {
+  FailedToFindTransactionError,
+  Logger,
+  SmartAccountClientOptsSchema,
+  type WaitForUserOperationTxParameters,
+} from "@aa-sdk/core";
 import { useMutation, type UseMutateFunction } from "@tanstack/react-query";
-import type { Hash } from "viem";
+import { concatHex, numberToHex, pad, type Hash } from "viem";
 import { useAlchemyAccountContext } from "./useAlchemyAccountContext.js";
 import { ClientUndefinedHookError } from "../errors.js";
 import { ReactLogger } from "../metrics.js";
 import type { BaseHookMutationArgs } from "../types.js";
-import { type UseSmartAccountClientResult } from "./useSmartAccountClient.js";
+import { useSmartWalletClient } from "../experimental/hooks/useSmartWalletClient.js";
+import type { UseSmartAccountClientResult } from "./useSmartAccountClient.js";
+import type z from "zod";
 
 export type UseWaitForUserOperationTransactionMutationArgs =
   BaseHookMutationArgs<Hash, WaitForUserOperationTxParameters>;
@@ -54,9 +61,13 @@ export type UseWaitForUserOperationTransactionResult = {
  * });
  * ```
  */
-export function useWaitForUserOperationTransaction({
-  client,
-}: UseWaitForUserOperationTransactionArgs): UseWaitForUserOperationTransactionResult {
+export function useWaitForUserOperationTransaction(
+  config: UseWaitForUserOperationTransactionArgs,
+): UseWaitForUserOperationTransactionResult {
+  const { client } = config;
+  const smartWalletClient = useSmartWalletClient({
+    account: client?.account.address,
+  });
   const { queryClient } = useAlchemyAccountContext();
 
   const {
@@ -67,13 +78,53 @@ export function useWaitForUserOperationTransaction({
   } = useMutation(
     {
       mutationFn: async (params: WaitForUserOperationTxParameters) => {
-        if (!client) {
+        if (!smartWalletClient) {
           throw new ClientUndefinedHookError(
             "useWaitForUserOperationTransaction",
           );
         }
 
-        return client.waitForUserOperationTransaction(params);
+        // TODO(jh): test that this actually works
+        const clientOptions = client as unknown as z.infer<
+          typeof SmartAccountClientOptsSchema
+        >;
+        const {
+          hash,
+          retries = {
+            maxRetries: clientOptions.txMaxRetries,
+            intervalMs: clientOptions.txRetryIntervalMs,
+            multiplier: clientOptions.txRetryMultiplier,
+          },
+        } = params;
+
+        const chainIdPadded = pad(numberToHex(smartWalletClient.chain.id), {
+          size: 32,
+        });
+        const callId = concatHex([chainIdPadded, hash]);
+
+        for (let i = 0; i < retries.maxRetries; i++) {
+          const txRetryIntervalWithJitterMs =
+            retries.intervalMs * Math.pow(retries.multiplier, i) +
+            Math.random() * 100;
+
+          await new Promise((resolve) =>
+            setTimeout(resolve, txRetryIntervalWithJitterMs),
+          );
+
+          const result = await smartWalletClient
+            .getCallsStatus(callId)
+            .catch((err) => {
+              Logger.error(
+                `[useWaitForUserOperationTransaction] error fetching calls status for call ${callId}: ${err}`,
+              );
+            });
+
+          if (result?.receipts?.length) {
+            return result.receipts[0].transactionHash;
+          }
+        }
+
+        throw new FailedToFindTransactionError(hash);
       },
     },
     queryClient,


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new hook, `useCallsStatus`, to retrieve the status of prepared calls from the Wallet API and enhances the existing `useWaitForUserOperationTransaction` hook to utilize a smart wallet client for transaction handling.

### Detailed summary
- Added `useCallsStatus` hook for querying call status from the Wallet API.
- Introduced `UseGetCallsStatusParams` type for parameters.
- Implemented error handling for undefined client and call ID in `useCallsStatus`.
- Enhanced `useWaitForUserOperationTransaction` to use `smartWalletClient`.
- Added retry logic for fetching transaction status in `useWaitForUserOperationTransaction`.
- Updated error handling and logging for transaction fetching in `useWaitForUserOperationTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->