### PR TITLE
feat: add support for upgrades from ma v1

### DIFF
--- a/account-kit/smart-contracts/src/light-account/accounts/base.ts
+++ b/account-kit/smart-contracts/src/light-account/accounts/base.ts
@@ -15,7 +15,7 @@ import {
   fromHex,
   hashMessage,
   hashTypedData,
-  trim,
+  isAddressEqual,
   type Address,
   type Chain,
   type Hex,
@@ -128,7 +128,9 @@ export async function createLightAccountBase<
     // only upgrade undeployed accounts (storage 0) or deployed light accounts, error otherwise
     if (
       fromHex(storage, "number") !== 0 &&
-      !implementationAddresses.some((x) => x === trim(storage))
+      !implementationAddresses.some((x) =>
+        isAddressEqual(x, `0x${storage.slice(26)}`),
+      )
     ) {
       throw new Error(
         `could not determine if smart account implementation is ${type} ${String(


### PR DESCRIPTION
add support for upgrading from ma v1

others:
1. fix potential issue with `trim`ming addresses in LA's, see https://github.com/alchemyplatform/aa-sdk/pull/1261
2. using `isAddressEqual` to be safe in case address checksum capitalization is different