### PR TITLE
fix: force docs-site submodule to be up-to-date

### DIFF
--- a/.github/actions/setup-docs/action.yml
+++ b/.github/actions/setup-docs/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Ensure docs-site submodule is up-to-date
       shell: bash
-      run: git submodule update --init --recursive
+      run: git submodule update --init --remote docs-site/
 
     - name: Insert Account Kit docs.yml into docs-site/fern/docs.yml
       shell: bash

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,6 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
+# Ensure the docs-site submodule is up-to-date
+git submodule update --init --remote docs-site/
+git add -A docs-site/

--- a/docs/scripts/docs-dev.sh
+++ b/docs/scripts/docs-dev.sh
@@ -39,7 +39,7 @@ if ! command -v pnpm &> /dev/null; then
 fi
 
 # Update docs-site submodule
-git submodule update --init --recursive
+git submodule update --init --recursive --remote docs-site/
 
 cd "$DOCS_SITE_DIR"
 # Install/update dependencies


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?
