### PR TITLE
refactor: re-add experiments section to docs.yml in aa-sdk side

### DIFF
--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -3,6 +3,10 @@
 instances:
   - url: https://alchemy.com/docs
 
+experimental:
+  mdx-components:
+    - wallets/components
+
 navigation:
   - tab: wallets
     layout:

--- a/docs/scripts/docs-dev.sh
+++ b/docs/scripts/docs-dev.sh
@@ -54,6 +54,11 @@ ONCHANGE_PID=$!
 
 # Start the docs site
 cd "$DOCS_SITE_DIR"
-pnpm dev
+pnpm dev || {
+    echo "Fern local dev server failed to start"
+    cleanup
+    exit 1
+}
 
+# Catch-all to ensure cleanup is always run at termination
 cleanup

--- a/docs/scripts/insert-docs.sh
+++ b/docs/scripts/insert-docs.sh
@@ -67,6 +67,28 @@ awk '
     }
 ' fern/docs.yml > fern/docs.yml.tmp && mv fern/docs.yml.tmp fern/docs.yml
 
+# Extract the experimental section from aa-sdk version of docs.yml
+sed -n '/^experimental:/,/^[a-z]/p' fern/wallets/docs.yml | sed '$d' > fern/wallets/temp_experimental.yml
+
+# Find the experimental section and append additional settings
+awk '
+    BEGIN { found = 0; }
+    /^experimental:/ {
+        found = 1;
+        print;
+        next;
+    }
+    found && (/^[a-z]/ || /^$/) {
+        # We found either the next section or an empty line, insert new settings before it
+        system("cat fern/wallets/temp_experimental.yml | grep -v ^experimental:");
+        found = 0;
+        print;
+        next;
+    }
+    { print; }
+' fern/docs.yml > fern/docs.yml.tmp && mv fern/docs.yml.tmp fern/docs.yml
+
 # Clean up temporary files
 rm -f fern/wallets/temp_wallets.yml
+rm -f fern/wallets/temp_experimental.yml
 rm -f fern/docs.yml.bak


### PR DESCRIPTION
[Slack thread here](https://alchemyinsights.slack.com/archives/C08801YNZG9/p1750265626399699?thread_ts=1750231891.909669&cid=C08801YNZG9)

Basically I was hoping to avoid doing this by just having the experimental section live in the docs repo rather than having to merge the docs/aa-sdk versions. Turns out that broke things in local dev. So this merges them again.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?
