### PR TITLE
docs: include initCode when creating session key client

### DIFF
--- a/docs/pages/smart-contracts/modular-account-v2/session-keys/using-session-keys.mdx
+++ b/docs/pages/smart-contracts/modular-account-v2/session-keys/using-session-keys.mdx
@@ -35,6 +35,7 @@ const sessionKeyClient = await createModularAccountV2Client({
   transport: alchemy({ apiKey: "your-api-key" }),
   signer: sessionKeySigner,
   accountAddress: client.getAddress(client.account),
+  initCode: await client.account.getInitCode(),
   signerEntity: {
     entityId: sessionKeyEntityId,
     isGlobalValidation: true,
@@ -50,4 +51,4 @@ await sessionKeyClient.sendUserOperation({
 });
 ```
 
-Note that you have to pass in `accountAddress` to session key clients. By default, the client uses an account address counterfactual that assumes that the connected signer is the owner.
+Note that you have to pass in `accountAddress` and `initCode` to session key clients. By default, the client uses an account address counterfactual that assumes that the connected signer is the owner.


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for using session keys in the `docs/pages/smart-contracts/modular-account-v2/session-keys/using-session-keys.mdx` file. It adds information regarding the `initCode` parameter required for session key clients.

### Detailed summary
- Added `initCode: await client.account.getInitCode()` to the session key client configuration.
- Updated documentation to state that both `accountAddress` and `initCode` must be passed to session key clients.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->