### PR TITLE
fix: typos in wallet api links

### DIFF
--- a/docs/pages/smart-wallets/quickstart.mdx
+++ b/docs/pages/smart-wallets/quickstart.mdx
@@ -182,7 +182,7 @@ const preparedCalls = await client.prepareCalls({
 
 const signedCalls = await signPreparedCalls(
   sessionKey, // Note that we now sign with the session key!
-  preparedCalls
+  preparedCalls,
 );
 
 const result = await client.sendPreparedCalls({

--- a/docs/pages/smart-wallets/quickstart.mdx
+++ b/docs/pages/smart-wallets/quickstart.mdx
@@ -6,7 +6,7 @@ url: https://docs.alchemy.com/reference/smart-wallet-quickstart
 slug: reference/smart-wallet-quickstart
 ---
 
-This guide outlines exactly what you need to use Wallet Server with your app! We’ll go over the [`wallet_requestAccount`](https://www.alchemy.com/docs/node/smart-wallets/wallets-api-endpoints/wallets-api-endpoints/wallet-request-account), [`wallet_createSession`](https://www.alchemy.com/docs/node/smart-wallets/wallets-api-endpoints/wallets-api-endpoints/wallet-create-session), [`wallet_prepareCalls`](https://www.alchemy.com/docs/node/smart-wallets/wallets-api-endpoints/wallets-api-endpoints/wallet-prepare-calls), and [`wallet_sendPreparedCalls`](https://www.alchemy.com/docs/node/smart-wallets/wallets-api-endpoints/wallets-api-endpoints/wallet-send-prepared-calls) endpoints in this tutorial. _(Note: If you are wanting to use EIP-7702, see [this guide](/docs/reference/wallet-apis-7702-quickstart) instead.)_
+This guide outlines exactly what you need to use Wallet Server with your app! We’ll go over the [`wallet_requestAccount`](https://www.alchemy.com/docs/wallets/api/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-request-account), [`wallet_createSession`](https://www.alchemy.com/docs/wallets/api/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-create-session), [`wallet_prepareCalls`](https://www.alchemy.com/docs/wallets/api/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-prepare-calls), and [`wallet_sendPreparedCalls`](https://www.alchemy.com/docs/wallets/api/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-send-prepared-calls) endpoints in this tutorial. _(Note: If you are wanting to use EIP-7702, see [this guide](/docs/reference/wallet-apis-7702-quickstart) instead.)_
 
 The logical flow is to get an account for a given signer, create a session for use with that account, prepare the calls you’re looking to send, and send them! If you're looking for a typescript SDK guide, you'll find that here too.
 
@@ -182,7 +182,7 @@ const preparedCalls = await client.prepareCalls({
 
 const signedCalls = await signPreparedCalls(
   sessionKey, // Note that we now sign with the session key!
-  preparedCalls,
+  preparedCalls
 );
 
 const result = await client.sendPreparedCalls({


### PR DESCRIPTION
# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the links in the `quickstart.mdx` file for the Wallet Server documentation to point to the correct API endpoint paths.

### Detailed summary
- Updated links for the following endpoints:
  - `wallet_requestAccount`
  - `wallet_createSession`
  - `wallet_prepareCalls`
  - `wallet_sendPreparedCalls` 
- Maintained the existing content and structure of the guide.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->