### PR TITLE
feat(core): leverage the signer proxy for chain agnostic routes

### DIFF
--- a/account-kit/core/src/createConfig.ts
+++ b/account-kit/core/src/createConfig.ts
@@ -55,16 +55,31 @@ export const createConfig = (
 
   const connections: Connection[] = [];
   if (connectionConfig.chains == null) {
+    const transportConfig = { ...connectionConfig.transport.config };
+    if (signerConnection?.rpcUrl && transportConfig.chainAgnosticUrl == null) {
+      transportConfig.chainAgnosticUrl = `${signerConnection.rpcUrl}/v2`;
+    }
+
     connections.push({
-      transport: connectionConfig.transport.config,
+      transport: transportConfig,
       policyId: connectionConfig.policyId,
       chain,
     });
   } else {
     connectionConfig.chains.forEach((params) => {
       const { chain, policyId, transport } = params;
+      const transportConfig =
+        transport?.config ?? connectionConfig.transport!.config;
+
+      if (
+        signerConnection?.rpcUrl &&
+        transportConfig.chainAgnosticUrl == null
+      ) {
+        transportConfig.chainAgnosticUrl = `${signerConnection.rpcUrl}/v2`;
+      }
+
       connections.push({
-        transport: transport?.config ?? connectionConfig.transport!.config,
+        transport: transportConfig,
         chain,
         policyId: policyId ?? connectionConfig.policyId,
       });

--- a/account-kit/core/src/store/store.test.ts
+++ b/account-kit/core/src/store/store.test.ts
@@ -536,7 +536,7 @@ describe("createConfig tests", () => {
             },
             "smartWalletClients": {},
           },
-          "version": 14,
+          "version": ${STORAGE_VERSION},
         }
       `);
   });
@@ -607,7 +607,7 @@ describe("createConfig tests", () => {
             },
             "smartWalletClients": {},
           },
-          "version": 14,
+          "version": ${STORAGE_VERSION},
         }
       `);
   });

--- a/account-kit/core/src/store/store.test.ts
+++ b/account-kit/core/src/store/store.test.ts
@@ -25,6 +25,7 @@ describe("createConfig tests", () => {
       `
       {
         "config": {
+          "chainAgnosticUrl": "/api/signer/v2",
           "rpcUrl": "/api/sepolia",
         },
         "dynamicFetchOptions": {
@@ -58,10 +59,11 @@ describe("createConfig tests", () => {
     );
 
     expect(getAlchemyTransport(hydratedConfig).config).toMatchInlineSnapshot(`
-        {
-          "rpcUrl": "/api/arbitrumSepolia",
-        }
-      `);
+      {
+        "chainAgnosticUrl": "/api/signer/v2",
+        "rpcUrl": "/api/arbitrumSepolia",
+      }
+    `);
   });
 
   it("should overwrite the state if the config changed (chain removed)", async () => {
@@ -79,6 +81,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -91,6 +94,7 @@ describe("createConfig tests", () => {
               },
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/arbitrumSepolia",
               },
             },
@@ -129,6 +133,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -153,6 +158,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -165,6 +171,7 @@ describe("createConfig tests", () => {
               },
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/arbitrumSepolia",
               },
             },
@@ -207,6 +214,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id2",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -219,6 +227,7 @@ describe("createConfig tests", () => {
               },
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/arbitrumSepolia",
               },
             },
@@ -243,6 +252,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -255,6 +265,7 @@ describe("createConfig tests", () => {
               },
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/arbitrumSepolia",
               },
             },
@@ -298,6 +309,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -310,6 +322,7 @@ describe("createConfig tests", () => {
               },
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/arbitrumSepolia",
               },
             },
@@ -381,6 +394,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -393,6 +407,7 @@ describe("createConfig tests", () => {
               },
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/arbitrumSepolia",
               },
             },
@@ -436,6 +451,7 @@ describe("createConfig tests", () => {
               "policyId": "test-policy-id",
               "transport": {
                 "__type": "Transport",
+                "chainAgnosticUrl": "/api/signer/v2",
                 "rpcUrl": "/api/sepolia",
               },
             },
@@ -449,6 +465,7 @@ describe("createConfig tests", () => {
               "transport": {
                 "__type": "Transport",
                 "apiKey": "test-api-key",
+                "chainAgnosticUrl": "/api/signer/v2",
               },
             },
           ],
@@ -490,6 +507,7 @@ describe("createConfig tests", () => {
                     "policyId": "test-policy-id",
                     "transport": {
                       "__type": "Transport",
+                      "chainAgnosticUrl": "/api/signer/v2",
                       "rpcUrl": "/api/sepolia",
                     },
                   },
@@ -502,6 +520,7 @@ describe("createConfig tests", () => {
                     },
                     "transport": {
                       "__type": "Transport",
+                      "chainAgnosticUrl": "/api/signer/v2",
                       "rpcUrl": "/api/arbitrumSepolia",
                     },
                   },
@@ -517,7 +536,7 @@ describe("createConfig tests", () => {
             },
             "smartWalletClients": {},
           },
-          "version": ${STORAGE_VERSION},
+          "version": 14,
         }
       `);
   });
@@ -572,6 +591,7 @@ describe("createConfig tests", () => {
                     "policyId": "test-policy-id",
                     "transport": {
                       "__type": "Transport",
+                      "chainAgnosticUrl": "/api/signer/v2",
                       "rpcUrl": "/api/sepolia",
                     },
                   },
@@ -587,7 +607,7 @@ describe("createConfig tests", () => {
             },
             "smartWalletClients": {},
           },
-          "version": ${STORAGE_VERSION},
+          "version": 14,
         }
       `);
   });


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the configuration management for transport connections in the `createConfig.ts` file by adding a `chainAgnosticUrl` property to the transport configuration, allowing for better handling of RPC URLs.

### Detailed summary
- Added `chainAgnosticUrl` to the transport configuration in `createConfig.ts`.
- Updated logic to set `chainAgnosticUrl` based on `signerConnection.rpcUrl`.
- Modified tests in `store.test.ts` to verify the presence of `chainAgnosticUrl` in various configurations. 
- Ensured backward compatibility by using existing transport configurations when necessary.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->