### PR TITLE
fix: default client retries in `useWaitForUserOperationTransaction`

### DIFF
--- a/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts
+++ b/account-kit/react/src/hooks/useWaitForUserOperationTransaction.ts
@@ -14,7 +14,6 @@ import { ReactLogger } from "../metrics.js";
 import type { BaseHookMutationArgs } from "../types.js";
 import { useSmartWalletClient } from "../experimental/hooks/useSmartWalletClient.js";
 import type { UseSmartAccountClientResult } from "./useSmartAccountClient.js";
-import type z from "zod";
 
 export type UseWaitForUserOperationTransactionMutationArgs =
   BaseHookMutationArgs<Hash, WaitForUserOperationTxParameters>;
@@ -78,16 +77,14 @@ export function useWaitForUserOperationTransaction(
   } = useMutation(
     {
       mutationFn: async (params: WaitForUserOperationTxParameters) => {
-        if (!smartWalletClient) {
+        if (!smartWalletClient || !client) {
           throw new ClientUndefinedHookError(
             "useWaitForUserOperationTransaction",
           );
         }
 
-        // TODO(jh): test that this actually works
-        const clientOptions = client as unknown as z.infer<
-          typeof SmartAccountClientOptsSchema
-        >;
+        const clientOptions =
+          SmartAccountClientOptsSchema.passthrough().parse(client);
         const {
           hash,
           retries = {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the error handling and type validation in the `useWaitForUserOperationTransaction` hook by ensuring that both `smartWalletClient` and `client` are defined before proceeding. It also updates the way `clientOptions` are parsed.

### Detailed summary
- Modified the condition to check both `smartWalletClient` and `client` for undefined values.
- Updated the parsing of `clientOptions` to use `SmartAccountClientOptsSchema.passthrough().parse(client)` instead of casting with `z.infer`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->