### PR TITLE
feat: support multiple policyIds in wallet client

### DIFF
--- a/account-kit/core/src/experimental/actions/getSmartWalletClient.ts
+++ b/account-kit/core/src/experimental/actions/getSmartWalletClient.ts
@@ -56,7 +56,11 @@ export function getSmartWalletClient(
     chain: connection.chain,
     signer,
     account: params?.account,
-    policyId: connection.policyId as string | undefined,
+    ...(Array.isArray(connection.policyId)
+      ? { policyIds: connection.policyId }
+      : connection.policyId
+        ? { policyId: connection.policyId }
+        : {}),
   });
 
   config.store.setState((state) => ({

--- a/account-kit/wallet-client/package.json
+++ b/account-kit/wallet-client/package.json
@@ -48,7 +48,7 @@
     "@aa-sdk/core": "^4.47.0",
     "@account-kit/infra": "^4.47.0",
     "@account-kit/smart-contracts": "^4.47.0",
-    "@alchemy/wallet-api-types": "0.1.0-alpha.12",
+    "@alchemy/wallet-api-types": "0.1.0-alpha.13",
     "@sinclair/typebox": "^0.34.33",
     "deep-equal": "^2.2.3",
     "ox": "^0.6.12",

--- a/account-kit/wallet-client/src/client/actions/prepareCalls.ts
+++ b/account-kit/wallet-client/src/client/actions/prepareCalls.ts
@@ -62,10 +62,11 @@ export async function prepareCalls<
     throw new AccountNotFoundError();
   }
 
-  if (client.policyId && !params.capabilities?.paymasterService) {
+  if (client.policyIds && !params.capabilities?.paymasterService) {
     params.capabilities = {
       ...params.capabilities,
-      paymasterService: { policyId: client.policyId },
+      // TODO(jh): need to do a prod wallet server release & publish new rpc types pkg for this to work
+      paymasterService: { policyIds: client.policyIds },
     };
   }
 

--- a/account-kit/wallet-client/src/client/actions/prepareCalls.ts
+++ b/account-kit/wallet-client/src/client/actions/prepareCalls.ts
@@ -65,7 +65,6 @@ export async function prepareCalls<
   if (client.policyIds && !params.capabilities?.paymasterService) {
     params.capabilities = {
       ...params.capabilities,
-      // TODO(jh): need to do a prod wallet server release & publish new rpc types pkg for this to work
       paymasterService: { policyIds: client.policyIds },
     };
   }

--- a/account-kit/wallet-client/src/types.ts
+++ b/account-kit/wallet-client/src/types.ts
@@ -16,7 +16,7 @@ export type CreateInnerClientParams<
 > = {
   chain: Chain;
   transport: AlchemyTransport;
-  policyId?: string;
+  policyIds?: string[];
   account?: TAccount | Address | undefined;
 };
 
@@ -29,7 +29,7 @@ export type InnerWalletApiClientBase<
   Chain,
   JsonRpcAccount<Address> | undefined,
   WalletServerViemRpcSchema,
-  { policyId?: string } & TExtend
+  { policyIds?: string[] } & TExtend
 >;
 
 export type CachedAccount = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,10 +77,10 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
   integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
 
-"@alchemy/wallet-api-types@0.1.0-alpha.12":
-  version "0.1.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@alchemy/wallet-api-types/-/wallet-api-types-0.1.0-alpha.12.tgz#81dffd2288d22c25a4a55f7a9251e48b14cd8dd7"
-  integrity sha512-veqMfG/n0z6Aa4sKFcP2Rya9knfBlbMnRbM34NuERNucNEDhLTUD2n2VUymKf1Lj8tiSnj0RaPPHQ9DVckl/7g==
+"@alchemy/wallet-api-types@0.1.0-alpha.13":
+  version "0.1.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/@alchemy/wallet-api-types/-/wallet-api-types-0.1.0-alpha.13.tgz#7e9c8d76f8bbf57c9baa26ffda522792d9661835"
+  integrity sha512-huQYiNbmvOKXR3qZ6MWoWrXwvOQUlpfPJDTLHoXT5GXPQnd3VoW4n8SM/s5uwMOosVblnXxR/VU/YYuwCIRP1Q==
   dependencies:
     "@sinclair/typebox" "^0.34.33"
     deep-equal "^2.2.3"


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `@alchemy/wallet-api-types` dependency and modifying the code to support an array of `policyIds` instead of a single `policyId`, enhancing flexibility in handling policy identifiers.

### Detailed summary
- Updated `@alchemy/wallet-api-types` from `0.1.0-alpha.12` to `0.1.0-alpha.13`.
- Changed `policyId` to `policyIds` in `getSmartWalletClient.ts` for better handling of multiple policies.
- Updated condition to check for `client.policyIds` instead of `client.policyId` in `prepareCalls.ts`.
- Modified type definition in `types.ts` to reflect `policyIds` as an array of strings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->