### PR TITLE
fix: add more fallbacks for chain agnostic rpc url

### DIFF
--- a/account-kit/core/src/createConfig.ts
+++ b/account-kit/core/src/createConfig.ts
@@ -56,9 +56,12 @@ export const createConfig = (
   const connections: Connection[] = [];
   if (connectionConfig.chains == null) {
     const transportConfig = { ...connectionConfig.transport.config };
-    if (signerConnection?.rpcUrl && transportConfig.chainAgnosticUrl == null) {
-      transportConfig.chainAgnosticUrl = `${signerConnection.rpcUrl}/v2`;
-    }
+
+    transportConfig.chainAgnosticUrl ??= signerConnection?.rpcUrl
+      ? `${signerConnection.rpcUrl}/v2`
+      : transportConfig.rpcUrl
+        ? `${transportConfig.rpcUrl}/v2`
+        : undefined;
 
     connections.push({
       transport: transportConfig,
@@ -71,12 +74,13 @@ export const createConfig = (
       const transportConfig =
         transport?.config ?? connectionConfig.transport!.config;
 
-      if (
-        signerConnection?.rpcUrl &&
-        transportConfig.chainAgnosticUrl == null
-      ) {
-        transportConfig.chainAgnosticUrl = `${signerConnection.rpcUrl}/v2`;
-      }
+      transportConfig.chainAgnosticUrl ??= signerConnection?.rpcUrl
+        ? `${signerConnection.rpcUrl}/v2`
+        : connectionConfig.transport?.config.rpcUrl
+          ? `${connectionConfig.transport.config.rpcUrl}/v2`
+          : transportConfig.rpcUrl
+            ? `${transportConfig.rpcUrl}/v2`
+            : undefined;
 
       connections.push({
         transport: transportConfig,

--- a/examples/ui-demo/src/app/api/rpc-base-sepolia/route.ts
+++ b/examples/ui-demo/src/app/api/rpc-base-sepolia/route.ts
@@ -6,10 +6,6 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const headers: Record<string, string> = {};
 
-  if (body.method.startsWith("wallet_")) {
-    headers.Authorization = `Bearer ${env.API_KEY}`;
-  }
-
   req.headers.forEach((value: string, key: string) => {
     // don't pass the cookie because it doesn't get used downstream
     if (key === "cookie") return;
@@ -17,11 +13,7 @@ export async function POST(req: NextRequest) {
     headers[key] = value;
   });
 
-  const url = body.method.startsWith("wallet_")
-    ? `${env.ALCHEMY_API_URL}/v2`
-    : env.ALCHEMY_RPC_URL_BASE_SEPOLIA;
-
-  const res = await fetch(url, {
+  const res = await fetch(env.ALCHEMY_RPC_URL_BASE_SEPOLIA, {
     method: "POST",
     headers: {
       ...headers,

--- a/examples/ui-demo/src/app/api/rpc/route.ts
+++ b/examples/ui-demo/src/app/api/rpc/route.ts
@@ -6,10 +6,6 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const headers: Record<string, string> = {};
 
-  if (body.method.startsWith("wallet_")) {
-    headers.Authorization = `Bearer ${env.API_KEY}`;
-  }
-
   req.headers.forEach((value: string, key: string) => {
     // don't pass the cookie because it doesn't get used downstream
     if (key === "cookie") return;
@@ -17,11 +13,7 @@ export async function POST(req: NextRequest) {
     headers[key] = value;
   });
 
-  const url = body.method.startsWith("wallet_")
-    ? `${env.ALCHEMY_API_URL}/v2`
-    : env.ALCHEMY_RPC_URL;
-
-  const res = await fetch(url, {
+  const res = await fetch(env.ALCHEMY_RPC_URL, {
     method: "POST",
     headers: {
       ...headers,


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on simplifying the logic for setting up headers and URLs in the `POST` request handling of two API routes, while also enhancing the assignment of `chainAgnosticUrl` in the configuration.

### Detailed summary
- Removed conditional authorization header setup in `examples/ui-demo/src/app/api/rpc/route.ts` and `examples/ui-demo/src/app/api/rpc-base-sepolia/route.ts`.
- Simplified URL assignment for `fetch` calls to directly use `env.ALCHEMY_RPC_URL` and `env.ALCHEMY_RPC_URL_BASE_SEPOLIA`.
- Refactored the logic for setting `chainAgnosticUrl` in `account-kit/core/src/createConfig.ts` using nullish coalescing and conditional chaining.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->