### PR TITLE
fix: adds new webauthn factory address

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/account/modularAccountV2.ts
+++ b/account-kit/smart-contracts/src/ma-v2/account/modularAccountV2.ts
@@ -21,6 +21,7 @@ import {
 import { accountFactoryAbi } from "../abis/accountFactoryAbi.js";
 import {
   getDefaultMAV2FactoryAddress,
+  getDefaultWebAuthnMAV2FactoryAddress,
   getDefaultSMAV2BytecodeAddress,
 } from "../utils.js";
 import {
@@ -169,7 +170,7 @@ export async function createModularAccountV2<
         const { x, y } = parsePublicKey(publicKey);
         const {
           salt = 0n,
-          factoryAddress = getDefaultMAV2FactoryAddress(chain),
+          factoryAddress = getDefaultWebAuthnMAV2FactoryAddress(),
           initCode,
         } = config;
 

--- a/account-kit/smart-contracts/src/ma-v2/utils.ts
+++ b/account-kit/smart-contracts/src/ma-v2/utils.ts
@@ -72,13 +72,11 @@ export const pack1271Signature = ({
   ]);
 };
 
-export const getDefaultMAV2FactoryAddress = (
-  chain: Chain,
-  isWebauthnAccount?: false,
-): Address => {
-  if (isWebauthnAccount) {
-    return "0x9c607854b60fb6AFDB33daC5a1676AC06048bE5f";
-  }
+export const getDefaultWebAuthnMAV2FactoryAddress = (): Address => {
+  return "0x9c607854b60fb6AFDB33daC5a1676AC06048bE5f";
+};
+
+export const getDefaultMAV2FactoryAddress = (chain: Chain): Address => {
   switch (chain.id) {
     // TODO: case mekong.id:
     case sepolia.id:


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function to provide a default factory address for WebAuthn in the `ma-v2` module and updates the `createModularAccountV2` function to use this new address.

### Detailed summary
- Added the function `getDefaultWebAuthnMAV2FactoryAddress` in `utils.ts` to return a specific address.
- Updated `createModularAccountV2` in `modularAccountV2.ts` to use `getDefaultWebAuthnMAV2FactoryAddress` instead of `getDefaultMAV2FactoryAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->