### PR TITLE
Update bundler FAQs for staking

### DIFF
--- a/docs/pages/bundler-api/bundler-faqs.mdx
+++ b/docs/pages/bundler-api/bundler-faqs.mdx
@@ -77,6 +77,8 @@ After calculating the new values, send your `userOp` again with the updated fe
 
 Our bundler supports up to 4 parallel nonces (default value from ERC-7562) for unstaked senders and unlimited parallel nonces for staked senders. See [below](/reference/bundler-faqs#what-is-the-minimum-amount-that-must-be-staked-with-the-entrypoint) for stake requirements.
 
+Unstaked accounts that attempt to exceed this limit will receive the error `Max operations (4) reached for account`. Staking the account removes the restriction. Accounts can be staked by calling `addStake(uint32 unstakeDelaySec)` on the EntryPoint contract, and later `unlockStake()` followed by `withdrawStake(address payable)` to recover the stake.
+
 Staked senders are subject to ERC-7562 reputation rules. If a sender submits a large number of userOps and subsequently invalidates them all, they may be throttled or banned.
 
 ### Can I include multiple parallel nonces in a single bundle?
@@ -174,7 +176,7 @@ EntryPoint v0.6: `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789`
 
 We plan to deprecate support for EntryPoint v0.6 in September 2025. Please ensure that you have migrated to EntryPoint v0.7 by that time. If you have any questions or need assistance with the migration process, please file a ticket via our [Discord server](https://discord.com/channels/735965332958871634/1115787488838033538).
 
-## Compatibility with 3P Paymasters and Factories
+## Entity Staking Requirements
 
 ### What is the minimum amount that must be staked with the EntryPoint?
 
@@ -188,8 +190,8 @@ Testnets:
 - Native token: ETH --> 0.1 ETH
 - Native token: MATIC --> 10 MATIC
 
-If a Paymaster or Factory used in the userOp does not have the above amounts staked with the Entrypoint, the userOp will be rejected.
+Paymasters and factories must have at least the above stake or their userOps will be rejected. Accounts only need to stake if they wish to exceed 4 parallel nonces in the Bundler's mempool; otherwise, userOps beyond this limit will be rejected. The same stake amounts apply to accounts.
 
 ### What is the minimum delay value?
 
-The minimum unstake delay required by Rundler is 1 Day. If a Paymaster or Factory used in the userOp does not have the "minimum delay" value configured with the Entrypoint, the userOp will be rejected.
+The minimum unstake delay required by Rundler is 1 Day. Paymasters and factories must configure at least this delay or their userOps will be rejected. Staked accounts are subject to the same delay requirement.


### PR DESCRIPTION
## Summary
- clarify the error for hitting the parallel nonce limit and how to remove it
- rename the staking section and mention accounts
- document that accounts only stake when exceeding 4 parallel nonces

## Testing
- `yarn test:ci` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*


------
https://chatgpt.com/codex/tasks/task_b_687febfcd650832789f076c163115819

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation regarding the bundler's nonce limits for staked and unstaked accounts, clarifying staking requirements and conditions for user operations (userOps). It also changes section headings for better organization.

### Detailed summary
- Added information about the error received by unstaked accounts exceeding nonce limits.
- Clarified the staking process with `addStake(uint32 unstakeDelaySec)`, `unlockStake()`, and `withdrawStake(address payable)`.
- Changed section title from "Compatibility with 3P Paymasters and Factories" to "Entity Staking Requirements".
- Specified that paymasters and factories must stake to exceed nonce limits.
- Stated that the same stake amounts apply to accounts for exceeding nonce limits.
- Clarified that paymasters and factories must configure the minimum unstake delay.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->