### PR TITLE
docs: fixing typo

### DIFF
--- a/account-kit/react/src/createConfig.ts
+++ b/account-kit/react/src/createConfig.ts
@@ -20,7 +20,7 @@ export type AlchemyAccountsConfigWithUI = AlchemyAccountsConfig & {
  * (the modal and AuthCard).
  *
  * @example
- * ```ts
+ * ```ts twoslash
  * import { sepolia, alchemy } from "@account-kit/infra"
  * import { AlchemyAccountsUIConfig, createConfig } from "@account-kit/react"
  * import { QueryClient } from "@tanstack/react-query";
@@ -37,6 +37,9 @@ export type AlchemyAccountsConfigWithUI = AlchemyAccountsConfig & {
  *   transport: alchemy({ apiKey: "your_api_key" })
  *   chain: sepolia,
  *   ssr: true,
+ *   sessionConfig: {
+ *     expirationTimeMs: 1000 * 60 * 60 * 24, // <-- Adjust the session expiration time as needed (defauly 15 mins)
+ *   },
  * }, uiConfig)
  *
  * export const queryClient = new QueryClient();
@@ -48,11 +51,11 @@ export type AlchemyAccountsConfigWithUI = AlchemyAccountsConfig & {
  */
 export const createConfig = (
   props: CreateConfigProps,
-  ui?: AlchemyAccountsUIConfig,
+  ui?: AlchemyAccountsUIConfig
 ): AlchemyAccountsConfigWithUI => {
   if (
     ui?.auth?.sections.some((x) =>
-      x.some((y) => y.type === "social" && y.mode === "popup"),
+      x.some((y) => y.type === "social" && y.mode === "popup")
     )
   ) {
     props.enablePopupOauth = true;
@@ -70,7 +73,7 @@ export const createConfig = (
   ) {
     const walletConnectAuthConfig = externalWalletSection?.walletConnect;
     const walletConnectParams = getWalletConnectParams(
-      walletConnectAuthConfig,
+      walletConnectAuthConfig
     )!;
 
     props.connectors ??= [];

--- a/account-kit/react/src/createConfig.ts
+++ b/account-kit/react/src/createConfig.ts
@@ -40,7 +40,7 @@ export type AlchemyAccountsConfigWithUI = AlchemyAccountsConfig & {
  *   chain: sepolia,
  *   ssr: true,
  *   sessionConfig: {
- *     expirationTimeMs: 1000 * 60 * 60 * 24, // <-- Adjust the session expiration time as needed (defauly 15 mins)
+ *     expirationTimeMs: 1000 * 60 * 60 * 24, // <-- Adjust the session expiration time as needed (default 15 mins)
  *   },
  * }, uiConfig)
  *

--- a/account-kit/react/src/createConfig.ts
+++ b/account-kit/react/src/createConfig.ts
@@ -19,6 +19,8 @@ export type AlchemyAccountsConfigWithUI = AlchemyAccountsConfig & {
  * an additional argument, the configuration object for the Auth Components UI
  * (the modal and AuthCard).
  *
+ * **Note:** In `props.sessionConfig`, if `expirationTimeMs` is not provided, the default session timeout is 15 minutes. Sessions are stored in `localStorage` unless cleared due to browser behavior or extensions.
+ *
  * @example
  * ```ts twoslash
  * import { sepolia, alchemy } from "@account-kit/infra"

--- a/docs/pages/reference/account-kit/react/functions/createConfig.mdx
+++ b/docs/pages/reference/account-kit/react/functions/createConfig.mdx
@@ -9,6 +9,8 @@ Wraps the `createConfig` that is exported from `@aa-sdk/core` to allow passing
 an additional argument, the configuration object for the Auth Components UI
 (the modal and AuthCard).
 
+**Note:** In `props.sessionConfig`, if `expirationTimeMs` is not provided, the default session timeout is 15 minutes. Sessions are stored in `localStorage` unless cleared due to browser behavior or extensions.
+
 ## Import
 
 ```ts

--- a/docs/pages/reference/account-kit/react/functions/createConfig.mdx
+++ b/docs/pages/reference/account-kit/react/functions/createConfig.mdx
@@ -17,7 +17,7 @@ import { createConfig } from "@account-kit/react";
 
 ## Usage
 
-```ts
+```ts twoslash
 import { sepolia, alchemy } from "@account-kit/infra"
 import { AlchemyAccountsUIConfig, createConfig } from "@account-kit/react"
 import { QueryClient } from "@tanstack/react-query";
@@ -31,12 +31,12 @@ addPasskeyOnSignup: true,
 }
 
 const config = createConfig({
-  transport: alchemy({ apiKey: "your_api_key" })
-  chain: sepolia,
-  ssr: true,
-  sessionConfig: {
-    duration: 60 * 60, // 1 hour in seconds
-  },
+transport: alchemy({ apiKey: "your_api_key" })
+chain: sepolia,
+ssr: true,
+sessionConfig: {
+expirationTimeMs: 1000 * 60 * 60 * 24, // <-- Adjust the session expiration time as needed (defauly 15 mins)
+},
 }, uiConfig)
 
 export const queryClient = new QueryClient();
@@ -53,11 +53,6 @@ for creating an alchemy account config
 
 `AlchemyAccountsUIConfig`
 (optional) configuration to use for the Auth Components UI
-
-### sessionConfig
-
-`SessionConfig`
-**Note**: If no duration is provided, the default session timeout is 15 minutes (900 seconds). Sessions are stored in `localStorage` unless cleared due to browser behavior or extensions.
 
 ## Returns
 

--- a/docs/pages/resources/faqs.mdx
+++ b/docs/pages/resources/faqs.mdx
@@ -349,7 +349,7 @@ You can customize the session timeout by passing a `sessionConfig` object to the
 createConfig({
   ...,
   sessionConfig: {
-    duration: 60 * 60, // Session duration in seconds (e.g., 1 hour)
+    expirationTimeMs: 1000 * 60 * 60 * 24, // Session duration in milliseconds (e.g., 24 hours)
   },
 })
 ```


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the session configuration in the `createConfig` function to use `expirationTimeMs` instead of `duration`, reflecting a change in how session durations are defined and documented.

### Detailed summary
- Changed `sessionConfig.duration` to `sessionConfig.expirationTimeMs` in `createConfig` and related documentation.
- Updated session duration from 1 hour (in seconds) to 24 hours (in milliseconds).
- Added note about default session timeout of 15 minutes if `expirationTimeMs` is not provided.
- Adjusted documentation to reflect the new session configuration format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->