### PR TITLE
docs: clarify session handling and ssr warning

### DIFF
--- a/docs/pages/react/ssr.mdx
+++ b/docs/pages/react/ssr.mdx
@@ -4,6 +4,8 @@ description: An overview on how to use React Hooks with Server Side Rendering
 slug: wallets/react/ssr
 ---
 
+> ⚠️ **Common Issue**: If SSR is not set up correctly, you may see sessions resetting or users getting logged out unexpectedly. Make sure to follow this guide fully to preserve session state.
+
 When using the React hooks exported by Smart Wallets in a server-side rendered setting, you will see inconsistencies of the user state between the server and the client. This will lead to flashes of content when a user is logged in. To avoid this, the account state can be optimistically loaded on the server and passed to the client.
 
 To enable this setting, you can set `ssr: true` when creating a config. We also make the config a function, so that we can call it once per request which allows for request-based isolation of the account state.

--- a/docs/pages/reference/account-kit/react/functions/createConfig.mdx
+++ b/docs/pages/reference/account-kit/react/functions/createConfig.mdx
@@ -31,9 +31,12 @@ addPasskeyOnSignup: true,
 }
 
 const config = createConfig({
-transport: alchemy({ apiKey: "your_api_key" })
-chain: sepolia,
-ssr: true,
+  transport: alchemy({ apiKey: "your_api_key" })
+  chain: sepolia,
+  ssr: true,
+  sessionConfig: {
+    duration: 60 * 60, // 1 hour in seconds
+  },
 }, uiConfig)
 
 export const queryClient = new QueryClient();
@@ -50,6 +53,11 @@ for creating an alchemy account config
 
 `AlchemyAccountsUIConfig`
 (optional) configuration to use for the Auth Components UI
+
+### sessionConfig
+
+`SessionConfig`
+**Note**: If no duration is provided, the default session timeout is 15 minutes (900 seconds). Sessions are stored in `localStorage` unless cleared due to browser behavior or extensions.
 
 ## Returns
 

--- a/docs/pages/resources/faqs.mdx
+++ b/docs/pages/resources/faqs.mdx
@@ -322,3 +322,53 @@ For more information on how to secure your API key, refer to [this guide](https:
 Protecting your Policy ID requires some custom work, but it’s similar to safeguarding any key on the backend. One solution is to use a proxy server that holds both the API key and Policy ID. In the frontend, when creating an Alchemy client, pass the proxy server URL as the RPC URL instead of a public Alchemy URL.
 
 Additionally, you'll need to implement custom code on your proxy server to limit gas sponsorship requests. This could include rules that make sense for your app, such as limiting gas fees, restricting certain contract or method calls, or implementing limits based on IP addresses or CAPTCHA verification.
+
+### Why are my users getting logged out unexpectedly?
+
+**Issue:**
+You or your users might notice that the session ends sooner than expected, requiring re-authentication.
+
+**Default behavior:**
+By default, authenticated sessions using `AlchemyWebSigner` are stored in `localStorage` and expire after **15 minutes** of inactivity.
+
+---
+
+#### ✅ Solution: Extend or configure session duration
+
+You can customize the session timeout by passing a `sessionConfig` object to the `createConfig` method:
+
+```ts
+createConfig({
+  ...,
+  sessionConfig: {
+    duration: 60 * 60, // Session duration in seconds (e.g., 1 hour)
+  },
+})
+```
+
+👉 [Reference: createConfig](https://www.alchemy.com/docs/wallets/reference/account-kit/react/functions/createConfig)
+
+---
+
+#### 🧪 Other common causes of session ending:
+
+* **Server-Side Rendering (SSR) misconfigured**
+  If you're using SSR and haven't configured the provider correctly, session state can reset on the client.
+  👉 [Enable SSR and pass initial params →](https://www.alchemy.com/docs/wallets/react/ssr)
+
+* **Ad blockers**
+  Some ad blockers (especially those with aggressive cookie or storage policies) can interfere with localStorage or SDK requests, causing unexpected logouts.
+
+* **Private/incognito mode**
+  Browsers often restrict or wipe localStorage between tabs or after a short time in incognito mode. Consider warning users or designing for short session lengths in those environments.
+
+---
+
+#### 🔁 Debugging Checklist
+
+If you're seeing repeated or sporadic logouts in production, test the behavior across:
+
+* Browsers (Chrome, Firefox, Safari)
+* Devices (desktop vs mobile)
+* Browsing modes (incognito vs standard)
+* With and without ad blockers


### PR DESCRIPTION
## Summary
- add FAQ on session timeouts
- explain default session behavior and customization
- mention default session duration in `createConfig` docs
- highlight SSR logout issues in SSR guide

## Testing
- `yarn lint:check` *(fails: fetch from registry blocked)*
- `yarn test:ci` *(fails: fetch from registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6880f904279883249af14465432c5500

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating documentation related to FAQs and the `createConfig` function in the `account-kit` for React, specifically enhancing the clarity and detail of session configuration.

### Detailed summary
- In `faqs.mdx`, a line was modified to improve clarity regarding ad blockers.
- In `createConfig.mdx`, a new section `sessionConfig` was added, detailing the `SessionConfig` and its default session timeout of 15 minutes, along with information on session storage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->