### PR TITLE
fix: optimize toFlagCase function by caching split result

### DIFF
--- a/.vitest/src/rundler/toArgs.ts
+++ b/.vitest/src/rundler/toArgs.ts
@@ -49,8 +49,9 @@ export function toArgs(
 /** Converts to a --flag-case string. */
 export function toFlagCase(str: string, separator = "-") {
   const keys = [];
-  for (let i = 0; i < str.split(".").length; i++) {
-    const key = str.split(".")[i];
+  const parts = str.split(".");
+  for (let i = 0; i < parts.length; i++) {
+    const key = parts[i];
     if (!key) continue;
     keys.push(
       key


### PR DESCRIPTION
Optimize the toFlagCase function in rundler/toArgs.ts by caching the result of str.split(".") to avoid redundant string splitting operations in each loop iteration

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `toFlagCase` function in the `toArgs.ts` file by optimizing how the input string is split and processed.

### Detailed summary
- Replaced the use of `str.split(".").length` with a separate `parts` variable to store the result of `str.split(".")`.
- Updated the loop to iterate over `parts` instead of calling `str.split(".")` multiple times.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->