### PR TITLE
chore(v5): fix precommit checks on v5 branch

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,5 +66,11 @@
         "react/jsx-no-undef": "off",
       },
     },
+    {
+      "files": ["packages/**/*"],
+      "rules": {
+        "no-warning-comments": "off",
+      },
+    },
   ],
 }

--- a/doc-gen/src/constants/packageMap.ts
+++ b/doc-gen/src/constants/packageMap.ts
@@ -9,6 +9,8 @@ const packageMap: Record<string, string> = {
   "account-kit/smart-contracts": "Smart Contracts",
   "aa-sdk/core": "aa-sdk/core",
   "aa-sdk/ethers": "aa-sdk/ethers",
+  "alchemy/common": "Alchemy Common",
+  "alchemy/smart-accounts": "Alchemy Smart Accounts",
 };
 
 export default packageMap;

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -1118,6 +1118,56 @@ navigation:
                       - page: send
                         path: wallets/pages/reference/aa-sdk/ethers/classes/EthersProviderAdapter/send.mdx
 
+      - section: Alchemy Common
+        contents:
+          - section: SDK Reference
+            path: wallets/pages/reference/alchemy/common/index.mdx
+            contents:
+              - section: Functions
+                contents:
+                  - page: addBreadCrumb
+                    path: wallets/pages/reference/alchemy/common/functions/addBreadCrumb.mdx
+                  - page: alchemy
+                    path: wallets/pages/reference/alchemy/common/functions/alchemy.mdx
+                  - page: isAlchemyTransport
+                    path: wallets/pages/reference/alchemy/common/functions/isAlchemyTransport.mdx
+                  - page: split
+                    path: wallets/pages/reference/alchemy/common/functions/split.mdx
+              - section: Classes
+                contents:
+                  - page: AccountNotFoundError
+                    path: wallets/pages/reference/alchemy/common/classes/AccountNotFoundError/constructor.mdx
+                  - page: ChainNotFoundError
+                    path: wallets/pages/reference/alchemy/common/classes/ChainNotFoundError/constructor.mdx
+      - section: Alchemy Smart Accounts
+        contents:
+          - section: SDK Reference
+            path: wallets/pages/reference/alchemy/smart-accounts/index.mdx
+            contents:
+              - section: Functions
+                contents:
+                  - page: defaultLightAccountVersion
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/defaultLightAccountVersion.mdx
+                  - page: getDefaultLightAccountFactoryAddress
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/getDefaultLightAccountFactoryAddress.mdx
+                  - page: getDefaultMultiOwnerLightAccountFactoryAddress
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/getDefaultMultiOwnerLightAccountFactoryAddress.mdx
+                  - page: getLightAccountImplAddress
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/getLightAccountImplAddress.mdx
+                  - page: getLightAccountVersionForAccount
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/getLightAccountVersionForAccount.mdx
+                  - page: multiOwnerLightAccountActions
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/multiOwnerLightAccountActions.mdx
+                  - page: predictLightAccountAddress
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/predictLightAccountAddress.mdx
+                  - page: predictMultiOwnerLightAccountAddress
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/predictMultiOwnerLightAccountAddress.mdx
+                  - page: singleOwnerLightAccountActions
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/singleOwnerLightAccountActions.mdx
+                  - page: toLightAccount
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/toLightAccount.mdx
+                  - page: toMultiOwnerLightAccount
+                    path: wallets/pages/reference/alchemy/smart-accounts/functions/toMultiOwnerLightAccount.mdx
       - section: API
         contents:
           - section: Smart Wallets

--- a/docs/pages/reference/alchemy/common/index.mdx
+++ b/docs/pages/reference/alchemy/common/index.mdx
@@ -1,0 +1,7 @@
+---
+title: alchemy/common reference
+description: The landing page for all of the reference documentation for @alchemy/common
+slug: wallets/reference/alchemy/common
+---
+
+The `@alchemy/common` package contains components shared across other Alchemy packages.

--- a/docs/pages/reference/alchemy/smart-accounts/index.mdx
+++ b/docs/pages/reference/alchemy/smart-accounts/index.mdx
@@ -1,0 +1,8 @@
+---
+title: alchemy/smart-accounts reference
+description: The landing page for all of the reference documentation for @alchemy/smart-accounts
+slug: wallets/reference/alchemy/smart-accounts
+---
+
+The `@alchemy/smart-accounts` package contains all of the definitions for our smart contracts.
+This package is designed for developers who want to use our smart contract accounts directly with viem. For a better integration path, we recommend using `@alchemy/wallet-apis`, or a platform-specific package like `@alchemy/react`.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "vitest dev",
     "test:ci": "vitest run",
     "test:typecheck": "TYPECHECK=true vitest --typecheck --typecheck.only run",
-    "lint:write": "eslint . --fix && yarn fern:gen && prettier --loglevel warn --write --ignore-unknown .",
+    "lint:write": "eslint . --fix && yarn fern:gen && prettier --log-level warn --write --ignore-unknown .",
     "lint:check": "eslint . && prettier --check .",
     "prepare": "husky install && yarn turbo prepare",
     "docs:dev": "./docs/scripts/docs-dev.sh",


### PR DESCRIPTION
The v5 branch is currently failing precommit checks for two reasons:
- todo comments aren't allowed by the linter
- the docsgen tool fails to find a section to put v5 packages into

This PR patches these issues by:
- Ignoring the `no-warning-comments` rule within the v5 `packages/` folder.
- Adding sections (and section mappings) to docs-gen for the v5 packages `@alchemy/common` and `@alchemy/smart-accounts`
- Also fixes the naming of a parameter to prettier, which changed between prettier versions. This prevents prettier from logging files without changes to the console when running the formatter.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the documentation for the `@alchemy/common` and `@alchemy/smart-accounts` packages, adding new reference pages and updating configurations to improve linting and project structure.

### Detailed summary
- Added a commit reference to the `docs-site`.
- Updated `.eslintrc` to include new rules.
- Expanded `packageMap.ts` with new entries for `alchemy/common` and `alchemy/smart-accounts`.
- Created reference pages for `@alchemy/common` and `@alchemy/smart-accounts`.
- Modified `package.json` for linting command adjustments.
- Updated `docs.yml` to include new sections and paths for documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->