### PR TITLE
fix: respect retryCount on alchemy transport & in alchemy smart account client

### DIFF
--- a/account-kit/infra/src/alchemyTransport.test.ts
+++ b/account-kit/infra/src/alchemyTransport.test.ts
@@ -1,7 +1,10 @@
 import * as AACoreModule from "@aa-sdk/core";
+import { createSmartAccountClient } from "@aa-sdk/core";
 import { avalanche } from "viem/chains";
 import { alchemy } from "./alchemyTransport.js";
-import { sepolia } from "./chains.js";
+import { arbitrumSepolia, sepolia } from "./chains.js";
+import { http } from "viem";
+import { createBundlerClient } from "viem/account-abstraction";
 
 describe("Alchemy Transport Tests", () => {
   it.each([
@@ -46,4 +49,69 @@ describe("Alchemy Transport Tests", () => {
       ]]
     `);
   });
+
+  it.each([0, 1, 2, 3])(
+    "respects retryCount of %i when used with a viem bundler client",
+    async (retryCount) => {
+      const { mockFetch, unstub } = givenMockFetchError();
+
+      const client = createBundlerClient({
+        transport: alchemy({
+          rpcUrl: "http://invalid",
+          retryCount,
+        }),
+        chain: arbitrumSepolia,
+      });
+
+      await expect(
+        client.request({
+          // @ts-expect-error - Method doesn't matter for this test.
+          method: "eth_blockNumber",
+        }),
+      ).rejects.toThrow();
+
+      expect(mockFetch.mock.calls.length).toEqual(retryCount + 1);
+      unstub();
+    },
+  );
+
+  it.each([0, 1, 2, 3])(
+    "respects retryCount of %i when used with an alchemy smart account client",
+    async (retryCount) => {
+      const { mockFetch, unstub } = givenMockFetchError();
+
+      const client = createSmartAccountClient({
+        transport: alchemy({
+          apiKey: "invalid",
+          retryCount,
+        }),
+        chain: arbitrumSepolia,
+      });
+
+      await expect(
+        client.request({
+          method: "eth_blockNumber",
+        }),
+      ).rejects.toThrow();
+
+      expect(mockFetch.mock.calls.length).toEqual(retryCount + 1);
+      unstub();
+    },
+  );
 });
+
+// Mocks global fetch to always return a 500 error.
+const givenMockFetchError = () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    json: () => Promise.resolve({ error: "Internal Server Error" }),
+    text: () => Promise.resolve("Internal Server Error"),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+  return {
+    mockFetch,
+    unstub: () => vi.unstubAllGlobals(),
+  };
+};

--- a/account-kit/infra/src/alchemyTransport.test.ts
+++ b/account-kit/infra/src/alchemyTransport.test.ts
@@ -2,8 +2,7 @@ import * as AACoreModule from "@aa-sdk/core";
 import { createSmartAccountClient } from "@aa-sdk/core";
 import { avalanche } from "viem/chains";
 import { alchemy } from "./alchemyTransport.js";
-import { arbitrumSepolia, sepolia } from "./chains.js";
-import { http } from "viem";
+import { sepolia } from "./chains.js";
 import { createBundlerClient } from "viem/account-abstraction";
 
 describe("Alchemy Transport Tests", () => {
@@ -60,7 +59,7 @@ describe("Alchemy Transport Tests", () => {
           rpcUrl: "http://invalid",
           retryCount,
         }),
-        chain: arbitrumSepolia,
+        chain: sepolia,
       });
 
       await expect(
@@ -85,7 +84,7 @@ describe("Alchemy Transport Tests", () => {
           apiKey: "invalid",
           retryCount,
         }),
-        chain: arbitrumSepolia,
+        chain: sepolia,
       });
 
       await expect(

--- a/account-kit/infra/src/alchemyTransport.ts
+++ b/account-kit/infra/src/alchemyTransport.ts
@@ -190,7 +190,7 @@ export function alchemy(config: AlchemyTransportConfig): AlchemyTransport {
           overrides: [
             {
               methods: alchemyMethods,
-              transport: http(rpcUrl, { fetchOptions }),
+              transport: http(rpcUrl, { fetchOptions, retryCount }),
             },
             {
               methods: chainAgnosticMethods,
@@ -228,8 +228,15 @@ export function alchemy(config: AlchemyTransportConfig): AlchemyTransport {
       {
         key: "alchemy",
         name: "Alchemy Transport",
-        request: innerTransport(opts).request,
-        retryCount: retryCount ?? opts?.retryCount,
+        request: innerTransport({
+          ...opts,
+          // Retries are already handled above within the split transport,
+          // so `retryCount` must be 0 here for the expected behavior.
+          retryCount: 0,
+        }).request,
+        // Retries are already handled above within the split transport,
+        // so `retryCount` must be 0 here too for the expected behavior.
+        retryCount: 0,
         retryDelay,
         type: "alchemy",
       },


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `alchemy` transport by introducing a `retryCount` option, allowing for better error handling during RPC requests. It also includes tests to verify the behavior of retry logic with both `viem` and `alchemy` clients.

### Detailed summary
- Added `retryCount` option to `alchemy` transport configuration.
- Updated `request` method in `alchemy` to handle `retryCount`.
- Enhanced tests for `alchemy` transport to validate retry logic.
- Introduced a mock fetch error for testing purposes.
- Improved error handling in `SmartAccountClientTransport` methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->