### PR TITLE
chore(rn-signer): update Java libraries to latest versions

### DIFF
--- a/account-kit/rn-signer/android/build.gradle
+++ b/account-kit/rn-signer/android/build.gradle
@@ -164,11 +164,11 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-android:0.76"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "javax.xml.bind:jaxb-api:2.3.1"
+  api "javax.xml.bind:jaxb-api:2.4.0-b180830.0359"
   api "xerces:xercesImpl:2.12.2"
-  api "androidx.security:security-crypto:1.1.0-alpha06"
-  api "com.google.crypto.tink:tink-android:1.15.0"
-  api "org.bitcoinj:bitcoinj-core:0.16.3"
+  api "androidx.security:security-crypto:1.1.0"
+  api "com.google.crypto.tink:tink-android:1.18.0"
+  api "org.bitcoinj:bitcoinj-core:0.17"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1"
 }
 

--- a/account-kit/rn-signer/android/src/main/java/com/accountkit/reactnativesigner/core/TEKStamper.kt
+++ b/account-kit/rn-signer/android/src/main/java/com/accountkit/reactnativesigner/core/TEKStamper.kt
@@ -12,7 +12,7 @@ import com.google.crypto.tink.subtle.EllipticCurves
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.bitcoinj.core.Base58
+import org.bitcoinj.base.Base58
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.jce.spec.ECPublicKeySpec


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating dependencies and imports in the `TEKStamper.kt` file and the `build.gradle` file for the Android project. 

### Detailed summary
- Changed import from `org.bitcoinj.core.Base58` to `org.bitcoinj.base.Base58` in `TEKStamper.kt`.
- Updated `javax.xml.bind:jaxb-api` version from `2.3.1` to `2.4.0-b180830.0359` in `build.gradle`.
- Updated `androidx.security:security-crypto` version from `1.1.0-alpha06` to `1.1.0`.
- Updated `com.google.crypto.tink:tink-android` version from `1.15.0` to `1.18.0`.
- Updated `org.bitcoinj:bitcoinj-core` version from `0.16.3` to `0.17`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->