### PR TITLE
refactor: replace magic number with named constant for OAuth redirect…

### DIFF
--- a/account-kit/signer/src/client/index.ts
+++ b/account-kit/signer/src/client/index.ts
@@ -445,8 +445,11 @@ export class AlchemySignerWebClient extends BaseSignerClient<ExportWalletParams>
     });
 
     window.location.href = providerUrl;
+    
+    // Timeout for OAuth redirect in case of failure
+    const OAUTH_REDIRECT_TIMEOUT_MS = 1000;
     return new Promise((_, reject) =>
-      setTimeout(() => reject("Failed to redirect to OAuth provider"), 1000),
+      setTimeout(() => reject("Failed to redirect to OAuth provider"), OAUTH_REDIRECT_TIMEOUT_MS),
     );
   };
 


### PR DESCRIPTION
Replace hardcoded 1000ms timeout with OAUTH_REDIRECT_TIMEOUT_MS constant to improve code readability and maintainability. This change eliminates magic numbers and makes the timeout value self-documenting.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a constant for the OAuth redirect timeout, enhancing code readability and maintainability.

### Detailed summary
- Added a comment explaining the purpose of `OAUTH_REDIRECT_TIMEOUT_MS`.
- Introduced the constant `OAUTH_REDIRECT_TIMEOUT_MS` set to `1000` milliseconds.
- Replaced the hardcoded timeout value in the `setTimeout` function with `OAUTH_REDIRECT_TIMEOUT_MS`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->