### PR TITLE
chore: add anvil/foundry readme to V5 and check for installation before tests

### DIFF
--- a/.vitest/README.md
+++ b/.vitest/README.md
@@ -1,0 +1,47 @@
+# Vitest Testing Infrastructure
+
+This directory contains the testing infrastructure for the aa-sdk project using Vitest.
+
+## Prerequisites
+
+### Anvil Installation
+
+To run the tests in this project, you need to have **Anvil** installed. Anvil is part of the Foundry toolchain and is used as a local Ethereum node for testing.
+
+#### Install via Foundryup (Recommended)
+
+The easiest way to install Anvil is through Foundryup, the official installer for the Foundry toolchain.
+
+1. **Install Foundryup:**
+
+   ```bash
+   curl -L https://foundry.paradigm.xyz | bash
+   ```
+
+2. **Install the latest stable version:**
+   ```bash
+   foundryup
+   ```
+
+This will install `forge`, `cast`, `anvil`, and `chisel` binaries.
+
+#### Verify Installation
+
+Check that Anvil is installed correctly:
+
+```bash
+anvil --version
+```
+
+For complete installation instructions and troubleshooting, visit the official Foundry documentation:
+**https://getfoundry.sh/introduction/installation/**
+
+## Running Tests
+
+Once Anvil is installed, you can run the tests using:
+
+```bash
+yarn test
+```
+
+The test infrastructure will automatically start and manage Anvil instances as needed.

--- a/.vitest/setupTests.ts
+++ b/.vitest/setupTests.ts
@@ -4,15 +4,27 @@ dotenv.config();
 import fetch from "node-fetch";
 import { setAutomine } from "viem/actions";
 import { beforeAll } from "vitest";
-import { poolId } from "./src/constants.js";
+import { poolId, rundlerBinaryPath } from "./src/constants.js";
 import { local060Instance, local070Instance } from "./src/instances.js";
 import { paymaster060 } from "./src/paymaster/paymaster060.js";
 import { paymaster070 } from "./src/paymaster/paymaster070.js";
+import { checkFoundryInstallation } from "./src/utils/checkFoundryInstallation.js";
 
 // @ts-expect-error this does exist but ts is not liking it
 global.fetch = fetch;
 
 beforeAll(async () => {
+  const foundryCheck = checkFoundryInstallation(rundlerBinaryPath);
+  if (!foundryCheck.isInstalled) {
+    const baseMessage = `
+    ❌ Foundry/Anvil is not properly installed or not in your PATH.
+    Please see the README in .vitest/ for installation instructions.
+    Error details: ${foundryCheck.error || "Unknown error"}
+    `;
+
+    throw new Error(baseMessage);
+  }
+
   const client060 = local060Instance.getClient();
   const client070 = local070Instance.getClient();
   await setAutomine(client060, true);

--- a/.vitest/src/utils/checkFoundryInstallation.ts
+++ b/.vitest/src/utils/checkFoundryInstallation.ts
@@ -1,0 +1,49 @@
+import { execSync } from "child_process";
+
+export interface FoundryCheckResult {
+  isInstalled: boolean;
+  anvilVersion?: string;
+  rundlerBinaryPath?: string;
+  error?: string;
+}
+
+export function checkFoundryInstallation(
+  rundlerBinary?: string,
+): FoundryCheckResult {
+  try {
+    // Check anvil installation
+    const anvilVersion = execSync("anvil --version", {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    // Check rundler binary if provided
+    let rundlerBinaryPath: string | undefined;
+    if (rundlerBinary) {
+      try {
+        execSync(`${rundlerBinary} --version`, {
+          encoding: "utf-8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        rundlerBinaryPath = rundlerBinary;
+      } catch {
+        // Rundler check failed but anvil is available
+      }
+    }
+
+    return {
+      isInstalled: true,
+      anvilVersion,
+      rundlerBinaryPath,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    return {
+      isInstalled: false,
+      error: errorMessage,
+    };
+  }
+}


### PR DESCRIPTION
Got stuck during dev with tests timing out, and spent a bit too long trying to debug what was wrong, only to realize I had switched node versions and forgot to reinstall `anvil`. Adding anvil/foundryup installation instructions back in from the `main` branch and also adding a check at the beginning of the tests that require anvil in order to fail quickly if it's not installed

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new utility function to check for the installation of Foundry and Anvil, integrates this check into test setup, and updates the README to include installation instructions for Anvil.

### Detailed summary
- Added `checkFoundryInstallation` function in `checkFoundryInstallation.ts` to verify Foundry and Anvil installation.
- Integrated the installation check in `setupTests.ts` to ensure tests only run if Foundry/Anvil is installed.
- Updated `README.md` with detailed Anvil installation instructions and verification steps.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->