### PR TITLE
docs: fix gas sponsorship url

### DIFF
--- a/docs/pages/transactions/send/evm-user-ops.mdx
+++ b/docs/pages/transactions/send/evm-user-ops.mdx
@@ -12,7 +12,7 @@ Once your users have been authenticated, you can start sending user operations! 
 
     Sending user operations is really easy with React hooks. Use the [`useSendUserOperation`](/wallets/reference/account-kit/react/hooks/useSendUserOperation) hook to send transactions.
 
-    If you want to sponsor the gas for a user, see our [guide](/wallets/transactions/sponsor-gas/sponsor-gas-evm).
+    If you want to sponsor the gas for a user, see our [guide](/wallets/transactions/sponsor-gas/sponsor-gas).
 
     ## Single user operation
 
@@ -68,7 +68,7 @@ Once your users have been authenticated, you can start sending user operations! 
   <Tab title="React Native">
     Sending user operations is pretty straightforward. All you have to do is use the `useSendUserOperation()` hook from the `@account-kit/react-native` package.
 
-    If you want to sponsor the gas for a user, see our [guide](/wallets/react-native/using-smart-accounts/sponsor-gas).
+    If you want to sponsor the gas for a user, see our [guide](/wallets/transactions/sponsor-gas/sponsor-gas).
 
     ## Single user operation
 

--- a/docs/pages/transactions/send/send-user-operations.mdx
+++ b/docs/pages/transactions/send/send-user-operations.mdx
@@ -12,7 +12,7 @@ Once your users have been authenticated, you can start sending user operations! 
 
     Sending user operations is really easy with React hooks. Use the [`useSendUserOperation`](/wallets/reference/account-kit/react/hooks/useSendUserOperation) hook to send transactions.
 
-    If you want to sponsor the gas for a user, see our [guide](/wallets/transactions/sponsor-gas/sponsor-gas-evm).
+    If you want to sponsor the gas for a user, see our [guide](/wallets/transactions/sponsor-gas/sponsor-gas).
 
     ## Single user operation
 
@@ -125,7 +125,7 @@ Once your users have been authenticated, you can start sending user operations! 
 
     Sending user operations is pretty straightforward. All you have to do is use the `useSendUserOperation()` hook from the `@account-kit/react-native` package.
 
-    If you want to sponsor the gas for a user, see our [guide](/wallets/react-native/using-smart-accounts/sponsor-gas).
+    If you want to sponsor the gas for a user, see our [guide](/wallets/transactions/sponsor-gas/sponsor-gas).
 
     ## Single user operation
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates references to a gas sponsorship guide in the documentation for sending user operations. It removes the specific mention of "sponsor-gas-evm" and replaces it with a more general "sponsor-gas" link across multiple documentation files.

### Detailed summary
- Updated link in `docs/pages/transactions/send/send-user-operations.mdx` to the gas sponsorship guide.
- Updated link in `docs/pages/transactions/send/evm-user-ops.mdx` to the gas sponsorship guide.
- Updated link in `docs/pages/transactions/send/evm-user-ops.mdx` under the React Native tab to the gas sponsorship guide.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->