### PR TITLE
fix: update efficiency value in doc

### DIFF
--- a/docs/pages/bundler-api/bundler-faqs.mdx
+++ b/docs/pages/bundler-api/bundler-faqs.mdx
@@ -122,7 +122,7 @@ Recommended Actions for Calculating `maxFeePerGas`:
 5. **Determine `maxFeePerGas`**: Add the buffered values from steps 2 and 4 together to obtain the `maxFeePerGas` for your user operation.
 
 <Warning>
-  The Alchemy bundler requires the simulated gas limit efficiency of both a UO's pre-operation gas and call gas to be greater than or equal to 15%. (Note: the 15% efficiency value is subject to change and we will update docs if it does.)
+  The Alchemy bundler requires the simulated gas limit efficiency of both a UO's pre-operation gas and call gas to be greater than or equal to 20%. (Note: the 20% efficiency value is subject to change and we will update docs if it does.)
 
 **Gas limit efficiency** = gas used / gas limit
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the `Alchemy` bundler regarding the required simulated gas limit efficiency.

### Detailed summary
- Changed the required efficiency from `15%` to `20%` for both a UO's pre-operation gas and call gas.
- Updated the note to reflect that the efficiency value is subject to change and will be updated in the documentation if necessary.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->