### PR TITLE
docs: fix dark mode for react quickstart CTA

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -17,8 +17,9 @@ slug: wallets
   <Button
     icon="bolt"
     href="/wallets/react/quickstart"
+    className="react-quickstart-cta"
     style={{
-      backgroundColor: "white",
+      backgroundColor: "var(--accent-2, #ECF3FF)",
       color: "black",
       padding: "2rem 2rem",
       fontSize: "1rem",
@@ -39,6 +40,15 @@ slug: wallets
     Try our demo
   </Button>
 </div>
+
+<style>
+  {`@media (prefers-color-scheme: dark) {
+    .react-quickstart-cta {
+      background-color: white !important;
+      color: black !important;
+    }
+  }`}
+</style>
 
 ## Everything you need for onchain applications
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -18,8 +18,8 @@ slug: wallets
     icon="bolt"
     href="/wallets/react/quickstart"
     style={{
-      backgroundColor: "var(--accent-2, #ECF3FF)",
-      color: "var(--fg-primary)",
+      backgroundColor: "white",
+      color: "black",
       padding: "2rem 2rem",
       fontSize: "1rem",
     }}

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -19,7 +19,7 @@ slug: wallets
     href="/wallets/react/quickstart"
     style={{
       backgroundColor: "var(--accent-2, #ECF3FF)",
-      color: "black",
+      color: "var(--fg-primary)",
       padding: "2rem 2rem",
       fontSize: "1rem",
     }}


### PR DESCRIPTION
## Summary
- ensure React Quickstart CTA adapts to dark mode using themed foreground color

## Testing
- `yarn lint:check` *(fails: ESLint couldn't find config "react-app"; dependencies missing due to Node version)*
- `echo "docs: fix dark mode for react quickstart CTA" | yarn commitlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8a3bc80d08324a7494c5d9a7703f4

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new class for a button component in the documentation page, enhancing its styling for different color schemes.

### Detailed summary
- Added `className="react-quickstart-cta"` to a `Button`.
- Introduced a `<style>` block that applies dark mode styles:
  - Sets background color to white and text color to black for elements with the `react-quickstart-cta` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->