### PR TITLE
fix: improve dark mode for docs quickstart

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -17,9 +17,8 @@ slug: wallets
   <Button
     icon="bolt"
     href="/wallets/react/quickstart"
+    className="react-quickstart-btn"
     style={{
-      backgroundColor: "var(--accent-2, #ECF3FF)",
-      color: "black",
       padding: "2rem 2rem",
       fontSize: "1rem",
     }}
@@ -39,6 +38,19 @@ slug: wallets
     Try our demo
   </Button>
 </div>
+
+<style>{`
+  .react-quickstart-btn {
+    background-color: var(--accent-2, #ECF3FF);
+    color: black;
+  }
+  @media (prefers-color-scheme: dark) {
+    .react-quickstart-btn {
+      background-color: #4B5563;
+      color: white;
+    }
+  }
+`}</style>
 
 ## Everything you need for onchain applications
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -40,15 +40,19 @@ slug: wallets
 </div>
 
 <style>{`
-  .react-quickstart-btn {
-    background-color: var(--accent-2, #ECF3FF);
-    color: black;
+  :root {
+    --react-quickstart-btn-bg: var(--accent-2, #ECF3FF);
+    --react-quickstart-btn-color: black;
   }
-  @media (prefers-color-scheme: dark) {
-    .react-quickstart-btn {
-      background-color: #4B5563;
-      color: white;
-    }
+
+  html[data-theme='dark'] {
+    --react-quickstart-btn-bg: #6B7280;
+    --react-quickstart-btn-color: white;
+  }
+
+  .react-quickstart-btn {
+    background-color: var(--react-quickstart-btn-bg);
+    color: var(--react-quickstart-btn-color);
   }
 `}</style>
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -46,7 +46,7 @@ slug: wallets
   }
 
   html[data-theme='dark'] {
-    --react-quickstart-btn-bg: #6B7280;
+    --react-quickstart-btn-bg: #777777;
     --react-quickstart-btn-color: white;
   }
 


### PR DESCRIPTION
## Summary
- ensure React Quickstart CTA uses white text on dark mode
- lighten dark mode background color for CTA button

## Testing
- `npx prettier docs/pages/index.mdx --check`
- `yarn install` (fails: The engine "node" is incompatible with this module)
- `npx vitest run docs/pages/index.mdx` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_b_68a8a53eb88083298576b7f54830f180

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new button style for the `react-quickstart-btn`, enhancing its appearance with CSS variables for light and dark themes, and applying these styles to a button in the documentation.

### Detailed summary
- Added `className="react-quickstart-btn"` to a button.
- Introduced CSS variables for button background and text color.
- Defined styles for light and dark themes.
- Created a `.react-quickstart-btn` class to apply the new styles.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->