### PR TITLE
feat: add http debug options to alchemyTransport

### DIFF
--- a/packages/common/src/transport/alchemy.ts
+++ b/packages/common/src/transport/alchemy.ts
@@ -34,6 +34,11 @@ export type AlchemyTransportConfig = {
   /** The base delay (in ms) between retries. */
   retryDelay?: TransportConfig["retryDelay"] | undefined;
   fetchOptions?: NoUndefined<HttpTransportConfig["fetchOptions"]>;
+  /** HTTP transport options for debugging and configuration */
+  httpOptions?: Pick<
+    HttpTransportConfig,
+    "onFetchRequest" | "onFetchResponse" | "timeout" | "batch"
+  >;
 };
 
 type AlchemyTransportBase<
@@ -121,6 +126,21 @@ export function isAlchemyTransport(
  * });
  * ```
  *
+ * @example
+ * Using HTTP debugging options:
+ * ```ts
+ * import { alchemyTransport } from "@alchemy/common";
+ *
+ * const transport = alchemyTransport({
+ *   apiKey: "your-api-key",
+ *   httpOptions: {
+ *     onFetchRequest: (request) => console.log("Request:", request),
+ *     onFetchResponse: (response) => console.log("Response:", response),
+ *     timeout: 30000
+ *   }
+ * });
+ * ```
+ *
  * @param {AlchemyTransportConfig} config - The configuration object for the Alchemy transport
  * @param {string} [config.apiKey] - API key for Alchemy authentication
  * @param {string} [config.jwt] - JWT token for authentication
@@ -128,6 +148,7 @@ export function isAlchemyTransport(
  * @param {number} [config.retryDelay] - The delay between retries, in milliseconds
  * @param {number} [config.retryCount] - The number of retry attempts (default: 0)
  * @param {object} [config.fetchOptions] - Optional fetch options for HTTP requests
+ * @param {object} [config.httpOptions] - HTTP transport options for debugging (onFetchRequest, onFetchResponse, timeout, batch)
  * @returns {AlchemyTransport} The configured Alchemy transport function
  */
 export function alchemyTransport<
@@ -141,6 +162,7 @@ export function alchemyTransport<
     retryDelay,
     retryCount = 0,
     fetchOptions: fetchOptions_,
+    httpOptions,
   } = config;
 
   // Create a copy of fetch options for modification
@@ -208,6 +230,8 @@ export function alchemyTransport<
       // count that is already specified on the underlying transport.
       retryCount: 0,
       retryDelay,
+      // Pass through HTTP debugging options
+      ...httpOptions,
     });
 
     return createTransport(

--- a/packages/common/tests/transport/alchemyTransport.test.ts
+++ b/packages/common/tests/transport/alchemyTransport.test.ts
@@ -81,6 +81,26 @@ describe("Alchemy Transport Tests", () => {
       expect(result.config.retryCount).toBe(3);
       expect(result.config.retryDelay).toBe(1000);
     });
+
+    it("should accept HTTP debugging options", () => {
+      const onFetchRequest = vi.fn();
+      const onFetchResponse = vi.fn();
+
+      const transport = alchemyTransport({
+        apiKey: "test-key",
+        httpOptions: {
+          onFetchRequest,
+          onFetchResponse,
+          timeout: 30000,
+        },
+      });
+
+      expect(transport).toBeDefined();
+      expect(typeof transport).toBe("function");
+
+      const result = transport({ chain: sepolia });
+      expect(result).toBeDefined();
+    });
   });
 
   describe("Chain Validation", () => {


### PR DESCRIPTION
Add viem's http options into `alchemyTransport` for easier debugging

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?
