### PR TITLE
fix: revert lint-staged change

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,8 @@
     }
   },
   "lint-staged": {
-    "**/*.{mdx,md,js,jsx,ts,tsx}": [
-      "eslint --fix --max-warnings 0",
-      "prettier --write"
+    "**/src/**/*.{tsx,jsx,ts,js}": [
+      "yarn lint:write"
     ]
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `package.json` file to modify the `lint-staged` configuration, focusing on the files that will be linted and formatted during pre-commit checks. It also includes a subproject commit reference.

### Detailed summary
- Changed `lint-staged` file patterns from `"**/*.{mdx,md,js,jsx,ts,tsx}"` to `"**/src/**/*.{tsx,jsx,ts,js}"`
- Updated linting command from ESLint and Prettier to `yarn lint:write`
- Added subproject commit `b5a4494510a58e82a3739df57ec21a82cd6105d1`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->