### PR TITLE
docs: add redirect for rollups quickstart

### DIFF
--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -7,6 +7,10 @@ experimental:
   mdx-components:
     - wallets/components
 
+redirects:
+  - from: /reference/rollups/quickstart
+    to: https://www.alchemy.com/docs/reference/rollups-quickstart
+
 navigation:
   - tab: wallets
     layout:


### PR DESCRIPTION
## Summary
- redirect legacy rollups quickstart path to updated Alchemy docs page

## Testing
- `npx prettier docs/docs.yml --write`


------
https://chatgpt.com/codex/tasks/task_b_68b0ac5d935c83299e6a08c53a136496

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `docs/docs.yml` file by adding a redirect for a specific URL and modifying the navigation structure.

### Detailed summary
- Removed `wallets/components` from the `docs.yml`.
- Added a `redirects` section with:
  - `from`: `/reference/rollups/quickstart`
  - `to`: `https://www.alchemy.com/docs/reference/rollups-quickstart`
- Updated the `navigation` to remove the `wallets` tab.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->