### PR TITLE
feat: add swap api decorator

### DIFF
--- a/packages/wallet-apis/src/actions/requestAccount.ts
+++ b/packages/wallet-apis/src/actions/requestAccount.ts
@@ -3,12 +3,18 @@ import type { Address } from "abitype";
 import type { Prettify, UnionOmit } from "viem";
 import type { wallet_requestAccount } from "@alchemy/wallet-api-types/rpc";
 import deepEqual from "deep-equal";
-import type { InnerWalletApiClient, SignerClient } from "../types";
+import type {
+  InnerWalletApiClient,
+  OptionalSignerAddress,
+  SignerClient,
+} from "../types";
 
 export type RequestAccountParams = Prettify<
-  UnionOmit<
-    Static<typeof wallet_requestAccount>["Request"]["params"][0],
-    "includeCounterfactualInfo"
+  OptionalSignerAddress<
+    UnionOmit<
+      Static<typeof wallet_requestAccount>["Request"]["params"][0],
+      "includeCounterfactualInfo"
+    >
   >
 >;
 
@@ -50,6 +56,7 @@ export async function requestAccount(
             includeCounterfactualInfo: true,
           }
         : {
+            ...params,
             signerAddress:
               params?.signerAddress ?? signerClient.account.address,
             includeCounterfactualInfo: true,

--- a/packages/wallet-apis/src/actions/requestAccount.ts
+++ b/packages/wallet-apis/src/actions/requestAccount.ts
@@ -1,18 +1,15 @@
 import type { Static } from "@sinclair/typebox";
 import type { Address } from "abitype";
-import type { Prettify } from "viem";
+import type { Prettify, UnionOmit } from "viem";
 import type { wallet_requestAccount } from "@alchemy/wallet-api-types/rpc";
 import deepEqual from "deep-equal";
 import type { InnerWalletApiClient, SignerClient } from "../types";
 
 export type RequestAccountParams = Prettify<
-  Omit<
-    Extract<
-      Static<typeof wallet_requestAccount>["Request"]["params"][0],
-      { signerAddress: Address }
-    >,
-    "signerAddress" | "includeCounterfactualInfo"
-  > & { accountAddress?: Address }
+  UnionOmit<
+    Static<typeof wallet_requestAccount>["Request"]["params"][0],
+    "includeCounterfactualInfo"
+  >
 >;
 
 export type RequestAccountResult = Prettify<{ address: Address }>;
@@ -47,14 +44,14 @@ export async function requestAccount(
           accountAddress: client.account.address,
           includeCounterfactualInfo: true,
         }
-      : params?.accountAddress
+      : params != null && "accountAddress" in params
         ? {
             accountAddress: params.accountAddress,
             includeCounterfactualInfo: true,
           }
         : {
-            ...params,
-            signerAddress: signerClient.account.address,
+            signerAddress:
+              params?.signerAddress ?? signerClient.account.address,
             includeCounterfactualInfo: true,
           };
 

--- a/packages/wallet-apis/src/actions/signMessage.ts
+++ b/packages/wallet-apis/src/actions/signMessage.ts
@@ -10,7 +10,6 @@ import { prepareSign } from "./prepareSign.js";
 import { signSignatureRequest } from "./signSignatureRequest.js";
 import { formatSign } from "./formatSign.js";
 import { signableMessageToJsonSafe } from "../utils/format.js";
-import { AccountNotFoundError } from "@alchemy/common";
 
 export type SignMessageParams = Prettify<{
   message: SignableMessage;
@@ -44,12 +43,13 @@ export async function signMessage(
   signerClient: SignerClient,
   params: SignMessageParams,
 ): Promise<SignMessageResult> {
-  const account = await requestAccount(client, signerClient, {
-    accountAddress: params.account ?? client.account?.address,
-  });
-  if (!account) {
-    throw new AccountNotFoundError();
-  }
+  const accountAddress = params.account ?? client.account?.address;
+
+  const account = await requestAccount(
+    client,
+    signerClient,
+    accountAddress != null ? { accountAddress } : undefined,
+  );
 
   const prepared = await prepareSign(client, {
     from: account.address,

--- a/packages/wallet-apis/src/actions/signTypedData.ts
+++ b/packages/wallet-apis/src/actions/signTypedData.ts
@@ -10,7 +10,6 @@ import { prepareSign } from "./prepareSign.js";
 import { signSignatureRequest } from "./signSignatureRequest.js";
 import { formatSign } from "./formatSign.js";
 import { typedDataToJsonSafe } from "../utils/format.js";
-import { AccountNotFoundError } from "@alchemy/common";
 import type { SignerClient } from "../types.js";
 
 export type SignTypedDataParams = Prettify<
@@ -60,12 +59,12 @@ export async function signTypedData(
   signerClient: SignerClient,
   params: SignTypedDataParams,
 ): Promise<SignTypedDataResult> {
-  const account = await requestAccount(client, signerClient, {
-    accountAddress: params.account ?? client.account?.address,
-  });
-  if (!account) {
-    throw new AccountNotFoundError();
-  }
+  const accountAddress = params.account ?? client.account?.address;
+  const account = await requestAccount(
+    client,
+    signerClient,
+    accountAddress != null ? { accountAddress } : undefined,
+  );
 
   const prepared = await prepareSign(client, {
     from: account.address,

--- a/packages/wallet-apis/src/client.e2e.test.ts
+++ b/packages/wallet-apis/src/client.e2e.test.ts
@@ -6,12 +6,10 @@ import {
   type WaitForCallsStatusReturnType,
 } from "viem";
 import type { PrepareCallsParams } from "./actions/prepareCalls.js";
-import { alchemyTransport } from "@alchemy/common";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { arbitrumSepolia } from "viem/chains";
 import { createSmartWalletClient } from "./client.js";
-
-const ALCHEMY_API_URL = "https://api.g.alchemy.com/v2";
+import { apiTransport, publicTransport } from "./testSetup.js";
 
 // We want to test both the "unroll each step" method and the full e2e "sendCalls" method.
 const sendVariants: Array<
@@ -49,27 +47,6 @@ const sendVariants: Array<
 ];
 
 describe("Client E2E Tests", () => {
-  const apiTransport = alchemyTransport(
-    process.env.ALCHEMY_PROXY_RPC_URL
-      ? {
-          url: process.env.ALCHEMY_PROXY_RPC_URL,
-        }
-      : {
-          url: ALCHEMY_API_URL,
-          apiKey: process.env.TEST_ALCHEMY_API_KEY!,
-        },
-  );
-
-  const publicTransport = alchemyTransport(
-    process.env.ALCHEMY_PROXY_RPC_URL
-      ? {
-          url: process.env.ALCHEMY_PROXY_RPC_URL,
-        }
-      : {
-          apiKey: process.env.TEST_ALCHEMY_API_KEY!,
-        },
-  );
-
   const signer = privateKeyToAccount(
     "0xd7b061ef04d29cf68b3c89356678eccec9988de8d5ed892c19461c4a9d65925d",
   );

--- a/packages/wallet-apis/src/experimental/actions/requestQuoteV0.ts
+++ b/packages/wallet-apis/src/experimental/actions/requestQuoteV0.ts
@@ -1,0 +1,52 @@
+import type { Static } from "@sinclair/typebox";
+import {
+  toHex,
+  type Address,
+  type IsUndefined,
+  type Prettify,
+  type UnionOmit,
+} from "viem";
+import type { BaseWalletClient, OptionalChainId } from "../../types.ts";
+import type { wallet_requestQuote_v0 } from "@alchemy/wallet-api-types/rpc";
+import { AccountNotFoundError } from "@alchemy/common";
+
+export type RequestQuoteV0Params<
+  TAccount extends Address | undefined = Address | undefined,
+> = Prettify<
+  OptionalChainId<
+    UnionOmit<
+      Static<
+        (typeof wallet_requestQuote_v0)["properties"]["Request"]["properties"]["params"]
+      >[0],
+      "from"
+    >
+  > &
+    (IsUndefined<TAccount> extends true ? { from: Address } : { from?: never })
+>;
+
+export type RequestQuoteV0Result = Prettify<
+  Static<typeof wallet_requestQuote_v0>["ReturnType"]
+>;
+
+export async function requestQuoteV0<
+  TAccount extends Address | undefined = Address | undefined,
+>(
+  client: BaseWalletClient,
+  params: RequestQuoteV0Params<TAccount>,
+): Promise<RequestQuoteV0Result> {
+  const from = params.from ?? client.account?.address;
+  if (!from) {
+    throw new AccountNotFoundError();
+  }
+
+  return await client.request({
+    method: "wallet_requestQuote_v0",
+    params: [
+      {
+        ...params,
+        chainId: params.chainId ?? toHex(client.chain.id),
+        from,
+      },
+    ],
+  });
+}

--- a/packages/wallet-apis/src/experimental/swapActionsDecorator.e2e.test.ts
+++ b/packages/wallet-apis/src/experimental/swapActionsDecorator.e2e.test.ts
@@ -1,0 +1,43 @@
+import { arbitrum } from "viem/chains";
+import { apiTransport } from "../testSetup.js";
+import { createSmartWalletClient } from "../client.js";
+import { swapActions } from "./swapActionsDecorator.js";
+import { privateKeyToAccount } from "viem/accounts";
+
+describe("swapActions decorator tests", () => {
+  it("should successfully request a quote", async () => {
+    const dummySigner = privateKeyToAccount(
+      "0xd7b061ef04d29cf68b3c89356678eccec9988de8d5ed892c19461c4a9d65925d",
+    );
+
+    const testAccountAddr = "0x0d1Ea60Dddd2a76F3a3afD6d78660d366C6A30c0";
+
+    const client = createSmartWalletClient({
+      transport: apiTransport,
+      chain: arbitrum,
+      signer: dummySigner,
+    }).extend(swapActions);
+
+    const account = await client.requestAccount({
+      signerAddress: testAccountAddr,
+      creationHint: {
+        accountType: "7702",
+      },
+    });
+
+    const USDC_ARB = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+    const NATIVE_TOKEN_ADDR = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEee"; // from ERC-7528
+
+    const quote = await client.requestQuoteV0({
+      from: account.address,
+      fromToken: USDC_ARB,
+      toToken: NATIVE_TOKEN_ADDR,
+      minimumToAmount: "0x5AF3107A4000",
+    });
+
+    expect(quote.quote).toBeDefined();
+    expect(quote.quote.fromAmount).toBeDefined();
+    expect(quote.quote.minimumToAmount).toBeDefined();
+    expect(quote.quote.expiry).toBeDefined();
+  });
+});

--- a/packages/wallet-apis/src/experimental/swapActionsDecorator.ts
+++ b/packages/wallet-apis/src/experimental/swapActionsDecorator.ts
@@ -1,0 +1,23 @@
+import type { Address } from "viem";
+import {
+  requestQuoteV0,
+  type RequestQuoteV0Params,
+  type RequestQuoteV0Result,
+} from "./actions/requestQuoteV0.js";
+import type { BaseWalletClient } from "../types.js";
+
+export type SwapActions<
+  TAccount extends Address | undefined = Address | undefined,
+> = {
+  requestQuoteV0: (
+    params: RequestQuoteV0Params<TAccount>,
+  ) => Promise<RequestQuoteV0Result>;
+};
+
+export const swapActions: <
+  TAccount extends Address | undefined = Address | undefined,
+>(
+  client: BaseWalletClient,
+) => SwapActions<TAccount> = (client) => ({
+  requestQuoteV0: (params) => requestQuoteV0(client, params),
+});

--- a/packages/wallet-apis/src/testSetup.ts
+++ b/packages/wallet-apis/src/testSetup.ts
@@ -1,0 +1,24 @@
+import { alchemyTransport } from "@alchemy/common";
+
+export const ALCHEMY_API_URL = "https://api.g.alchemy.com/v2";
+
+export const apiTransport = alchemyTransport(
+  process.env.ALCHEMY_PROXY_RPC_URL
+    ? {
+        url: process.env.ALCHEMY_PROXY_RPC_URL,
+      }
+    : {
+        url: ALCHEMY_API_URL,
+        apiKey: process.env.TEST_ALCHEMY_API_KEY!,
+      },
+);
+
+export const publicTransport = alchemyTransport(
+  process.env.ALCHEMY_PROXY_RPC_URL
+    ? {
+        url: process.env.ALCHEMY_PROXY_RPC_URL,
+      }
+    : {
+        apiKey: process.env.TEST_ALCHEMY_API_KEY!,
+      },
+);

--- a/packages/wallet-apis/src/types.ts
+++ b/packages/wallet-apis/src/types.ts
@@ -34,6 +34,10 @@ export type OptionalChainId<T> = T extends { chainId: Hex }
   ? Omit<T, "chainId"> & { chainId?: Hex | undefined }
   : T;
 
+export type OptionalSignerAddress<T> = T extends { signerAddress: Address }
+  ? Omit<T, "signerAddress"> & { signerAddress?: Address | undefined }
+  : T;
+
 export type WithoutRawPayload<T> = T extends { rawPayload: Hex }
   ? Omit<T, "rawPayload">
   : T;


### PR DESCRIPTION
Adds `wallet_requestQuote_v0` support to `@alchemy/wallet-apis` via a decorator exported at `@alchemy/wallet-apis/experimental`.

- Refactors `requestAccount` to allow overriding the `signerAddress` param.
- Refactors common test setup components to `testSetup.ts`. This file cannot be named `testSetup.test.ts`, otherwise vitest complains about no tests defined in the file.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new types and functions for handling optional signer addresses and swap actions in the wallet APIs. It also refactors existing code for better readability and adds tests for the new functionalities.

### Detailed summary
- Added `OptionalSignerAddress` type in `types.ts`.
- Introduced `SwapActions` type and `swapActions` function in `swapActionsDecorator.ts`.
- Refactored `signMessage` and `signTypedData` functions to simplify account retrieval.
- Added `requestQuoteV0` function in `requestQuoteV0.ts`.
- Created tests for swap actions in `swapActionsDecorator.e2e.test.ts`.
- Updated transport configuration in `testSetup.ts` and removed redundant code in `client.e2e.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->