### PR TITLE
chore: update CODEOWNERS to match main branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @moldy530 @rthomare @dancoombs @mokok123 @dphilipson @linnall @adamegyed @howydev @zer0dot @jaypaik @blu-j @noam-alchemy @jakehobbs @archit2407 @avarobinson @florrdv @blakecduncan @Shenghu-Yang
+*    @dancoombs @mokok123 @dphilipson @linnall @adamegyed @zer0dot @noam-alchemy @jakehobbs @avarobinson @florrdv @blakecduncan @Shenghu-Yang @andysim3d @0xfourzerofour @niveda-krish @alex-miao @thebrianchen @joshzhang5 @AlvaroLuken @Dan-Nolan @SahilAujla @CodesMcCabe @Richard-Dang


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a subproject commit reference and updates the `CODEOWNERS` file to include a comprehensive list of contributors responsible for code ownership.

### Detailed summary
- Added subproject commit `2854c370f1284dc05d1bbaa2d33744ccf601b00a` to `docs-site`.
- Updated `CODEOWNERS` file to include multiple contributors: `@dancoombs`, `@mokok123`, `@dphilipson`, `@linnall`, `@adamegyed`, `@zer0dot`, `@noam-alchemy`, `@jakehobbs`, `@avarobinson`, `@florrdv`, `@blakecduncan`, `@Shenghu-Yang`, `@andysim3d`, `@0xfourzerofour`, `@niveda-krish`, `@alex-miao`, `@thebrianchen`, `@joshzhang5`, `@AlvaroLuken`, `@Dan-Nolan`, `@SahilAujla`, `@CodesMcCabe`, `@Richard-Dang`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->