### PR TITLE
docs: fix minor typos and grammar in user operations guide

### DIFF
--- a/docs/pages/bundler-api/bundler-api-quickstart.mdx
+++ b/docs/pages/bundler-api/bundler-api-quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bundler API Quickstart
-description: Learn about the Bundler API and how you can use it work with user operations.
-subtitle: Learn about the Bundler API and how you can use it work with user operations.
+description: Learn about the Bundler API and how you can use it to work with user operations.
+subtitle: Learn about the Bundler API and how you can use it to work with user operations.
 url: https://docs.alchemy.com/reference/bundler-api-quickstart
 slug: reference/bundler-api-quickstart
 ---
@@ -10,11 +10,11 @@ slug: reference/bundler-api-quickstart
 
 The concept of a Bundler is introduced by [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337), which aims to bring Account Abstraction to EVM chains. With the expectation of an increased adoption of Smart Contract Wallets (SCWs) for their user-friendly experience and flexibility, the Bundler plays a vital role. Essentially, it forwards the user operations to the Entrypoint which are then further forwarded to the smart contract accounts for execution. Our custom built Bundler called Rundler provides high performance and reliability, it's written in Rust and is [completely open source](https://github.com/alchemyplatform/rundler).
 
-To gain deeper insights into this topic, explore our [blog post on Account Abstraction](https://www.alchemy.com//blog/account-abstraction).
+To gain deeper insights into this topic, explore our [blog post on Account Abstraction](https://www.alchemy.com/blog/account-abstraction).
 
 ## What is the Bundler API?
 
-The Bundler APIs are a collection of [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-eth-namespace) compliant JSON-RPC endpoints which makes it possible for users to work with user operations.
+The Bundler APIs are a collection of [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-eth-namespace) compliant JSON-RPC endpoints which make it possible for users to work with user operations.
 
 <Info>
   Please note that using


### PR DESCRIPTION
spotted a few issues:

* added the missing “to” in *how you can use it to work with user operations*.
* removed the extra slash in the URL: *[https://www.alchemy.com/blog/account-abstraction](https://www.alchemy.com/blog/account-abstraction)*.
* corrected grammar: changed *which makes it possible* → *which make it possible* to match the plural subject.


# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [x] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?
