### PR TITLE
feat: add flashblocks support to react

### DIFF
--- a/account-kit/react/src/hooks/useSendUserOperation.ts
+++ b/account-kit/react/src/hooks/useSendUserOperation.ts
@@ -45,6 +45,7 @@ export type UseSendUserOperationArgs<
 > = {
   client: UseSmartAccountClientResult["client"] | undefined;
   waitForTxn?: boolean;
+  waitForTxnTag?: "pending" | "latest";
 } & UseSendUserOperationMutationArgs<TEntryPointVersion, TAccount>;
 
 export type UseSendUserOperationResult<
@@ -129,7 +130,12 @@ export function useSendUserOperation<
 >(
   params: UseSendUserOperationArgs<TEntryPointVersion, TAccount>,
 ): UseSendUserOperationResult<TEntryPointVersion, TAccount> {
-  const { client: _client, waitForTxn = false, ...mutationArgs } = params;
+  const {
+    client: _client,
+    waitForTxn = false,
+    waitForTxnTag = "latest",
+    ...mutationArgs
+  } = params;
 
   const { sendCallsAsync } = useSendCalls<TEntryPointVersion>({
     client: _client,
@@ -186,7 +192,7 @@ export function useSendUserOperation<
 
         // TODO: this should really use useCallsStatusHook instead (once it exists)
         const txnHash = await _client
-          .waitForUserOperationTransaction({ hash: uoHash })
+          .waitForUserOperationTransaction({ hash: uoHash, tag: waitForTxnTag })
           .catch((e) => {
             throw new WaitForUserOperationError(request!, e);
           });


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new optional parameter, `waitForTxnTag`, to the `useSendUserOperation` hook, allowing the specification of transaction tags. It updates the destructuring of `params` to include this new parameter and modifies the call to wait for a user operation transaction to use the specified tag.

### Detailed summary
- Added `waitForTxnTag` optional parameter to `UseSendUserOperationArgs`.
- Updated destructuring in `useSendUserOperation` to include `waitForTxnTag` with a default value of `"latest"`.
- Modified the `waitForUserOperationTransaction` call to use the `waitForTxnTag` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->