### PR TITLE
chore: remove twoslash to get up the page not being rendered

### DIFF
--- a/docs/pages/transactions/swap-tokens/client.mdx
+++ b/docs/pages/transactions/swap-tokens/client.mdx
@@ -13,7 +13,7 @@ You'll need the following env variables:
 
 <CodeBlocks>
 
-```ts twoslash title="requestQuote.ts"
+```ts title="requestQuote.ts"
 import { client, config } from "./client.ts";
 
 interface SwapQuoteResponse {
@@ -114,7 +114,7 @@ console.log(
 );
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import { type Address, type Hex, toHex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";
@@ -151,7 +151,7 @@ export const client = createSmartWalletClient({
 
 This example swaps 0.01 USDC for DAI on Arbitrum, and includes additional error handling.
 
-```ts twoslash
+```ts
 /**
  * Note: This uses direct fetch calls as the swap feature is not yet
  * available in @account-kit/wallet-client. Once available, you'll be


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation in `docs/pages/transactions/swap-tokens/client.mdx` by changing the code block titles and enhancing the explanation for the swap feature.

### Detailed summary
- Changed code block title from `twoslash` to a standard title for `requestQuote.ts` and `client.ts`.
- Added a note in the documentation about using direct fetch calls for the swap feature, which is not yet available in `@account-kit/wallet-client`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->