### PR TITLE
fix: remove twoslash within codeblocks due to fern issue

### DIFF
--- a/docs/pages/authentication/login-methods/email-otp.mdx
+++ b/docs/pages/authentication/login-methods/email-otp.mdx
@@ -335,7 +335,7 @@ Email OTP (One-Time Password) authentication is a two-step process:
 
     <CodeBlocks>
 
-    ```tsx sign-in-with-otp.tsx twoslash filename="sign-in-with-otp.tsx"
+    ```tsx sign-in-with-otp.tsx filename="sign-in-with-otp.tsx"
     // @noErrors
     import React, { useCallback, useState } from "react";
     import { View, Text, TextInput, Button } from "react-native";
@@ -413,7 +413,7 @@ Email OTP (One-Time Password) authentication is a two-step process:
     };
     ```
 
-    ```tsx otp-popup.tsx twoslash filename="otp-popup.tsx"
+    ```tsx otp-popup.tsx filename="otp-popup.tsx"
     // @noErrors
     import React, { useCallback, useState } from "react";
     import {

--- a/docs/pages/core/quickstart.mdx
+++ b/docs/pages/core/quickstart.mdx
@@ -59,7 +59,7 @@ email based auth as an example you would:
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { config } from "./config";
 import { getSigner } from "@account-kit/core";
 
@@ -95,7 +95,7 @@ Now that you have your config, you can send user operations by leveraging the un
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { watchSmartAccountClient } from "@account-kit/core";
 import { config } from "./config";
 

--- a/docs/pages/infra/quickstart.mdx
+++ b/docs/pages/infra/quickstart.mdx
@@ -56,7 +56,7 @@ The last step is to send a user operation using the client you just created.
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { client } from "./client";
 
 const { hash } = await client.sendUserOperation({

--- a/docs/pages/low-level-infra/bundler/sdk.mdx
+++ b/docs/pages/low-level-infra/bundler/sdk.mdx
@@ -6,7 +6,7 @@ The `@account-kit/infra` library enables direct interaction with Alchemy's ERC-4
 
 <CodeBlocks>
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { alchemy, sepolia } from "@account-kit/infra";
 
 const YOUR_API_KEY = "<YOUR_API_KEY>";
@@ -18,7 +18,7 @@ export const transport = alchemy({
 });
 ```
 
-```ts twoslash title="estimateAndSendUserOperation.ts"
+```ts title="estimateAndSendUserOperation.ts"
 import { alchemyFeeEstimator } from "@account-kit/infra";
 import { createModularAccountV2Client } from "@account-kit/smart-contracts";
 import { LocalAccountSigner } from "@aa-sdk/core";
@@ -65,7 +65,7 @@ export async function estimateAndSendUserOperation() {
 }
 ```
 
-```ts twoslash title="getUserOperationByHash.ts"
+```ts title="getUserOperationByHash.ts"
 import { createAlchemyPublicRpcClient } from "@account-kit/infra";
 import { chain, transport } from "./config.ts";
 import type { Hash } from "viem";

--- a/docs/pages/low-level-infra/quickstart.mdx
+++ b/docs/pages/low-level-infra/quickstart.mdx
@@ -49,7 +49,7 @@ The last step is to send a user operation using the client you just created.
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { getClient } from "./client";
 
 const client = await getClient();

--- a/docs/pages/react/mfa/setup-mfa.mdx
+++ b/docs/pages/react/mfa/setup-mfa.mdx
@@ -302,7 +302,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     const { multiFactors } = await signer.addMFA({
@@ -326,7 +326,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     await signer.verifyMfa({
@@ -345,7 +345,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     await signer.removeMfa({
@@ -361,7 +361,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     const { multiFactors } = await signer.getMfaFactors();
@@ -377,7 +377,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     signer.authenticate({
@@ -395,7 +395,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     signer.authenticate({
@@ -412,7 +412,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     const user = await signer?.validateMultiFactors({
@@ -430,7 +430,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { MfaRequiredError } from "@account-kit/signer";
     import { signer } from "./signer";
 
@@ -493,7 +493,7 @@ slug: wallets/react/mfa/setup-mfa
 
     <CodeBlocks>
 
-    ```ts twoslash example.ts
+    ```ts example.ts
     import { signer } from "./signer";
 
     await signer.authenticate({

--- a/docs/pages/recipes/multi-chain-setup.mdx
+++ b/docs/pages/recipes/multi-chain-setup.mdx
@@ -106,7 +106,7 @@ Once your app is configured to use multiple chains, you can switch between them 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { setChain } from "@account-kit/core";
 import { mainnet } from "@account-kit/infra";
 import { config } from "./config";
@@ -114,7 +114,7 @@ import { config } from "./config";
 await setChain(config, mainnet);
 ```
 
-```ts twoslash config.ts filename="config.ts"
+```ts config.ts filename="config.ts"
 import { createConfig } from "@account-kit/core";
 import { sepolia, mainnet, alchemy } from "@account-kit/infra";
 

--- a/docs/pages/signer/as-an-eoa.mdx
+++ b/docs/pages/signer/as-an-eoa.mdx
@@ -20,7 +20,7 @@ If you are using viem, then you can use the `toViemAccount` method which will al
 
 <CodeBlocks>
 
-```ts createWalletClient.ts twoslash
+```ts createWalletClient.ts
 import { signer } from "./signer";
 import { createWalletClient, http } from "viem";
 import { sepolia } from "viem/chains";

--- a/docs/pages/signer/authentication/add-passkey.mdx
+++ b/docs/pages/signer/authentication/add-passkey.mdx
@@ -12,7 +12,7 @@ to their account.
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 // NOTE: this assumes you have already authenticated the user

--- a/docs/pages/signer/authentication/auth0.mdx
+++ b/docs/pages/signer/authentication/auth0.mdx
@@ -47,7 +47,7 @@ However, you may prefer to send your users directly to the GitHub login without 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 await authenticate({

--- a/docs/pages/signer/authentication/email-magic-link.mdx
+++ b/docs/pages/signer/authentication/email-magic-link.mdx
@@ -22,7 +22,7 @@ For setting up the OTP flow, see [Email OTP Authentication](/wallets/authenticat
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 // send the email
@@ -57,7 +57,7 @@ Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 import { AlchemySignerStatus } from "@account-kit/signer";
 

--- a/docs/pages/signer/authentication/email-otp.mdx
+++ b/docs/pages/signer/authentication/email-otp.mdx
@@ -15,7 +15,7 @@ Email OTP authentication allows you to log in and sign up users using an email a
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 // send the email
@@ -46,7 +46,7 @@ Use `signer.on("statusChanged", callback)` and the `AlchemySignerStatus` enum to
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 import { AlchemySignerStatus } from "@account-kit/signer";
 

--- a/docs/pages/signer/authentication/passkey-login.mdx
+++ b/docs/pages/signer/authentication/passkey-login.mdx
@@ -18,7 +18,7 @@ If you want to allow sign-up and login with a passkey, you can ask the user for 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 const result = await signer.authenticate({
@@ -35,7 +35,7 @@ const result = await signer.authenticate({
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 const result = await signer.authenticate({

--- a/docs/pages/signer/authentication/passkey-signup.mdx
+++ b/docs/pages/signer/authentication/passkey-signup.mdx
@@ -20,7 +20,7 @@ If you want to allow sign-up and login with a passkey, you can ask the user for 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 const result = await signer.authenticate({

--- a/docs/pages/signer/authentication/social-login.mdx
+++ b/docs/pages/signer/authentication/social-login.mdx
@@ -16,7 +16,7 @@ Social login authentication allows you to log in and sign up users using an OAut
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 await signer.authenticate({

--- a/docs/pages/signer/export-private-key.mdx
+++ b/docs/pages/signer/export-private-key.mdx
@@ -41,7 +41,7 @@ To add export private key functionality to your app, you can use the `exportPriv
 
 <CodeBlocks>
 
-```tsx twoslash ExportPrivateKey.tsx
+```tsx ExportPrivateKey.tsx
 import React from "react";
 import { useMutation } from "@tanstack/react-query";
 import { signer } from "./signer";

--- a/docs/pages/signer/quickstart.mdx
+++ b/docs/pages/signer/quickstart.mdx
@@ -50,7 +50,7 @@ Next, you'll need to authenticate your user before you can use the Signer as an 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 
 const result = await signer.authenticate({
@@ -69,7 +69,7 @@ Now that you have authenticated your user, you can use the signer as an owner on
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { createLightAccount } from "@account-kit/smart-contracts";
 import { sepolia } from "@account-kit/infra";
 import { http } from "viem";

--- a/docs/pages/signer/solana-wallets/solana-signer-package.mdx
+++ b/docs/pages/signer/solana-wallets/solana-signer-package.mdx
@@ -16,7 +16,7 @@ Once you've [authenticated users](/wallets/signer/quickstart), convert the `Alch
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 import { SolanaSigner } from "@account-kit/signer";
 
@@ -35,7 +35,7 @@ To sign either a string or byte array with your Solana wallet use the `signMessa
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { signer } from "./signer";
 import { toBytes } from "viem";
 

--- a/docs/pages/signer/user-sessions.mdx
+++ b/docs/pages/signer/user-sessions.mdx
@@ -12,7 +12,7 @@ You can check if the user has an active session with the following command:
 
 <CodeBlocks>
 
-```ts twoslash getAuthDetails.ts
+```ts getAuthDetails.ts
 import { signer } from "./signer";
 
 // NOTE: this method throws if there is no authenticated user

--- a/docs/pages/smart-contracts/modular-account-v2/using-7702.mdx
+++ b/docs/pages/smart-contracts/modular-account-v2/using-7702.mdx
@@ -140,7 +140,7 @@ This will delegate to the 7702 compatible smart contract account, Modular Accoun
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { createModularAccountV2Client } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { signer } from "./signer.js";
@@ -167,7 +167,7 @@ const txnHash =
   await smartAccountClient.waitForUserOperationTransaction(uoHash);
 ```
 
-```ts twoslash signer.ts filename="signer.ts"
+```ts signer.ts filename="signer.ts"
 import { LocalAccountSigner } from "@aa-sdk/core";
 
 const privateKey = "0x...";

--- a/docs/pages/smart-contracts/other-accounts/light-account/multi-owner-light-account.mdx
+++ b/docs/pages/smart-contracts/other-accounts/light-account/multi-owner-light-account.mdx
@@ -27,7 +27,7 @@ You can use the `getOwnerAddresses` method on the `MultiOwnerLightAccount` objec
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { multiOwnerLightAccountClient } from "./client";
 
 const owners = await multiOwnerLightAccountClient.account.getOwnerAddresses();
@@ -43,7 +43,7 @@ You can use the `updateOwners` method on the `multiOwnerLightAccountClientAction
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { multiOwnerLightAccountClient } from "./client";
 
 const ownersToAdd = []; // the addresses of owners to be added

--- a/docs/pages/smart-contracts/other-accounts/light-account/transfer-ownership-light-account.mdx
+++ b/docs/pages/smart-contracts/other-accounts/light-account/transfer-ownership-light-account.mdx
@@ -20,7 +20,7 @@ There a number of ways you can call this method using Smart Wallets.
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { lightAccountClient } from "./client";
 import { createLightAccountClient } from "@account-kit/smart-contracts";
 
@@ -55,7 +55,7 @@ Since `@alchemy/aa-accounts` exports a `LightAccount` ABI, the above approach ma
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { encodeFunctionData } from "viem";
 import { lightAccountClient } from "./client";
 

--- a/docs/pages/smart-contracts/other-accounts/modular-account/manage-ownership-mav1.mdx
+++ b/docs/pages/smart-contracts/other-accounts/modular-account/manage-ownership-mav1.mdx
@@ -44,7 +44,7 @@ Then, you can use the `readOwners` method of the `multiOwnerPluginActions` exten
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 
 const ownerToCheck = "0x..."; // the address of the account to check the ownership of
@@ -65,7 +65,7 @@ You can use the `readOwners` method on the `multiOwnerPluginActions` extended sm
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 
 // owners is an array of the addresses of the account owners
@@ -82,7 +82,7 @@ You can use the `updateOwners` method on the `multiOwnerPluginActions` extended 
 
 <CodeBlocks>
 
-```ts example.ts  twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 
 const ownersToAdd = []; // the addresses of owners to be added

--- a/docs/pages/smart-contracts/other-accounts/modular-account/manage-plugins/get-installed-plugins.mdx
+++ b/docs/pages/smart-contracts/other-accounts/modular-account/manage-plugins/get-installed-plugins.mdx
@@ -29,7 +29,7 @@ Then, you can use the `getInstalledPlugins` method of the `accountLoupeActions` 
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 import { IPluginAbi } from "@account-kit/smart-contracts";
 

--- a/docs/pages/smart-contracts/other-accounts/modular-account/manage-plugins/install-plugins.mdx
+++ b/docs/pages/smart-contracts/other-accounts/modular-account/manage-plugins/install-plugins.mdx
@@ -38,7 +38,7 @@ Then, you can use the `installSessionKeyPlugin()` method exposed on `sessionKeyP
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 import { sessionKeyPluginActions } from "@account-kit/smart-contracts";
 
@@ -82,7 +82,7 @@ For example, do not call uninstall plugin of the multi-owner plugin on a Modular
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { chain, modularAccountClient } from "./client";
 import { SessionKeyPlugin } from "@account-kit/smart-contracts";
 

--- a/docs/pages/smart-contracts/other-accounts/modular-account/multisig-plugin/getting-started.mdx
+++ b/docs/pages/smart-contracts/other-accounts/modular-account/multisig-plugin/getting-started.mdx
@@ -23,7 +23,7 @@ To propose a new user operation for review by the multisig signers, you will use
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { multisigAccountClient } from "./client";
 import { createMultisigAccountAlchemyClient } from "@account-kit/smart-contracts";
 
@@ -49,7 +49,7 @@ Next, you have to collect the next k-2 signatures, excluding the first signature
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { createMultisigAccountAlchemyClient } from "@account-kit/smart-contracts";
 import { signers, owners, threshold } from "./client";
 
@@ -80,7 +80,7 @@ After collecting k-1 signatures, you're ready to collect the last signature and 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { createMultisigAccountAlchemyClient } from "@account-kit/smart-contracts";
 import { signers, owners, threshold } from "./client";
 
@@ -111,7 +111,7 @@ By default, we use the variable gas feature in the Multisig Plugin smart contrac
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { multisigAccountClient } from "./client";
 
 const result = await multisigAccountClient.sendUserOperation({

--- a/docs/pages/smart-contracts/other-accounts/modular-account/session-keys/getting-started.mdx
+++ b/docs/pages/smart-contracts/other-accounts/modular-account/session-keys/getting-started.mdx
@@ -35,7 +35,7 @@ The base `modularAccountClient` and `AlchemymodularAccountClient`, only include 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { modularAccountClient } from "./client";
 import { sessionKeyPluginActions } from "@account-kit/smart-contracts";
 
@@ -52,7 +52,7 @@ Before you can start using session keys, you need to check whether the user’s 
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { modularAccountClient } from "./client.js";
 import {
   accountLoupeActions,
@@ -84,7 +84,7 @@ If the Session Key Plugin is not yet installed, you need to install it before it
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 import {
   accountLoupeActions,
@@ -144,7 +144,7 @@ Let's use the permission builder to build a set of permissions that sets a spend
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { modularAccountClient } from "./client";
 import {
   accountLoupeActions,
@@ -187,7 +187,7 @@ Session keys can be added either during installation, or using the `addSessionKe
 
 <CodeBlocks>
 
-```ts add-session-key.ts twoslash
+```ts add-session-key.ts
 import { SessionKeyPermissionsBuilder } from "@account-kit/smart-contracts";
 import { keccak256 } from "viem";
 import { client } from "./base-client";
@@ -210,7 +210,7 @@ Session keys can be removed using the `removeSessionKey` function.
 
 <CodeBlocks>
 
-```ts remove-session-key.ts twoslash
+```ts remove-session-key.ts
 import { client } from "./base-client";
 
 const result = await client.removeSessionKey({
@@ -228,7 +228,7 @@ Session key permissions can be edited after creation using the `updateKeyPermiss
 
 <CodeBlocks>
 
-```ts update-session-key.ts twoslash
+```ts update-session-key.ts
 import { SessionKeyPermissionsBuilder } from "@account-kit/smart-contracts";
 import { client } from "./base-client";
 
@@ -255,7 +255,7 @@ If the key is no longer available, but there exists a tag identifying a previous
 
 <CodeBlocks>
 
-```ts rotate-session-key.ts twoslash
+```ts rotate-session-key.ts
 import { client } from "./base-client.js";
 
 const result = await client.rotateSessionKey({

--- a/docs/pages/smart-contracts/other-accounts/modular-account/upgrading-to-modular-account.mdx
+++ b/docs/pages/smart-contracts/other-accounts/modular-account/upgrading-to-modular-account.mdx
@@ -10,7 +10,7 @@ Using the Light Account as an example, here is an overview of how the upgrade ca
 
 <CodeBlocks>
 
-```ts example.ts twoslash
+```ts example.ts
 import { lightAccountClient } from "./lightAccountClient";
 import { getMSCAUpgradeToData } from "@account-kit/smart-contracts";
 
@@ -27,7 +27,7 @@ const hash = await lightAccountClient.upgradeAccount({
 const upgradedAccount = await createMAAccount();
 ```
 
-```ts lightAccountClient.ts twoslash filename="lightAccountClient.ts"
+```ts lightAccountClient.ts filename="lightAccountClient.ts"
 import { createLightAccountAlchemyClient } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { LocalAccountSigner } from "@aa-sdk/core";
@@ -46,7 +46,7 @@ That is all! Now, you can create a smart account client to connect with the upgr
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { createAlchemySmartAccountClient, alchemy } from "@account-kit/infra";
 import { multiOwnerPluginActions } from "@account-kit/smart-contracts";
 import { upgradedAccount } from "./upgradedAccount";
@@ -60,7 +60,7 @@ const upgradedAccountClient = await createAlchemySmartAccountClient({
 const owners = await upgradedAccountClient.readOwners();
 ```
 
-```ts upgradedAccount.ts twoslash filename="upgradedAccount.ts"
+```ts upgradedAccount.ts filename="upgradedAccount.ts"
 import { lightAccountClient } from "./lightAccountClient";
 import { getMSCAUpgradeToData } from "@account-kit/smart-contracts";
 
@@ -77,7 +77,7 @@ const hash = await lightAccountClient.upgradeAccount({
 export const upgradedAccount = await createMAAccount();
 ```
 
-```ts lightAccountClient.ts twoslash filename="lightAccountClient.ts"
+```ts lightAccountClient.ts filename="lightAccountClient.ts"
 import { createLightAccountAlchemyClient } from "@account-kit/smart-contracts";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/pages/third-party/smart-contracts.mdx
+++ b/docs/pages/third-party/smart-contracts.mdx
@@ -60,7 +60,7 @@ To use your account, you will need to pass it into a `SmartAccountClient`.
 
 <CodeBlocks>
 
-```ts twoslash example.ts
+```ts example.ts
 import { createAlchemySmartAccountClient, alchemy } from "@account-kit/infra";
 import { sepolia } from "viem/chains";
 import { myAccount } from "./my-account";
@@ -75,7 +75,7 @@ const client = createAlchemySmartAccountClient({
 });
 ```
 
-```ts my-account.ts twoslash filename="my-account.ts"
+```ts my-account.ts filename="my-account.ts"
 import { getEntryPoint, toSmartContractAccount } from "@aa-sdk/core";
 import { http, type SignableMessage, type Hash } from "viem";
 import { sepolia } from "viem/chains";

--- a/docs/pages/transactions/pay-gas-with-any-token/client.mdx
+++ b/docs/pages/transactions/pay-gas-with-any-token/client.mdx
@@ -8,7 +8,7 @@ Use the `paymasterService` capability on the smart wallet client `sendCalls` or 
 
 <CodeBlocks>
 
-```ts twoslash title="sendCalls.ts"
+```ts title="sendCalls.ts"
 import { client, config } from "./client.ts";
 
 const { preparedCallIds } = await client.sendCalls({
@@ -36,7 +36,7 @@ const { preparedCallIds } = await client.sendCalls({
 });
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import { type Address, type Hex, toHex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/pages/transactions/pay-gas-with-any-token/react.mdx
+++ b/docs/pages/transactions/pay-gas-with-any-token/react.mdx
@@ -11,7 +11,7 @@ See the [`useSendCalls` SDK reference](/wallets/reference/account-kit/react/hook
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={5-7,14-27}
+```tsx title="sendCalls.tsx" focus={5-7,14-27}
 import { useSendCalls, useSmartAccountClient } from "@account-kit/react";
 import { config } from "./config";
 
@@ -59,7 +59,7 @@ export default function SendCalls() {
 }
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { type Address, toHex } from "viem";
 
 export const config = {

--- a/docs/pages/transactions/retry-transactions/client.mdx
+++ b/docs/pages/transactions/retry-transactions/client.mdx
@@ -14,7 +14,7 @@ You'll need the following env variables:
 
 <CodeBlocks>
 
-```ts twoslash title="retryTransaction.ts"
+```ts title="retryTransaction.ts"
 import { client, config } from "./client.ts";
 
 // Send initial transaction
@@ -71,7 +71,7 @@ if (status.status === 100) {
 }
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import { type Address, type Hex, toHex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/pages/transactions/retry-transactions/react.mdx
+++ b/docs/pages/transactions/retry-transactions/react.mdx
@@ -6,7 +6,7 @@ You'll need both `ALCHEMY_API_KEY` and `ALCHEMY_POLICY_ID` environment variables
 
 <CodeBlocks>
 
-```tsx twoslash title="retryTransaction.tsx"
+```tsx title="retryTransaction.tsx"
 import { config } from "@/app/config";
 import {
   useSendCalls,
@@ -109,7 +109,7 @@ export default function RetryTransaction() {
 }
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 export const config = {
   alchemyApiKey: process.env.ALCHEMY_API_KEY!,
   policyId: process.env.ALCHEMY_POLICY_ID!,

--- a/docs/pages/transactions/send-batch-transactions/client.mdx
+++ b/docs/pages/transactions/send-batch-transactions/client.mdx
@@ -8,7 +8,7 @@ You can batch transactions using either the smart wallet client `sendCalls` or `
 
 <CodeBlocks>
 
-```ts twoslash title="sendCalls.ts"
+```ts title="sendCalls.ts"
 import { type Address, erc20Abi, encodeFunctionData, parseUnits } from "viem";
 import { client } from "./client";
 import { swapAbi } from "./swapAbi";
@@ -42,7 +42,7 @@ const { preparedCallIds } = await client.sendCalls({
 });
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import type { Hex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";
@@ -69,7 +69,7 @@ export const client = createSmartWalletClient({
 });
 ```
 
-```ts twoslash title="swapAbi.ts"
+```ts title="swapAbi.ts"
 export const swapAbi = [
   {
     type: "constructor",

--- a/docs/pages/transactions/send-batch-transactions/react.mdx
+++ b/docs/pages/transactions/send-batch-transactions/react.mdx
@@ -4,7 +4,7 @@ Use the `useSendCalls` hook to send a batched transaction. You can also use the 
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={6-9,19-41}
+```tsx title="sendCalls.tsx" focus={6-9,19-41}
 import { useSendCalls, useSmartAccountClient } from "@account-kit/react";
 import { type Address, encodeFunctionData, erc20Abi, parseUnits } from "viem";
 import { swapAbi } from "./swapAbi";
@@ -57,7 +57,7 @@ export default function SendCalls() {
 }
 ```
 
-```ts twoslash title="swapAbi.ts"
+```ts title="swapAbi.ts"
 export const swapAbi = [
   {
     type: "constructor",

--- a/docs/pages/transactions/send-parallel-transactions/client.mdx
+++ b/docs/pages/transactions/send-parallel-transactions/client.mdx
@@ -14,7 +14,7 @@ You'll need the following env variables:
 
 <CodeBlocks>
 
-```ts twoslash title="sendParallelCalls.ts"
+```ts title="sendParallelCalls.ts"
 import { client, config } from "./client.ts";
 
 const [
@@ -67,7 +67,7 @@ const callStatusResults = await Promise.all([
 console.log("Calls status results:", callStatusResults);
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import { type Address, type Hex, toHex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/pages/transactions/send-parallel-transactions/react.mdx
+++ b/docs/pages/transactions/send-parallel-transactions/react.mdx
@@ -6,7 +6,7 @@ You'll need both `ALCHEMY_API_KEY` and `ALCHEMY_POLICY_ID` environment variables
 
 <CodeBlocks>
 
-```tsx twoslash title="sendParallelCalls.tsx"
+```tsx title="sendParallelCalls.tsx"
 import { config } from "@/app/config";
 import {
   useSendCalls,
@@ -84,7 +84,7 @@ export default function SendParallelCalls() {
 }
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 export const config = {
   alchemyApiKey: process.env.ALCHEMY_API_KEY!,
   policyId: process.env.ALCHEMY_POLICY_ID!,

--- a/docs/pages/transactions/send-transactions/client.mdx
+++ b/docs/pages/transactions/send-transactions/client.mdx
@@ -6,7 +6,7 @@ You can send transactions using the smart wallet client `sendCalls` action.
 
 <CodeBlocks>
 
-```ts twoslash title="sendCalls.ts"
+```ts title="sendCalls.ts"
 import { parseEther, toHex } from "viem";
 import { client } from "./client.ts";
 
@@ -27,7 +27,7 @@ const result = await client.waitForCallsStatus({ id: preparedCallIds[0] });
 console.log(result);
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import {

--- a/docs/pages/transactions/send-transactions/encoding-function-data/client.mdx
+++ b/docs/pages/transactions/send-transactions/encoding-function-data/client.mdx
@@ -2,7 +2,7 @@ In JavaScript, you can use [Viem](https://viem.sh/docs/contract/encodeFunctionDa
 
 <CodeBlocks>
 
-```ts twoslash title="sendCalls.ts" focus={9-13}
+```ts title="sendCalls.ts" focus={9-13}
 import { encodeFunctionData } from "viem";
 import { client } from "./client.ts";
 import { exampleAbi } from "./abi.ts";
@@ -21,7 +21,7 @@ await client.sendCalls({
 });
 ```
 
-```ts twoslash title="abi.ts"
+```ts title="abi.ts"
 export const exampleAbi = [
   {
     inputs: [{ name: "recipient", type: "address" }],
@@ -33,7 +33,7 @@ export const exampleAbi = [
 ] as const;
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import {

--- a/docs/pages/transactions/send-transactions/encoding-function-data/react.mdx
+++ b/docs/pages/transactions/send-transactions/encoding-function-data/react.mdx
@@ -6,7 +6,7 @@ In React, you can use [Viem](https://viem.sh/docs/contract/encodeFunctionData) t
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={20-24}
+```tsx title="sendCalls.tsx" focus={20-24}
 import { useSendCalls, useSmartAccountClient } from "@account-kit/react";
 import { encodeFunctionData } from "viem";
 import { exampleAbi } from "./abi.ts";
@@ -44,7 +44,7 @@ export default function SendCalls() {
 }
 ```
 
-```ts twoslash title="abi.ts"
+```ts title="abi.ts"
 export const exampleAbi = [
   {
     inputs: [{ name: "recipient", type: "address" }],

--- a/docs/pages/transactions/send-transactions/prepare-calls/client.mdx
+++ b/docs/pages/transactions/send-transactions/prepare-calls/client.mdx
@@ -4,7 +4,7 @@ You can use smart wallet client actions to prepare, sign, and send transactions.
 
 <CodeBlocks>
 
-```ts twoslash title="sendCalls.ts" focus={4-20}
+```ts title="sendCalls.ts" focus={4-20}
 import { parseEther, toHex } from "viem";
 import { client } from "./client.ts";
 
@@ -27,7 +27,7 @@ const sentCalls = await client.sendPreparedCalls(signedCalls);
 console.log({ sentCalls });
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import {

--- a/docs/pages/transactions/send-transactions/prepare-calls/react.mdx
+++ b/docs/pages/transactions/send-transactions/prepare-calls/react.mdx
@@ -8,7 +8,7 @@ You can use React hooks to prepare, sign, and send transactions.
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={10-15,22-39}
+```tsx title="sendCalls.tsx" focus={10-15,22-39}
 import {
   usePrepareCalls,
   useSmartAccountClient,

--- a/docs/pages/transactions/send-transactions/react.mdx
+++ b/docs/pages/transactions/send-transactions/react.mdx
@@ -9,7 +9,7 @@ You can use the `useSendCalls` hook to send calls, followed by the `useWaitForCa
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={11-22,29-37,42-44}
+```tsx title="sendCalls.tsx" focus={11-22,29-37,42-44}
 import {
   useSendCalls,
   useSmartAccountClient,

--- a/docs/pages/transactions/solana/api-prepare.mdx
+++ b/docs/pages/transactions/solana/api-prepare.mdx
@@ -1,6 +1,6 @@
 <CodeBlocks>
 
-```ts twoslash title="example.ts"
+```ts title="example.ts"
 import * as solanaWeb3 from "@solana/web3.js";
 import { connection, keypair } from "./config.ts";
 
@@ -29,7 +29,7 @@ export const serializedTx = Buffer.from(transaction.serialize()).toString(
 );
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { Connection, Keypair } from "@solana/web3.js";
 
 export const ALCHEMY_API_KEY = "<API_KEY>";

--- a/docs/pages/transactions/solana/api-request.mdx
+++ b/docs/pages/transactions/solana/api-request.mdx
@@ -1,6 +1,6 @@
 <CodeBlocks>
 
-```ts twoslash title="example.ts"
+```ts title="example.ts"
 import {
   ALCHEMY_API_KEY,
   POLICY_ID,
@@ -27,7 +27,7 @@ const data = (await response.json()) as AlchemyFeePayerResponse;
 const serializedSponsoredTransaction = data.result?.serializedTransaction;
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 export const ALCHEMY_API_KEY = "<API_KEY>";
 export const POLICY_ID = "<PolicyId>";
 export const RPC_URL = `https://solana-devnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`;
@@ -40,7 +40,7 @@ export interface AlchemyFeePayerResponse {
 }
 ```
 
-```ts twoslash title="prepare.ts"
+```ts title="prepare.ts"
 // Serialized transaction from the previous step
 export const serializedTransaction = "<base64-serialized-tx>";
 ```

--- a/docs/pages/transactions/solana/api-sign.mdx
+++ b/docs/pages/transactions/solana/api-sign.mdx
@@ -1,6 +1,6 @@
 <CodeBlocks>
 
-```ts twoslash title="example.ts"
+```ts title="example.ts"
 import { VersionedTransaction } from "@solana/web3.js";
 import { connection, keypair } from "./config.ts";
 import { sponsoredSerializedTransaction } from "./request.ts";
@@ -14,7 +14,7 @@ tx.sign([keypair]);
 const signature = await connection.sendRawTransaction(tx.serialize());
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { Connection, Keypair } from "@solana/web3.js";
 
 export const ALCHEMY_API_KEY = "<API_KEY>";
@@ -30,7 +30,7 @@ export const connection = new Connection(
 );
 ```
 
-```ts twoslash title="request.ts"
+```ts title="request.ts"
 // Result from the request step
 // Sponsored serialized transaction returned by alchemy_requestFeePayer
 export const sponsoredSerializedTransaction = "<base64-serialized-tx>";

--- a/docs/pages/transactions/solana/react-global.mdx
+++ b/docs/pages/transactions/solana/react-global.mdx
@@ -1,6 +1,6 @@
 <CodeBlocks>
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { cookieStorage, createConfig } from "@account-kit/react";
 import { Connection } from "@solana/web3.js";
 

--- a/docs/pages/transactions/solana/react-per-transaction.mdx
+++ b/docs/pages/transactions/solana/react-per-transaction.mdx
@@ -1,6 +1,6 @@
 <CodeBlocks>
 
-```tsx twoslash title="sponsor-solana-gas.tsx"
+```tsx title="sponsor-solana-gas.tsx"
 import { useSolanaTransaction } from "@account-kit/react";
 import { Connection, PublicKey, SystemProgram } from "@solana/web3.js";
 

--- a/docs/pages/transactions/sponsor-gas/client.mdx
+++ b/docs/pages/transactions/sponsor-gas/client.mdx
@@ -8,7 +8,7 @@ Use the `paymasterService` capability on the smart wallet client `sendCalls` or 
 
 <CodeBlocks>
 
-```ts twoslash title="sendCalls.ts"
+```ts title="sendCalls.ts"
 import { client, config } from "./client.ts";
 
 try {
@@ -33,7 +33,7 @@ try {
 }
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import type { Hex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/pages/transactions/sponsor-gas/react.mdx
+++ b/docs/pages/transactions/sponsor-gas/react.mdx
@@ -15,7 +15,7 @@ See the [`useSendCalls` SDK reference](/wallets/reference/account-kit/react/hook
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={5-6,14-21}
+```tsx title="sendCalls.tsx" focus={5-6,14-21}
 import { useSendCalls, useSmartAccountClient } from "@account-kit/react";
 import { config } from "./config.ts";
 
@@ -56,7 +56,7 @@ export default function SendCalls() {
 }
 ```
 
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { Address, toHex } from "viem";
 
 export const config = {

--- a/docs/pages/transactions/using-eip-7702/client.mdx
+++ b/docs/pages/transactions/using-eip-7702/client.mdx
@@ -15,7 +15,7 @@ for full descriptions of the parameters used in the following example.
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.ts"
+```tsx title="sendCalls.ts"
 import { client, config } from "./client.ts";
 
 try {
@@ -41,7 +41,7 @@ try {
 }
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import "dotenv/config";
 import type { Hex } from "viem";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/pages/transactions/using-eip-7702/react.mdx
+++ b/docs/pages/transactions/using-eip-7702/react.mdx
@@ -12,7 +12,7 @@ See the [`useSendCalls` SDK reference](/wallets/reference/account-kit/react/hook
 
 <CodeBlocks>
 
-```tsx twoslash title="sendCalls.tsx" focus={4-8,17-25}
+```tsx title="sendCalls.tsx" focus={4-8,17-25}
 import { useSendCalls, useSmartAccountClient } from "@account-kit/react";
 
 export default function SendCalls() {

--- a/docs/pages/troubleshooting/server-side-rendering.mdx
+++ b/docs/pages/troubleshooting/server-side-rendering.mdx
@@ -63,7 +63,7 @@ If you are using NextJS App Directory, you can read the cookie state and pass it
 
 <CodeBlocks>
 
-```tsx twoslash app/layout.tsx
+```tsx app/layout.tsx
 // @noErrors
 import React from "react";
 import { cookieToInitialState } from "@account-kit/core";
@@ -103,7 +103,7 @@ export default function RootLayout({
 }
 ```
 
-```tsx twoslash app/providers.tsx
+```tsx app/providers.tsx
 // @noErrors
 "use client";
 
@@ -141,7 +141,7 @@ export const Providers = (
 };
 ```
 
-```tsx twoslash config.ts
+```tsx config.ts
 import { createConfig, cookieStorage } from "@account-kit/react";
 import { sepolia, alchemy } from "@account-kit/infra";
 import { QueryClient } from "@tanstack/react-query";
@@ -164,7 +164,7 @@ export const config = () =>
   </Tab>
   <Tab title="Other Javascript">
 
-```ts twoslash
+```ts
 import { createConfig } from "@account-kit/core";
 import { sepolia, alchemy } from "@account-kit/infra";
 
@@ -183,7 +183,7 @@ Now that you've set up your config for SSR, you will have to manually hydrate th
 
 <CodeBlocks>
 
-```ts twoslash hydrate.ts
+```ts hydrate.ts
 import { hydrate } from "@account-kit/core";
 import { config } from "./config";
 
@@ -197,7 +197,7 @@ if (typeof window !== "undefined") {
 }
 ```
 
-```ts twoslash config.ts
+```ts config.ts
 import { createConfig } from "@account-kit/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 
@@ -230,7 +230,7 @@ Now you can get the initial state from cookies and pass it to the `hydrate` meth
 
 <CodeBlocks>
 
-```ts twoslash hydrate.ts {7}
+```ts hydrate.ts {7}
 import { cookieToInitialState, hydrate } from "@account-kit/core";
 import { config } from "./config";
 
@@ -245,7 +245,7 @@ if (typeof window !== "undefined") {
 }
 ```
 
-```ts twoslash config.ts {7-8}
+```ts config.ts {7-8}
 import { createConfig, cookieStorage } from "@account-kit/core";
 import { sepolia, alchemy } from "@account-kit/infra";
 

--- a/docs/shared/core/config.mdx
+++ b/docs/shared/core/config.mdx
@@ -1,4 +1,4 @@
-```ts twoslash config.ts
+```ts config.ts
 import { createConfig } from "@account-kit/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 

--- a/docs/shared/core/ssr-config.mdx
+++ b/docs/shared/core/ssr-config.mdx
@@ -1,4 +1,4 @@
-```ts twoslash config.ts
+```ts config.ts
 import { createConfig } from "@account-kit/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 

--- a/docs/shared/infra/client.mdx
+++ b/docs/shared/infra/client.mdx
@@ -1,4 +1,4 @@
-```ts twoslash client.ts
+```ts client.ts
 import {
   alchemy,
   createAlchemySmartAccountClient,

--- a/docs/shared/infra/mav2-client.mdx
+++ b/docs/shared/infra/mav2-client.mdx
@@ -1,5 +1,5 @@
 <CodeBlocks>
-```ts twoslash title="config.ts"
+```ts title="config.ts"
 import { alchemy, sepolia } from "@account-kit/infra";
 
 const YOUR_API_KEY = "<YOUR_API_KEY>";
@@ -13,7 +13,7 @@ export const transport = alchemy({
 });
 ```
 
-```ts twoslash title="client.ts"
+```ts title="client.ts"
 import { createModularAccountV2Client } from "@account-kit/smart-contracts";
 import { chain, transport, policyId } from "./config";
 import { LocalAccountSigner } from "@aa-sdk/core";

--- a/docs/shared/react-native/account-provider-setup.mdx
+++ b/docs/shared/react-native/account-provider-setup.mdx
@@ -1,4 +1,4 @@
-```ts twoslash _layout.tsx (Expo)
+```ts _layout.tsx (Expo)
 import "react-native-get-random-values"; // Shims for the crypto module
 import React from "react";
 import { alchemy, sepolia } from "@account-kit/infra";
@@ -32,7 +32,7 @@ export default function App() {
 }
 ```
 
-```ts twoslash App.tsx (Bare React Native)
+```ts App.tsx (Bare React Native)
 import "react-native-get-random-values"; // Shims for the crypto module
 import React from "react";
 import { alchemy, sepolia } from "@account-kit/infra";

--- a/docs/shared/signer/signer.mdx
+++ b/docs/shared/signer/signer.mdx
@@ -1,4 +1,4 @@
-```ts twoslash signer.ts
+```ts signer.ts
 import { AlchemyWebSigner } from "@account-kit/signer";
 
 export const signer = new AlchemyWebSigner({

--- a/docs/shared/signer/wallet-client-signer.mdx
+++ b/docs/shared/signer/wallet-client-signer.mdx
@@ -1,4 +1,4 @@
-```ts twoslash wallet-client-signer.ts
+```ts wallet-client-signer.ts
 import { WalletClientSigner, type SmartAccountSigner } from "@aa-sdk/core";
 import { createWalletClient, custom } from "viem";
 import { sepolia } from "viem/chains";

--- a/docs/shared/smart-contracts/light-account-client.mdx
+++ b/docs/shared/smart-contracts/light-account-client.mdx
@@ -1,4 +1,4 @@
-```ts twoslash client.ts
+```ts client.ts
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import { createLightAccountAlchemyClient } from "@account-kit/smart-contracts";

--- a/docs/shared/smart-contracts/modular-account-client.mdx
+++ b/docs/shared/smart-contracts/modular-account-client.mdx
@@ -1,4 +1,4 @@
-```ts twoslash client.ts
+```ts client.ts
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import { createModularAccountAlchemyClient } from "@account-kit/smart-contracts";

--- a/docs/shared/smart-contracts/multi-owner-light-account-client.mdx
+++ b/docs/shared/smart-contracts/multi-owner-light-account-client.mdx
@@ -1,4 +1,4 @@
-```ts twoslash client.ts
+```ts client.ts
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import { createMultiOwnerLightAccountAlchemyClient } from "@account-kit/smart-contracts";

--- a/docs/shared/smart-contracts/multisig-client.mdx
+++ b/docs/shared/smart-contracts/multisig-client.mdx
@@ -1,4 +1,4 @@
-```ts twoslash client.ts
+```ts client.ts
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import { createMultisigAccountAlchemyClient } from "@account-kit/smart-contracts";

--- a/docs/shared/smart-contracts/session-keys/base-client.mdx
+++ b/docs/shared/smart-contracts/session-keys/base-client.mdx
@@ -1,4 +1,4 @@
-```ts twoslash base-client.ts
+```ts base-client.ts
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";
 import {

--- a/docs/shared/smart-contracts/session-keys/full-example.mdx
+++ b/docs/shared/smart-contracts/session-keys/full-example.mdx
@@ -1,4 +1,4 @@
-```ts twoslash
+```ts
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { alchemy, sepolia } from "@account-kit/infra";


### PR DESCRIPTION
Fern doesn't correctly support twoslash, so it breaks the rendering of a `<CodeBlocks>` tag by making tabs inaccessible and disabling the code focus/highlighting and the max code block height.

Removing twoslash from these docs for now until Fern adds support for twoslash.

Cases found with the regex `<CodeBlocks>[\s\S]*?twoslash[\s\S]*?</CodeBlocks>`, which had 1 false positive due to non-`<CodeBlocks>` section in between two `<CodeBlocks>` sections.. Also had to remove from nested `<Markdown ...` inclusions.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates the documentation files, changing code block annotations from `twoslash` to standard code block formatting. This enhances clarity and consistency across various documentation pages.

### Detailed summary
- Changed `twoslash` annotations to standard code block formatting in multiple `.mdx` files.
- Updated file references in code examples to improve accuracy.
- Added new code snippets and examples for various components, including `signer`, `client`, and configuration files.
- Enhanced documentation for authentication methods and transaction handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->