### PR TITLE
chore: add vercel scripts to ignore build

### DIFF
--- a/scripts/test-vercel-ignore-build.sh
+++ b/scripts/test-vercel-ignore-build.sh
@@ -7,7 +7,11 @@ export VERCEL_GIT_REPO_OWNER="AlchemyPlatform"
 export VERCEL_GIT_REPO_SLUG="aa-sdk" 
 
 # Simulate the custom variables you'll add in Vercel dashboard
-export GITHUB_TOKEN="ghp_yourActualTokenHere"  # Use a real token for testing
+export GITHUB_TOKEN="YOUR_GITHUB_TOKEN_HERE"  # Replace with your actual GitHub token for testing
+if [ "$GITHUB_TOKEN" = "YOUR_GITHUB_TOKEN_HERE" ]; then
+  echo "Error: GITHUB_TOKEN is set to the placeholder value. Please replace it with your actual GitHub token." >&2
+  exit 1
+fi
 export SKIP_BUILD_FOR_BRANCH="moldy/v5-base"
 
 # Now run your actual script

--- a/scripts/test-vercel-ignore-build.sh
+++ b/scripts/test-vercel-ignore-build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Simulate Vercel's automatic variables
+export VERCEL_GIT_COMMIT_REF="bc/ci-filter" # replace with the branch you want to test
+export VERCEL_GIT_PULL_REQUEST_ID="2111"  # replace with the PR you want to test
+export VERCEL_GIT_REPO_OWNER="AlchemyPlatform"
+export VERCEL_GIT_REPO_SLUG="aa-sdk" 
+
+# Simulate the custom variables you'll add in Vercel dashboard
+export GITHUB_TOKEN="ghp_yourActualTokenHere"  # Use a real token for testing
+export SKIP_BUILD_FOR_BRANCH="moldy/v5-base"
+
+# Now run your actual script
+echo "=== Running Vercel ignore script with simulated environment ==="
+bash ./scripts/vercel-ignore-build.sh
+
+# Check the exit code
+if [ $? -eq 0 ]; then
+  echo "Result: Would SKIP build ❌"
+else
+  echo "Result: Would BUILD ✅"
+fi

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "🔍 Checking if build should be skipped..."
+
+# Safe default - if anything goes wrong, build anyway
+set +e  # Don't exit on error
+
+# Always build main branch
+if [ "$VERCEL_GIT_COMMIT_REF" == "main" ]; then
+  echo "Building for main branch"
+  exit 1
+fi
+
+# Only check PRs if we have the required variables
+if [ -n "$VERCEL_GIT_PULL_REQUEST_ID" ] && [ -n "$GITHUB_TOKEN" ]; then
+  echo "Checking PR #$VERCEL_GIT_PULL_REQUEST_ID"
+  
+  # Get PR info from GitHub API
+  PR_BASE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG/pulls/$VERCEL_GIT_PULL_REQUEST_ID" \
+    | jq -r '.base.ref')
+  
+  # If we got a valid base branch
+  if [ -n "$PR_BASE" ] && [ "$PR_BASE" != "null" ]; then
+    echo "PR base branch: $PR_BASE"
+    
+    # Check if we should skip this branch
+    SKIP_BRANCH="${SKIP_BUILD_FOR_BRANCH:-}"
+    if [ -n "$SKIP_BRANCH" ] && [ "$PR_BASE" == "$SKIP_BRANCH" ]; then
+      echo "🛑 Skipping build - PR targets $PR_BASE"
+      exit 0  # Skip build
+    fi
+  else
+    echo "⚠️ Could not get PR base branch"
+  fi
+fi
+
+echo "✅ Proceeding with build"
+exit 1  # Proceed with build


### PR DESCRIPTION
Checking in a script to integrate with [Vercel's ignored build step](https://vercel.com/docs/project-configuration/git-settings#ignored-build-step), which lets us conditionally kick off vercel deploys. The goal of this is to stop the vercel build in v5 branch so that we can properly remove v4 deps without breaking CI. Currently, we have the `aa-sdk-ui-demo`, which requires v4 `aa-sdk` to be built in the v5 branch.

This PR should be a no-op, since vercel checks against the `main` branch. I've also added a test script in here that you can try running against PR/branches against v5, which would skip.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a script for simulating Vercel's environment variables to test build skipping logic based on pull request information.

### Detailed summary
- Added `scripts/test-vercel-ignore-build.sh` to simulate Vercel's environment variables.
- Included error handling for `GITHUB_TOKEN` placeholder value.
- Added logic to run `scripts/vercel-ignore-build.sh` and check build skipping conditions.
- Modified `scripts/vercel-ignore-build.sh` to check PR base branch and determine if the build should be skipped.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->