### PR TITLE
fix(v5): coerce yParity to a number

### DIFF
--- a/packages/wallet-apis/src/actions/signSignatureRequest.ts
+++ b/packages/wallet-apis/src/actions/signSignatureRequest.ts
@@ -91,7 +91,12 @@ export async function signSignatureRequest(
       };
     }
     case "eip7702Auth": {
-      const { r, s, v, yParity } = await actions.signAuthorization({
+      const {
+        r,
+        s,
+        v,
+        yParity: _yParity,
+      } = await actions.signAuthorization({
         ...{
           ...params.data,
           chainId: hexToNumber(params.data.chainId),
@@ -99,13 +104,17 @@ export async function signSignatureRequest(
         },
         account: signerClient.account,
       });
+      // yParity *should* already be a number, but some 3rd
+      // party signers may mistakenly return it as a bigint.
+      const yParity =
+        _yParity != null ? Number(_yParity) : vToYParity(Number(v));
 
       return {
         type: "secp256k1",
         data: serializeSignature({
           r,
           s,
-          yParity: yParity ?? vToYParity(Number(v)),
+          yParity,
         }),
       };
     }


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `yParity` value in the `signSignatureRequest` function, ensuring that it is correctly processed even if returned as a `bigint` by third-party signers.

### Detailed summary
- Renamed `yParity` to `_yParity` for clarity.
- Added a check to convert `_yParity` to a number if it's not null.
- Updated the return object to use the new `yParity` variable instead of the previous conditional assignment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->