### PR TITLE
chore: add jsdoc and tests for alchemyAuth

### DIFF
--- a/docs/pages/reference/alchemy/connectors-web/functions/alchemyAuth.mdx
+++ b/docs/pages/reference/alchemy/connectors-web/functions/alchemyAuth.mdx
@@ -5,16 +5,39 @@ description: Overview of the alchemyAuth method
 slug: wallets/reference/alchemy/connectors-web/functions/alchemyAuth
 ---
 
-Creates the Alchemy Auth connector for Wagmi.
+Creates a Wagmi connector for Alchemy Auth, enabling email-based authentication
+with embedded wallet capabilities. This connector provides a seamless authentication
+experience using email OTP or OAuth, with automatic session management and persistence.
 
-This function returns a connector factory via Wagmi's `createConnector`.
+The connector supports:
 
-Reference: Creating Connectors (Wagmi)
+- Email OTP authentication
+- OAuth authentication flows
+- Automatic session persistence and restoration
+- Cross-tab synchronization
+- Multi-chain support
 
 ## Import
 
 ```ts
 import { alchemyAuth } from "@alchemy/connectors-web";
+```
+
+## Usage
+
+Basic usage with API key:
+
+```ts
+import { alchemyAuth } from "@alchemy/connectors-web";
+import { createConfig } from "wagmi";
+
+const config = createConfig({
+  connectors: [
+    alchemyAuth({
+      apiKey: "your-api-key",
+    }),
+  ],
+});
 ```
 
 ## Parameters
@@ -23,7 +46,7 @@ import { alchemyAuth } from "@alchemy/connectors-web";
 
 `AlchemyAuthOptions`
 
-- Configuration for the connector
+- Configuration options for the connector
 
 ### options.apiKey
 
@@ -45,17 +68,17 @@ import { alchemyAuth } from "@alchemy/connectors-web";
 
 ### options.createTekStamper
 
-`CreateTekStamperFn`
+`Function`
 
 - Optional custom TEK stamper factory for React Native
 
 ### options.createWebAuthnStamper
 
-`CreateWebAuthnStamperFn`
+`Function`
 
 - Optional custom WebAuthn stamper factory for passkey authentication
 
 ## Returns
 
 `CreateConnectorFn`
-A Wagmi connector factory compatible with `createConfig`.
+A Wagmi connector factory compatible with `createConfig`

--- a/packages/connectors-web/src/alchemyAuth.ts
+++ b/packages/connectors-web/src/alchemyAuth.ts
@@ -457,12 +457,20 @@ export function alchemyAuth(options: AlchemyAuthOptions): CreateConnectorFn {
         // In a full implementation, we might need to update internal state
         if (accounts.length === 0) {
           await this.disconnect();
+        } else {
+          config.emitter.emit("change", {
+            accounts: accounts as readonly Address[],
+          });
         }
       },
 
-      onChainChanged(chainId) {
+      async onChainChanged(chainId) {
         // Update the current chain ID when chain changes
         currentChainId = parseInt(chainId, 16);
+        config.emitter.emit("change", {
+          chainId: currentChainId,
+          accounts: await this.getAccounts(),
+        });
       },
 
       async onConnect(connectInfo) {

--- a/packages/connectors-web/src/alchemyAuth.ts
+++ b/packages/connectors-web/src/alchemyAuth.ts
@@ -52,7 +52,7 @@ alchemyAuth.type = "alchemy-auth" as const;
  *
  * @example
  * Basic usage with API key:
- * ```ts
+ * ```ts twoslash
  * import { alchemyAuth } from "@alchemy/connectors-web";
  * import { createConfig } from "wagmi";
  *

--- a/packages/connectors-web/src/alchemyAuth.ts
+++ b/packages/connectors-web/src/alchemyAuth.ts
@@ -79,7 +79,7 @@ alchemyAuth.type = "alchemy-auth" as const;
  *
  * @example
  * With custom stamper factories:
- * ```ts
+ * ```ts twoslash
  * import { alchemyAuth } from "@alchemy/connectors-web";
  *
  * const connector = alchemyAuth({

--- a/packages/connectors-web/src/alchemyAuth.ts
+++ b/packages/connectors-web/src/alchemyAuth.ts
@@ -19,6 +19,10 @@ import {
   type PersistedAuthSession,
 } from "./store/authSessionStorage.js";
 
+/**
+ * Configuration options for the Alchemy Auth connector.
+ * Extends Alchemy Auth client parameters with connector-specific options.
+ */
 export interface AlchemyAuthOptions
   extends Pick<
     WebAuthClientParams,
@@ -35,27 +39,95 @@ export interface AlchemyAuthOptions
 alchemyAuth.type = "alchemy-auth" as const;
 
 /**
- * Creates the Alchemy Auth connector for Wagmi.
+ * Creates a Wagmi connector for Alchemy Auth, enabling email-based authentication
+ * with embedded wallet capabilities. This connector provides a seamless authentication
+ * experience using email OTP or OAuth, with automatic session management and persistence.
  *
- * This function returns a connector factory via Wagmi's `createConnector`.
+ * The connector supports:
+ * - Email OTP authentication
+ * - OAuth authentication flows
+ * - Automatic session persistence and restoration
+ * - Cross-tab synchronization
+ * - Multi-chain support
  *
- * Reference: Creating Connectors (Wagmi)
+ * @example
+ * Basic usage with API key:
+ * ```ts
+ * import { alchemyAuth } from "@alchemy/connectors-web";
+ * import { createConfig } from "wagmi";
  *
- * @see https://wagmi.sh/dev/creating-connectors
+ * const config = createConfig({
+ *   connectors: [
+ *     alchemyAuth({
+ *       apiKey: "your-api-key"
+ *     })
+ *   ]
+ * });
+ * ```
  *
- * @param {AlchemyAuthOptions} options - Configuration for the connector
+ * @example
+ * With custom iframe configuration:
+ * ```ts
+ * import { alchemyAuth } from "@alchemy/connectors-web";
+ *
+ * const connector = alchemyAuth({
+ *   apiKey: "your-api-key",
+ *   iframeElementId: "turnkey-iframe",
+ *   iframeContainerId: "turnkey-container"
+ * });
+ * ```
+ *
+ * @example
+ * With custom stamper factories:
+ * ```ts
+ * import { alchemyAuth } from "@alchemy/connectors-web";
+ *
+ * const connector = alchemyAuth({
+ *   apiKey: "your-api-key",
+ *   createWebAuthnStamper: (config) => customWebAuthnStamper(config),
+ *   createTekStamper: (config) => customTekStamper(config)
+ * });
+ * ```
+ *
+ * @param {AlchemyAuthOptions} options - Configuration options for the connector
  * @param {string} [options.apiKey] - API key for authentication with Alchemy services
  * @param {string} [options.iframeElementId] - Optional ID for the iframe element used by Turnkey stamper
  * @param {string} [options.iframeContainerId] - Optional ID for the container element that holds the iframe
- * @param {CreateTekStamperFn} [options.createTekStamper] - Optional custom TEK stamper factory for React Native
- * @param {CreateWebAuthnStamperFn} [options.createWebAuthnStamper] - Optional custom WebAuthn stamper factory for passkey authentication
- * @returns {CreateConnectorFn} A Wagmi connector factory compatible with `createConfig`.
+ * @param {Function} [options.createTekStamper] - Optional custom TEK stamper factory for React Native
+ * @param {Function} [options.createWebAuthnStamper] - Optional custom WebAuthn stamper factory for passkey authentication
+ * @returns {CreateConnectorFn} A Wagmi connector factory compatible with `createConfig`
+ *
+ * @see {@link https://wagmi.sh/dev/creating-connectors | Wagmi Creating Connectors Guide}
  */
 export function alchemyAuth(options: AlchemyAuthOptions): CreateConnectorFn {
   type Provider = EIP1193Provider;
+
+  /**
+   * Custom properties added to the connector for Alchemy Auth functionality.
+   * These methods extend the standard Wagmi connector interface.
+   */
   type Properties = {
+    /**
+     * Gets the underlying Alchemy Auth client instance.
+     *
+     * @returns {AuthClient} The auth client used by this connector
+     */
     getAuthClient(): AuthClient;
+
+    /**
+     * Gets the current authentication session.
+     *
+     * @returns {Promise<AuthSession>} Promise resolving to the current auth session
+     * @throws {Error} If no auth session is available
+     */
     getAuthSession(): Promise<AuthSession>;
+
+    /**
+     * Sets the authentication session after successful authentication.
+     * This method should be called after completing email OTP or OAuth flows.
+     *
+     * @param {AuthSession} authSession - The authenticated session to set
+     */
     setAuthSession(authSession: AuthSession): void;
   };
 
@@ -76,6 +148,7 @@ export function alchemyAuth(options: AlchemyAuthOptions): CreateConnectorFn {
   // rather than triggering multiple concurrent tryResume() calls.
   // Returns true if the session was restored successfully, false if it was not.
   let resumePromise: Promise<boolean> | undefined;
+
   return createConnector<Provider, Properties>((config) => {
     function assertNotNullish<T>(
       value: T,

--- a/packages/connectors-web/src/alchemyAuth.ts
+++ b/packages/connectors-web/src/alchemyAuth.ts
@@ -67,7 +67,7 @@ alchemyAuth.type = "alchemy-auth" as const;
  *
  * @example
  * With custom iframe configuration:
- * ```ts
+ * ```ts twoslash
  * import { alchemyAuth } from "@alchemy/connectors-web";
  *
  * const connector = alchemyAuth({

--- a/packages/connectors-web/src/store/authSessionStorage.ts
+++ b/packages/connectors-web/src/store/authSessionStorage.ts
@@ -1,7 +1,11 @@
 import type { Storage } from "@wagmi/core";
 import { z } from "zod";
 
-// Persistence types - treat auth session state as opaque blob
+/**
+ * Persisted authentication session data stored in Wagmi storage.
+ * The auth session state is treated as an opaque serialized blob,
+ * with its contents managed by the auth package.
+ */
 export type PersistedAuthSession = {
   /** Version for migration handling */
   version: 1;
@@ -27,7 +31,13 @@ function isPersistedAuthSession(obj: unknown): obj is PersistedAuthSession {
   return result.success;
 }
 
-// Type-safe storage helpers
+/**
+ * Retrieves the persisted auth session from Wagmi storage.
+ * Validates the stored data structure and automatically cleans up invalid data.
+ *
+ * @param {Storage | null | undefined} storage - Wagmi storage instance
+ * @returns {Promise<PersistedAuthSession | null>} The persisted session if valid, otherwise null
+ */
 export async function getStoredAuthSession(
   storage: Storage | null | undefined,
 ): Promise<PersistedAuthSession | null> {
@@ -62,6 +72,14 @@ export async function getStoredAuthSession(
   }
 }
 
+/**
+ * Persists an auth session to Wagmi storage.
+ * Validates the session data structure before storing.
+ *
+ * @param {Storage | null | undefined} storage - Wagmi storage instance
+ * @param {PersistedAuthSession} session - The session data to persist
+ * @returns {Promise<boolean>} True if successfully stored, false otherwise
+ */
 export async function setStoredAuthSession(
   storage: Storage | null | undefined,
   session: PersistedAuthSession,
@@ -85,6 +103,13 @@ export async function setStoredAuthSession(
   }
 }
 
+/**
+ * Clears the persisted auth session from Wagmi storage.
+ * Called during logout or when session restoration fails.
+ *
+ * @param {Storage | null | undefined} storage - Wagmi storage instance
+ * @returns {Promise<void>}
+ */
 export async function clearStoredAuthSession(
   storage: Storage | null | undefined,
 ): Promise<void> {

--- a/packages/connectors-web/tests/alchemyAuth.test.ts
+++ b/packages/connectors-web/tests/alchemyAuth.test.ts
@@ -137,9 +137,7 @@ describe("alchemyAuth connector", () => {
       const result = await connectorInstance.connect();
 
       expect(result.accounts).toHaveLength(1);
-      expect(result.accounts[0]).toBe(
-        TEST_ADDRESS,
-      );
+      expect(result.accounts[0]).toBe(TEST_ADDRESS);
       expect(result.chainId).toBe(sepolia.id);
     });
 
@@ -532,10 +530,11 @@ describe("alchemyAuth connector", () => {
       const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
       connectorInstance.setAuthSession(mockAuthSession);
 
-      const newAddress = "0x9876543210987654321098765432109876543210" as Address;
+      const newAddress =
+        "0x9876543210987654321098765432109876543210" as Address;
 
       await expect(
-        connectorInstance.onAccountsChanged([newAddress])
+        connectorInstance.onAccountsChanged([newAddress]),
       ).resolves.not.toThrow();
     });
 
@@ -556,7 +555,7 @@ describe("alchemyAuth connector", () => {
       // Directly call onChainChanged - the implementation should emit "change" event
       // We can't easily test the event emission directly, but we can verify the method doesn't throw
       await expect(
-        connectorInstance.onChainChanged(`0x${mainnet.id.toString(16)}`)
+        connectorInstance.onChainChanged(`0x${mainnet.id.toString(16)}`),
       ).resolves.not.toThrow();
     });
 
@@ -703,7 +702,6 @@ describe("alchemyAuth connector", () => {
         connectorInstance.switchChain!({ chainId: mainnet.id }),
       ).resolves.toBeDefined();
     });
-
   });
 
   describe("Session Restoration Edge Cases", () => {

--- a/packages/connectors-web/tests/alchemyAuth.test.ts
+++ b/packages/connectors-web/tests/alchemyAuth.test.ts
@@ -1,0 +1,780 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { alchemyAuth } from "../src/alchemyAuth.js";
+import { createConfig } from "@wagmi/core";
+import { sepolia, mainnet } from "viem/chains";
+import { http, type Address } from "viem";
+import type { AuthClient, AuthSession } from "@alchemy/auth";
+import type { Connector } from "wagmi";
+
+// Type helper to get the connector instance type with custom properties
+type AlchemyAuthConnector = Connector & {
+  getAuthClient(): AuthClient;
+  getAuthSession(): Promise<AuthSession>;
+  setAuthSession(authSession: AuthSession): void;
+};
+
+// Mock dependencies
+vi.mock("@alchemy/auth-web");
+
+describe("alchemyAuth connector", () => {
+  const TEST_ADDRESS = "0x1234567890123456789012345678901234567890" as Address;
+
+  let mockAuthClient: AuthClient;
+  let mockAuthSession: AuthSession;
+  let mockProvider: any;
+  let mockStorage: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockProvider = {
+      request: vi.fn(),
+    };
+    mockAuthSession = {
+      getAddress: vi.fn().mockReturnValue(TEST_ADDRESS),
+      getProvider: vi.fn().mockReturnValue(mockProvider),
+      toViemLocalAccount: vi.fn().mockReturnValue({
+        address: TEST_ADDRESS,
+        type: "local",
+      }),
+      getSerializedState: vi.fn().mockReturnValue(
+        JSON.stringify({
+          type: "email",
+          bundle: "test-bundle",
+          expirationDateMs: Date.now() + 60 * 60 * 1000,
+          user: { address: TEST_ADDRESS },
+        }),
+      ),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    mockAuthClient = {
+      restoreAuthSession: vi.fn().mockResolvedValue(mockAuthSession),
+    } as any;
+    mockStorage = {
+      getItem: vi.fn().mockResolvedValue(null),
+      setItem: vi.fn().mockResolvedValue(undefined),
+      removeItem: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const { createWebAuthClient } = await import("@alchemy/auth-web");
+    vi.mocked(createWebAuthClient).mockReturnValue(mockAuthClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Session Management", () => {
+    it("should set and get auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const session = await connectorInstance.getAuthSession();
+      expect(session).toBe(mockAuthSession);
+    });
+
+    it("should throw error when getting auth session without setting it first", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      await expect(connectorInstance.getAuthSession()).rejects.toThrow(
+        "No auth session available",
+      );
+    });
+
+    it("should get auth client", () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      const authClient = connectorInstance.getAuthClient();
+
+      expect(authClient).toBeDefined();
+      expect(authClient).toBe(mockAuthClient);
+    });
+  });
+
+  describe("Connection Flow", () => {
+    it("should connect with auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const result = await connectorInstance.connect();
+
+      expect(result.accounts).toHaveLength(1);
+      expect(result.accounts[0]).toBe(
+        TEST_ADDRESS,
+      );
+      expect(result.chainId).toBe(sepolia.id);
+    });
+
+    it("should connect with specific chainId", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia, mainnet],
+        transports: {
+          [sepolia.id]: http(),
+          [mainnet.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const result = await connectorInstance.connect({ chainId: mainnet.id });
+
+      expect(result.chainId).toBe(mainnet.id);
+    });
+
+    it("should throw error when connecting without auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      await expect(connectorInstance.connect()).rejects.toThrow(
+        "No auth session available",
+      );
+    });
+  });
+
+  describe("Disconnection Flow", () => {
+    it("should disconnect and clear session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      await connectorInstance.disconnect();
+
+      expect(mockAuthSession.disconnect).toHaveBeenCalled();
+      expect(mockStorage.removeItem).toHaveBeenCalled();
+    });
+
+    it("should handle disconnect errors gracefully", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      // Mock disconnect to throw error
+      const errorSession = {
+        ...mockAuthSession,
+        disconnect: vi.fn().mockRejectedValue(new Error("Disconnect failed")),
+      };
+      connectorInstance.setAuthSession(errorSession as any);
+
+      await expect(connectorInstance.disconnect()).resolves.toBeUndefined();
+      expect(mockStorage.removeItem).toHaveBeenCalled();
+    });
+  });
+
+  describe("Account Management", () => {
+    it("should get accounts from auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const accounts = await connectorInstance.getAccounts();
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]).toBe(TEST_ADDRESS);
+    });
+
+    it("should return empty array when no auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      const accounts = await connectorInstance.getAccounts();
+
+      expect(accounts).toHaveLength(0);
+    });
+  });
+
+  describe("Chain Management", () => {
+    it("should get current chain id", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      const chainId = await connectorInstance.getChainId();
+
+      expect(chainId).toBe(sepolia.id);
+    });
+
+    it("should switch chain", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia, mainnet],
+        transports: {
+          [sepolia.id]: http(),
+          [mainnet.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const result = await connectorInstance.switchChain!({
+        chainId: mainnet.id,
+      });
+
+      expect(result.id).toBe(mainnet.id);
+    });
+
+    it("should throw error when switching to unsupported chain", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      await expect(
+        connectorInstance.switchChain!({ chainId: 999999 }),
+      ).rejects.toThrow("Chain with id 999999 not found in config");
+    });
+  });
+
+  describe("Provider Management", () => {
+    it("should get provider from auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const provider = await connectorInstance.getProvider();
+
+      expect(provider).toBe(mockProvider);
+      expect(mockAuthSession.getProvider).toHaveBeenCalled();
+    });
+
+    it("should throw error when getting provider without auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      await expect(connectorInstance.getProvider()).rejects.toThrow(
+        "No auth session available",
+      );
+    });
+  });
+
+  describe("Authorization", () => {
+    it("should return false when not authorized", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      const isAuthorized = await connectorInstance.isAuthorized();
+
+      expect(isAuthorized).toBe(false);
+    });
+
+    it("should return true when authorized", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const isAuthorized = await connectorInstance.isAuthorized();
+
+      expect(isAuthorized).toBe(true);
+    });
+  });
+
+  describe("Session Restoration", () => {
+    it("should restore session from storage on setup", async () => {
+      const persistedSession = {
+        version: 1,
+        chainId: sepolia.id,
+        authSessionState: JSON.stringify({
+          type: "email",
+          bundle: "test-bundle",
+          expirationDateMs: Date.now() + 60 * 60 * 1000,
+          user: { address: TEST_ADDRESS },
+        }),
+      };
+
+      mockStorage.getItem.mockResolvedValue(JSON.stringify(persistedSession));
+
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      await connectorInstance.setup?.();
+
+      // Give time for async restoration
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const isAuthorized = await connectorInstance.isAuthorized();
+      expect(isAuthorized).toBe(true);
+    });
+
+    it("should handle storage errors during restoration", async () => {
+      mockStorage.getItem.mockRejectedValue(new Error("Storage error"));
+
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      // Should not throw
+      await expect(connectorInstance.setup?.()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("Client Creation", () => {
+    it("should cache clients by chainId", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const client1 = await connectorInstance.getClient?.({
+        chainId: sepolia.id,
+      });
+      const client2 = await connectorInstance.getClient?.({
+        chainId: sepolia.id,
+      });
+
+      expect(client1).toBe(client2);
+      expect(mockAuthSession.toViemLocalAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw error when getting client without auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      await expect(
+        connectorInstance.getClient?.({ chainId: sepolia.id }),
+      ).rejects.toThrow("No auth session available");
+    });
+  });
+
+  describe("Event Handlers", () => {
+    it("should handle accounts changed event with empty array", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      // Trigger accounts changed with empty array - should disconnect
+      await connectorInstance.onAccountsChanged([]);
+
+      expect(mockAuthSession.disconnect).toHaveBeenCalled();
+    });
+
+    it("should emit change event when accounts changed to non-empty array", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      const newAddress = "0x9876543210987654321098765432109876543210" as Address;
+
+      await expect(
+        connectorInstance.onAccountsChanged([newAddress])
+      ).resolves.not.toThrow();
+    });
+
+    it("should emit change event when chain changed", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia, mainnet],
+        transports: {
+          [sepolia.id]: http(),
+          [mainnet.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      // Directly call onChainChanged - the implementation should emit "change" event
+      // We can't easily test the event emission directly, but we can verify the method doesn't throw
+      await expect(
+        connectorInstance.onChainChanged(`0x${mainnet.id.toString(16)}`)
+      ).resolves.not.toThrow();
+    });
+
+    it("should handle disconnect event", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      await connectorInstance.onDisconnect(new Error("Test error"));
+
+      expect(mockAuthSession.disconnect).toHaveBeenCalled();
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should throw error when apiKey is missing", () => {
+      const connector = alchemyAuth({} as any);
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+
+      expect(() => connectorInstance.getAuthClient()).toThrow(
+        "Authentication required",
+      );
+    });
+  });
+
+  describe("Storage Synchronization", () => {
+    it("should persist session after setting auth session", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      // Give time for async persistence
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockStorage.setItem).toHaveBeenCalled();
+    });
+
+    it("should persist session after connecting", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      await connectorInstance.connect();
+
+      expect(mockStorage.setItem).toHaveBeenCalled();
+    });
+
+    it("should persist chain change", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia, mainnet],
+        transports: {
+          [sepolia.id]: http(),
+          [mainnet.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      await connectorInstance.switchChain!({ chainId: mainnet.id });
+
+      expect(mockStorage.setItem).toHaveBeenCalled();
+    });
+
+    it("should handle persistence failure during connect gracefully", async () => {
+      mockStorage.setItem.mockRejectedValue(new Error("Storage full"));
+
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      // Should not throw even if persistence fails
+      await expect(connectorInstance.connect()).resolves.toBeDefined();
+    });
+
+    it("should handle persistence failure during chain switch gracefully", async () => {
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia, mainnet],
+        transports: {
+          [sepolia.id]: http(),
+          [mainnet.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      connectorInstance.setAuthSession(mockAuthSession);
+
+      // Make storage fail after initial connect
+      await connectorInstance.connect();
+      mockStorage.setItem.mockRejectedValue(new Error("Storage full"));
+
+      // Should not throw even if persistence fails
+      await expect(
+        connectorInstance.switchChain!({ chainId: mainnet.id }),
+      ).resolves.toBeDefined();
+    });
+
+  });
+
+  describe("Session Restoration Edge Cases", () => {
+    it("should clean up storage when restore fails", async () => {
+      const persistedSession = {
+        version: 1,
+        chainId: sepolia.id,
+        authSessionState: JSON.stringify({
+          type: "email",
+          bundle: "invalid-bundle",
+          expirationDateMs: Date.now() + 60 * 60 * 1000,
+          user: { address: TEST_ADDRESS },
+        }),
+      };
+
+      mockStorage.getItem.mockResolvedValue(JSON.stringify(persistedSession));
+      mockAuthClient.restoreAuthSession = vi
+        .fn()
+        .mockRejectedValue(new Error("Invalid bundle"));
+
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      await connectorInstance.setup?.();
+
+      // Give time for async restoration
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockStorage.removeItem).toHaveBeenCalled();
+    });
+
+    it("should clean up storage when restored session is null", async () => {
+      const persistedSession = {
+        version: 1,
+        chainId: sepolia.id,
+        authSessionState: JSON.stringify({
+          type: "email",
+          bundle: "test-bundle",
+          expirationDateMs: Date.now() + 60 * 60 * 1000,
+          user: { address: TEST_ADDRESS },
+        }),
+      };
+
+      mockStorage.getItem.mockResolvedValue(JSON.stringify(persistedSession));
+      mockAuthClient.restoreAuthSession = vi.fn().mockResolvedValue(null);
+
+      const connector = alchemyAuth({ apiKey: "test-key" });
+      const config = createConfig({
+        chains: [sepolia],
+        transports: {
+          [sepolia.id]: http(),
+        },
+        connectors: [connector],
+        storage: mockStorage,
+      });
+
+      const connectorInstance = config.connectors[0] as AlchemyAuthConnector;
+      await connectorInstance.setup?.();
+
+      // Give time for async restoration
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockStorage.removeItem).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/connectors-web/tests/index.test.ts
+++ b/packages/connectors-web/tests/index.test.ts
@@ -1,9 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("connectors-web package", () => {
-  it.skip("placeholder test - replace with actual tests later", () => {
-    // This is a placeholder test to prevent "no tests found" errors
-    // Remove .skip and add real tests when implementing package functionality
-    expect(true).toBe(true);
-  });
-});

--- a/packages/connectors-web/vitest.config.ts
+++ b/packages/connectors-web/vitest.config.ts
@@ -1,12 +1,14 @@
-import { defineProject, mergeConfig } from "vitest/config";
-import { sharedConfig } from "../../.vitest/vitest.shared";
+import { defineProject } from "vitest/config";
 
-export default mergeConfig(
-  // @ts-ignore this does work
-  sharedConfig,
-  defineProject({
-    test: {
-      name: "alchemy/connectors-web",
-    },
-  }),
-);
+export default defineProject({
+  test: {
+    name: "alchemy/connectors-web",
+    globals: true,
+    include: ["tests/**/*.test.ts"],
+    // Skip blockchain setup for unit tests - connector tests don't need anvil
+    setupFiles: [],
+    globalSetup: undefined,
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
Adding docs/test for `alchemyAuth` and also emitting a events on accounts changing.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `alchemyAuth` connector for improved configuration, documentation, and testing. It enhances the connector's functionality, adds new features, and updates related tests to ensure reliability.

### Detailed summary
- Replaced `mergeConfig` with `defineProject` in `vitest.config.ts`.
- Updated `alchemyAuth` documentation with detailed usage examples and features.
- Added configuration options for `alchemyAuth` including `globals` and `include`.
- Enhanced type definitions and added detailed comments in `authSessionStorage.ts`.
- Improved session management with new methods for persisting and clearing auth sessions.
- Expanded tests in `alchemyAuth.test.ts` to cover session management, connection flow, and error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->