### PR TITLE
fix: lookup vercel base branch by branch name instead of PR id

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -36,14 +36,16 @@ if [ -n "$SKIP_BRANCH" ] && [ -n "$GITHUB_TOKEN" ]; then
 
     # Search for open PRs from this branch
     API_URL="https://api.github.com/repos/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG/pulls?state=open&head=$VERCEL_GIT_REPO_OWNER:$VERCEL_GIT_COMMIT_REF"
-    SEARCH_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$API_URL")
+    PR_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$API_URL")
 
-    # Extract first PR from array response
-    PR_RESPONSE=$(echo "$SEARCH_RESPONSE" | grep -A 100 '"base"' | head -110)
+    # The response is an array, but we'll just look for the first base.ref in it
+    # This works because we're searching for a specific branch which should have only one PR
   fi
 
   # Extract base.ref from the PR response
   if [ -n "$PR_RESPONSE" ]; then
+    # Look for the first occurrence of "base": { ... "ref": "branch" ... }
+    # This works for both single PR responses and array responses
     PR_BASE=$(echo "$PR_RESPONSE" | grep -A 5 '"base"' | grep '"ref"' | head -1 | sed 's/.*"ref"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
     if [ -n "$PR_BASE" ]; then


### PR DESCRIPTION
When creating a new PR, Vercel triggers a build immediately but `VERCEL_GIT_PULL_REQUEST_ID` is empty on the first push. This is a race condition where Vercel's webhook fires before GitHub has fully processed the PR creation and notified Vercel about it. The PR id is used to determine the base branch in order to skip if it's v5.

This caused Vercel to incorrectly build PRs targeting `moldy/v5-base` on their initial push, even though the subsequent build would correctly skip (since the PR id is present).

Added fallback method to `scripts/vercel-ignore-build.sh` that searches for PRs by branch name when `VERCEL_GIT_PULL_REQUEST_ID` is not yet available using github's REST APIs.

Tested script locally and with this new branch, but there may be some more friction :/ 

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `scripts/vercel-ignore-build.sh` script to improve the handling of pull requests (PRs) by checking for a PR ID and allowing for branch name lookups, enhancing the logic for skipping builds based on specified conditions.

### Detailed summary
- Updated PR checking logic to first look for a PR ID.
- Added a method to find PRs by branch name if no PR ID is available.
- Improved error handling for GitHub API responses.
- Simplified conditions for skipping builds based on branch names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->