### PR TITLE
fix(rn-signer): switch back to session stamper after using passkey

### DIFF
--- a/account-kit/rn-signer/src/client.ts
+++ b/account-kit/rn-signer/src/client.ts
@@ -61,12 +61,13 @@ export type ExportWalletParams = {
 
 export type ExportWalletResult = string;
 
+const SESSION_STAMPER = NativeTEKStamper;
+
 // TODO: need to emit events
 export class RNSignerClient extends BaseSignerClient<
   ExportWalletParams,
   string
 > {
-  private stamper = NativeTEKStamper;
   oauthCallbackUrl: string;
   rpId: string | undefined;
   private validAuthenticatingTypes: AuthenticatingEventMetadata["type"][] = [
@@ -80,7 +81,7 @@ export class RNSignerClient extends BaseSignerClient<
       RNSignerClientParamsSchema.parse(params);
 
     super({
-      stamper: NativeTEKStamper,
+      stamper: SESSION_STAMPER,
       rootOrgId: rootOrgId ?? "24c1acf5-810f-41e0-a503-d5d13fa8e830",
       connection,
     });
@@ -93,7 +94,7 @@ export class RNSignerClient extends BaseSignerClient<
     args: Omit<OtpParams, "targetPublicKey">,
   ): Promise<SubmitOtpCodeResponse> {
     this.eventEmitter.emit("authenticating", { type: "otpVerify" });
-    const publicKey = await this.stamper.init();
+    const publicKey = await this.initSessionStamper();
 
     const response = await this.request("/v1/otp", {
       ...args,
@@ -130,7 +131,7 @@ export class RNSignerClient extends BaseSignerClient<
     params: Omit<EmailAuthParams, "targetPublicKey">,
   ): Promise<{ orgId: string; otpId?: string; multiFactors?: MfaFactor[] }> {
     this.eventEmitter.emit("authenticating", { type: "email" });
-    const targetPublicKey = await this.stamper.init();
+    const targetPublicKey = await this.initSessionStamper();
 
     try {
       return await this.request("/v1/auth", {
@@ -156,7 +157,7 @@ export class RNSignerClient extends BaseSignerClient<
   ): Promise<{ orgId: string; otpId?: string }> {
     this.eventEmitter.emit("authenticating", { type: "sms" });
     const { phone } = params;
-    const targetPublicKey = await this.stamper.init();
+    const targetPublicKey = await this.initSessionStamper();
 
     return this.request("/v1/auth", {
       phone,
@@ -169,7 +170,7 @@ export class RNSignerClient extends BaseSignerClient<
   ): Promise<JwtResponse> {
     this.eventEmitter.emit("authenticating", { type: "custom-jwt" });
 
-    const publicKey = await this.stamper.init();
+    const publicKey = await this.initSessionStamper();
     return this.request("/v1/auth-jwt", {
       jwt: args.jwt,
       targetPublicKey: publicKey,
@@ -194,9 +195,9 @@ export class RNSignerClient extends BaseSignerClient<
       type: params.authenticatingType,
     });
 
-    await this.stamper.init();
+    await this.initSessionStamper();
 
-    const result = await this.stamper.injectCredentialBundle(params.bundle);
+    const result = await SESSION_STAMPER.injectCredentialBundle(params.bundle);
 
     if (!result) {
       throw new Error("Failed to inject credential bundle");
@@ -223,7 +224,7 @@ export class RNSignerClient extends BaseSignerClient<
     this.eventEmitter.emit("authenticating", { type: "oauth" });
 
     const oauthParams = args;
-    const turnkeyPublicKey = await this.stamper.init();
+    const turnkeyPublicKey = await this.initSessionStamper();
     const oauthCallbackUrl = this.oauthCallbackUrl;
     const oauthConfig = await this.getOauthConfig();
     const providerUrl = await this.getOauthProviderUrl({
@@ -294,8 +295,8 @@ export class RNSignerClient extends BaseSignerClient<
 
   override async disconnect(): Promise<void> {
     this.user = undefined;
-    this.stamper.clear();
-    await this.stamper.init();
+    SESSION_STAMPER.clear();
+    await this.initSessionStamper();
   }
 
   /**
@@ -426,7 +427,7 @@ export class RNSignerClient extends BaseSignerClient<
   }
 
   override targetPublicKey(): Promise<string> {
-    return this.stamper.init();
+    return this.initSessionStamper();
   }
 
   protected override getWebAuthnAttestation = async (
@@ -461,14 +462,34 @@ export class RNSignerClient extends BaseSignerClient<
   };
 
   protected override getOauthConfig = async (): Promise<OauthConfig> => {
-    const publicKey = await this.stamper.init();
+    const currentStamper = this.turnkeyClient.stamper;
+    const publicKey = await this.initSessionStamper();
 
+    // swap the stamper back in case the user logged in with a different stamper (passkeys)
+    this.setStamper(currentStamper);
     const nonce = this.getOauthNonce(publicKey);
     return this.request("/v1/prepare-oauth", { nonce });
   };
 
+  private initSessionStamperPromise: Promise<string> | null = null;
+
   protected override async initSessionStamper(): Promise<string> {
-    return this.stamper.init();
+    if (this.initSessionStamperPromise) {
+      return this.initSessionStamperPromise;
+    }
+
+    this.initSessionStamperPromise = (async () => {
+      await SESSION_STAMPER.init();
+      this.setStamper(SESSION_STAMPER);
+      return SESSION_STAMPER.publicKey()!;
+    })();
+
+    try {
+      const result = await this.initSessionStamperPromise;
+      return result;
+    } finally {
+      this.initSessionStamperPromise = null;
+    }
   }
 
   protected override async initWebauthnStamper(


### PR DESCRIPTION
Fixes a state management bug in which once the react native signer client switched to the passkey stamper, it could never switch back to the session stamper. The new logic is made to look very similar to that of the web signer client.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `RNSignerClient` class to improve the handling of the `stamper` instance by introducing a new constant `SESSION_STAMPER` and modifying how session stamping is initialized and used throughout the class.

### Detailed summary
- Introduced `SESSION_STAMPER` constant.
- Replaced `this.stamper` with `SESSION_STAMPER` in multiple methods.
- Added `initSessionStamper` method to manage stamper initialization.
- Updated methods to use `initSessionStamper()` instead of `this.stamper.init()`.
- Enhanced error handling and session management for the stamper.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->