### PR TITLE
fix: detect if 7702 account is delgated to unexpected addr

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/account/common/modularAccountV2Base.ts
+++ b/account-kit/smart-contracts/src/ma-v2/account/common/modularAccountV2Base.ts
@@ -238,7 +238,9 @@ export async function createMAv2Base<
     );
 
   const isAccountDeployed: () => Promise<boolean> = async () => {
-    const code = await client.getCode({ address: accountAddress });
+    const code = (
+      await client.getCode({ address: accountAddress })
+    )?.toLowerCase();
     const is7702Delegated = code?.startsWith("0xef0100");
 
     if (!is7702Delegated) {
@@ -257,7 +259,7 @@ export async function createMAv2Base<
     const expectedCode = concatHex([
       "0xef0100",
       await config.getImplementationAddress(),
-    ]);
+    ]).toLowerCase();
     return code === expectedCode;
   };
 


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `isAccountDeployed` function in the `modularAccountV2Base.ts` file to handle cases where accounts are delegated to a third party, ensuring the client is properly initialized in 7702 mode.

### Detailed summary
- Added logic to check if the account code starts with `0xef0100` to identify delegated accounts.
- Threw a `BaseError` if the client is missing the implementation address for delegated accounts.
- Compared the retrieved account code with the expected code based on the implementation address.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->