### PR TITLE
feat: handle session expiration and make it configurable

### DIFF
--- a/docs/pages/reference/alchemy/wagmi-core/functions/loginWithOauth.mdx
+++ b/docs/pages/reference/alchemy/wagmi-core/functions/loginWithOauth.mdx
@@ -45,6 +45,12 @@ import { loginWithOauth } from "@alchemy/wagmi-core";
 
 - Authentication flow mode (defaults to "popup")
 
+### parameters.sessionExpirationMs
+
+`number | undefined`
+
+- The length of the session in milliseconds (defaults to 15 minutes)
+
 ## Returns
 
 `Promise<LoginWithOauthReturnType>`

--- a/docs/pages/reference/alchemy/wagmi-core/functions/sendEmailOtp.mdx
+++ b/docs/pages/reference/alchemy/wagmi-core/functions/sendEmailOtp.mdx
@@ -33,6 +33,12 @@ import { sendEmailOtp } from "@alchemy/wagmi-core";
 
 - The user's email address to receive the OTP
 
+### parameters.sessionExpirationMs
+
+`number | undefined`
+
+- The length of the session in milliseconds (defaults to 15 minutes)
+
 ## Returns
 
 `Promise<SendEmailOtpReturnType>`

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,6 +46,7 @@
     "@alchemy/aa-infra": "*",
     "@alchemy/common": "*",
     "@turnkey/http": "^3.13.0",
+    "eventemitter3": "^5.0.1",
     "viem": "2.29.2"
   },
   "publishConfig": {

--- a/packages/auth/tests/auth-client.test.ts
+++ b/packages/auth/tests/auth-client.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { AuthClient } from "../src/authClient.js";
 import {
-  AuthSession,
+  AuthClient,
   DEFAULT_SESSION_EXPIRATION_MS,
-} from "../src/authSession.js";
+} from "../src/authClient.js";
+import { AuthSession } from "../src/authSession.js";
 import type {
   AuthSessionState,
   User,
@@ -185,6 +185,7 @@ describe("AuthClient", () => {
     });
 
     it("should load valid passkey session state", async () => {
+      const expirationDateMs = Date.now() + 60 * 60 * 1000; // 1 hour from now
       // Mock the loginWithPasskey method to avoid the "not implemented" error
       const mockLoginWithPasskey = vi.spyOn(authClient, "loginWithPasskey");
       const mockAuthSession = await AuthSession.create({
@@ -194,13 +195,14 @@ describe("AuthClient", () => {
         idToken: mockUser.idToken,
         authType: "passkey",
         credentialId: "test-passkey-credential",
+        expirationDateMs,
       });
       mockLoginWithPasskey.mockResolvedValue(mockAuthSession);
 
       const validPasskeyState: AuthSessionState = {
         type: "passkey",
         user: mockUser,
-        expirationDateMs: Date.now() + 60 * 60 * 1000, // 1 hour from now
+        expirationDateMs,
         credentialId: "test-passkey-credential",
       };
 

--- a/packages/connectors-web/package.json
+++ b/packages/connectors-web/package.json
@@ -40,17 +40,18 @@
     "test:run": "vitest run"
   },
   "peerDependencies": {
-    "wagmi": "^2",
     "@wagmi/core": "^2",
-    "viem": "^2"
+    "viem": "^2",
+    "wagmi": "^2"
   },
   "devDependencies": {
+    "eventemitter3": "^5.0.1",
     "typescript-template": "*"
   },
   "dependencies": {
-    "@alchemy/common": "*",
     "@alchemy/auth": "*",
     "@alchemy/auth-web": "*",
+    "@alchemy/common": "*",
     "@alchemy/wagmi-core": "*",
     "@alchemy/wallet-apis": "*",
     "viem": "2.29.2"

--- a/packages/connectors-web/tests/alchemyAuth.test.ts
+++ b/packages/connectors-web/tests/alchemyAuth.test.ts
@@ -5,6 +5,7 @@ import { sepolia, mainnet } from "viem/chains";
 import { http, type Address } from "viem";
 import type { AuthClient, AuthSession } from "@alchemy/auth";
 import type { Connector } from "wagmi";
+import EventEmitter from "eventemitter3";
 
 // Type helper to get the connector instance type with custom properties
 type AlchemyAuthConnector = Connector & {
@@ -30,6 +31,7 @@ describe("alchemyAuth connector", () => {
     mockProvider = {
       request: vi.fn(),
     };
+    const emitter = new EventEmitter();
     mockAuthSession = {
       getAddress: vi.fn().mockReturnValue(TEST_ADDRESS),
       getProvider: vi.fn().mockReturnValue(mockProvider),
@@ -45,7 +47,13 @@ describe("alchemyAuth connector", () => {
           user: { address: TEST_ADDRESS },
         }),
       ),
-      disconnect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(() => emitter.emit("disconnect")),
+      on: (event: any, listener: any) => {
+        emitter.on(event, listener);
+        return () => {
+          emitter.removeListener(event, listener);
+        };
+      },
     } as any;
     mockAuthClient = {
       restoreAuthSession: vi.fn().mockResolvedValue(mockAuthSession),

--- a/packages/wagmi-core/src/actions/loginWithOauth.ts
+++ b/packages/wagmi-core/src/actions/loginWithOauth.ts
@@ -8,6 +8,8 @@ export type LoginWithOauthParameters = {
   redirectUrl?: string;
   /** Whether to use popup (default) or redirect flow */
   mode?: "popup" | "redirect";
+  /** The length of the session in milliseconds. Defaults to 15 minutes. */
+  sessionExpirationMs?: number;
 };
 
 export type LoginWithOauthReturnType = void;
@@ -20,6 +22,7 @@ export type LoginWithOauthReturnType = void;
  * @param {string} parameters.provider - The OAuth provider to use
  * @param {string} [parameters.redirectUrl] - Optional redirect URL after OAuth completion
  * @param {"popup" | "redirect"} [parameters.mode] - Authentication flow mode (defaults to "popup")
+ * @param {number | undefined} [parameters.sessionExpirationMs] - The length of the session in milliseconds (defaults to 15 minutes)
  * @returns {Promise<LoginWithOauthReturnType>} Promise that resolves when authentication completes and connection is established
  */
 export async function loginWithOauth(
@@ -33,6 +36,7 @@ export async function loginWithOauth(
     type: "oauth",
     authProviderId: parameters.provider,
     mode: parameters.mode ?? "popup",
+    sessionExpirationMs: parameters.sessionExpirationMs,
   });
 
   connector.setAuthSession(authSession);

--- a/packages/wagmi-core/src/actions/sendEmailOtp.ts
+++ b/packages/wagmi-core/src/actions/sendEmailOtp.ts
@@ -2,7 +2,10 @@ import { type Config } from "@wagmi/core";
 import { resolveAlchemyAuthConnector } from "../utils/resolveAuthConnector.js";
 
 export type SendEmailOtpParameters = {
+  /** The user's email address to receive the OTP */
   email: string;
+  /** The length of the session in milliseconds. Defaults to 15 minutes. */
+  sessionExpirationMs?: number;
 };
 
 export type SendEmailOtpReturnType = void;
@@ -13,6 +16,7 @@ export type SendEmailOtpReturnType = void;
  * @param {Config} config - The shared Wagmi/Alchemy config
  * @param {SendEmailOtpParameters} parameters - Parameters for the OTP request
  * @param {string} parameters.email - The user's email address to receive the OTP
+ * @param {number | undefined} [parameters.sessionExpirationMs] - The length of the session in milliseconds (defaults to 15 minutes)
  * @returns {Promise<SendEmailOtpReturnType>} Promise that resolves when the OTP has been sent
  */
 export async function sendEmailOtp(
@@ -22,6 +26,8 @@ export async function sendEmailOtp(
   const { connector } = resolveAlchemyAuthConnector(config);
 
   const authClient = connector.getAuthClient();
-  // TODO(v5): this fails if the account doesn't exist yet. do we want to handle creating accounts here?
-  await authClient.sendEmailOtp({ email: parameters.email });
+  await authClient.sendEmailOtp({
+    email: parameters.email,
+    sessionExpirationMs: parameters.sessionExpirationMs,
+  });
 }


### PR DESCRIPTION
`AuthSession` now emits events on disconnection, including when its session expires. the `alchemyAuth` connector listens to these events and disconnects itself when they occur.

Additionally, expose the option allowing users to choose how long their requested sessions are.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces session expiration management and event handling to the authentication system. It adds a new dependency, `eventemitter3`, and enhances functions to support session expiration parameters in various authentication methods.

### Detailed summary
- Added `eventemitter3` dependency.
- Introduced `sessionExpirationMs` parameter for `sendEmailOtp` and `loginWithOauth` functions.
- Updated `AuthSession` to handle expiration and emit disconnect events.
- Refactored `AuthClient` to manage session expiration dates.
- Enhanced tests to cover new session expiration logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->