### PR TITLE
feat: update wallet-api types for cross-chain wallet client support 

### DIFF
--- a/account-kit/wallet-client/package.json
+++ b/account-kit/wallet-client/package.json
@@ -47,7 +47,7 @@
     "@aa-sdk/core": "^4.69.0",
     "@account-kit/infra": "^4.69.0",
     "@account-kit/smart-contracts": "^4.69.0",
-    "@alchemy/wallet-api-types": "0.1.0-alpha.16",
+    "@alchemy/wallet-api-types": "0.1.0-alpha.17",
     "deep-equal": "^2.2.3",
     "ox": "^0.6.12"
   },

--- a/account-kit/wallet-client/src/experimental/swapActionsDecorator.e2e.test.ts
+++ b/account-kit/wallet-client/src/experimental/swapActionsDecorator.e2e.test.ts
@@ -1,6 +1,8 @@
+import { base } from "viem/chains";
 import { createSmartWalletClient } from "../client/index.js";
 import { swapActions } from "./swapActionsDecorator.js";
 import { alchemy, arbitrum } from "@account-kit/infra";
+import { size, toHex } from "viem";
 
 describe("swapActions decorator tests", () => {
   const transport = alchemy(
@@ -13,7 +15,7 @@ describe("swapActions decorator tests", () => {
         },
   );
 
-  it("should successfully request a quote", async () => {
+  it("should successfully request a same-chain quote", async () => {
     const testAccountAddr = "0x0d1Ea60Dddd2a76F3a3afD6d78660d366C6A30c0";
 
     const client = createSmartWalletClient({
@@ -52,5 +54,50 @@ describe("swapActions decorator tests", () => {
     expect(quote.quote.fromAmount).toBeDefined();
     expect(quote.quote.minimumToAmount).toBeDefined();
     expect(quote.quote.expiry).toBeDefined();
+    expect(quote.callId).not.toBeDefined();
+  }, 30_000);
+
+  it("should successfully request a cross-chain quote", async () => {
+    const testAccountAddr = "0x0d1Ea60Dddd2a76F3a3afD6d78660d366C6A30c0";
+
+    const client = createSmartWalletClient({
+      transport,
+      chain: arbitrum,
+      signer: {
+        getAddress: async () => testAccountAddr,
+        signMessage: async () => {
+          throw new Error("Not implemented");
+        },
+        signTypedData: async () => {
+          throw new Error("Not implemented");
+        },
+        signerType: "test",
+        inner: {},
+      },
+    }).extend(swapActions);
+
+    const account = await client.requestAccount({
+      creationHint: {
+        accountType: "7702",
+      },
+    });
+
+    const USDC_ARB = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+    const NATIVE_TOKEN_ADDR = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEee"; // from ERC-7528
+
+    const quote = await client.requestQuoteV0({
+      from: account.address,
+      fromToken: USDC_ARB,
+      toToken: NATIVE_TOKEN_ADDR,
+      toChainId: toHex(base.id),
+      minimumToAmount: "0x5AF3107A4000",
+    });
+
+    expect(quote.quote).toBeDefined();
+    expect(quote.quote.fromAmount).toBeDefined();
+    expect(quote.quote.minimumToAmount).toBeDefined();
+    expect(quote.quote.expiry).toBeDefined();
+    expect(quote.callId).toBeDefined();
+    expect(size(quote.callId!)).toBeGreaterThan(64);
   }, 30_000);
 });


### PR DESCRIPTION
in `account-kit/wallet-client`:
- Updates wallet-api-types
- Adds a check to ensure callId is not returned from same-chain quote requests
- Adds a test to ensure callId is returned from cross-chain quote requests

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@alchemy/wallet-api-types` version and enhances the test suite for the `swapActions` decorator by adding a new test for cross-chain quotes while renaming an existing test for clarity.

### Detailed summary
- Updated `@alchemy/wallet-api-types` from `0.1.0-alpha.16` to `0.1.0-alpha.17`.
- Renamed test from "should successfully request a quote" to "should successfully request a same-chain quote".
- Added a new test for requesting a cross-chain quote.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->