### PR TITLE
fix: github action out of space issue

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -48,13 +48,13 @@ jobs:
       
       - name: Free up disk space
         run: |
-          echo "Disk space before cleanup: "
+          echo "Disk space before cleanup:"
           df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-          echo "Disk space after cleanup: "
+          echo "Disk space after cleanup:"
           df -h
           
       - name: Setup


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing disk space usage in the GitHub Actions workflow by adding a cleanup step before the setup process.

### Detailed summary
- Added a new step named `Free up disk space` to the workflow.
- The step includes commands to:
  - Display disk space before cleanup.
  - Remove specific directories: `/usr/share/dotnet`, `/opt/ghc`, and `/opt/hostedtoolcache/CodeQL`.
  - Prune all unused Docker images.
  - Display disk space after cleanup.
- Removed the `Setup` step that used the action from `./.github/actions/setup`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->