### PR TITLE
fix: import type from wallet-api-types

### DIFF
--- a/account-kit/wallet-client/src/client/actions/signPreparedCalls.ts
+++ b/account-kit/wallet-client/src/client/actions/signPreparedCalls.ts
@@ -3,10 +3,10 @@ import { BaseError, type SmartAccountSigner } from "@aa-sdk/core";
 import { signSignatureRequest } from "./signSignatureRequest.js";
 import type { Static } from "typebox";
 import type { wallet_sendPreparedCalls } from "@alchemy/wallet-api-types/rpc";
-import {
-  type PreparedCall_Authorization,
-  type PreparedCall_UserOpV060,
-  type PreparedCall_UserOpV070,
+import type {
+  PreparedCall_Authorization,
+  PreparedCall_UserOpV060,
+  PreparedCall_UserOpV070,
 } from "@alchemy/wallet-api-types";
 import { metrics } from "../../metrics.js";
 import { assertNever } from "../../utils.js";


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying type imports in the `signPreparedCalls.ts` file to streamline the import statements for better clarity and organization.

### Detailed summary
- Removed unnecessary `type` keyword from the import statements for `PreparedCall_Authorization`, `PreparedCall_UserOpV060`, and `PreparedCall_UserOpV070`.
- Consolidated the import path for types from `@alchemy/wallet-api-types`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->