### PR TITLE
fix: wallet client requires wallet-api-types as a non-dev dep

### DIFF
--- a/account-kit/wallet-client/package.json
+++ b/account-kit/wallet-client/package.json
@@ -47,11 +47,11 @@
     "@aa-sdk/core": "^4.75.3",
     "@account-kit/infra": "^4.75.3",
     "@account-kit/smart-contracts": "^4.75.3",
+    "@alchemy/wallet-api-types": "0.1.0-alpha.18",
     "deep-equal": "^2.2.3",
     "ox": "^0.6.12"
   },
   "devDependencies": {
-    "@alchemy/wallet-api-types": "0.1.0-alpha.18",
     "@types/deep-equal": "^1.0.4",
     "@types/node": "^24.0.11",
     "bun": "^1.2.18",


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `package.json` file for the `wallet-client` by adding a new dependency and removing it from the `devDependencies`. 

### Detailed summary
- Added `@alchemy/wallet-api-types` version `0.1.0-alpha.18` to `dependencies`.
- Removed `@alchemy/wallet-api-types` version `0.1.0-alpha.18` from `devDependencies`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->