### PR TITLE
docs: move session keys section under transactions

### DIFF
--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -210,6 +210,14 @@ navigation:
             path: wallets/pages/transactions/sponsor-gas/index.mdx
           - page: Pay gas with any token
             path: wallets/pages/transactions/pay-gas-with-any-token/index.mdx
+          - section: Session Keys
+            contents:
+              - page: Overview
+                path: wallets/pages/smart-wallets/session-keys/index.mdx
+              - page: Using SDK
+                path: wallets/pages/smart-wallets/session-keys/sdk.mdx
+              - page: Using API
+                path: wallets/pages/smart-wallets/session-keys/api.mdx
           - page: "[NEW] Same-chain swaps"
             path: wallets/pages/transactions/swap-tokens/index.mdx
           - page: "[NEW] Cross-chain swaps"
@@ -284,14 +292,6 @@ navigation:
                   - api: Signer API Endpoints
                     api-name: accounts
                     flattened: true
-              - section: Session Keys
-                contents:
-                  - page: Overview
-                    path: wallets/pages/smart-wallets/session-keys/index.mdx
-                  - page: Using SDK
-                    path: wallets/pages/smart-wallets/session-keys/sdk.mdx
-                  - page: Using API
-                    path: wallets/pages/smart-wallets/session-keys/api.mdx
               - page: How to stamp requests
                 path: wallets/pages/smart-wallets/how-to-stamp-requests.mdx
             slug: smart-wallets


### PR DESCRIPTION
## Summary
- reposition the Session Keys section within the transactions navigation after the Pay gas with any token page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6904c3b17d0c8327ae4127c3617ba097

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on reorganizing the `docs/docs.yml` file by removing the `Session Keys` section and its contents, while adding a new page for `Pay gas with any token`. 

### Detailed summary
- Removed `Session Keys` section and its pages:
  - `Overview`
  - `Using SDK`
  - `Using API`
- Added new section for `Pay gas with any token` 
- Retained `How to stamp requests` page and its path

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->