### PR TITLE
fix: override webauthn send test timeout

### DIFF
--- a/account-kit/wallet-client/src/client/client.e2e.test.ts
+++ b/account-kit/wallet-client/src/client/client.e2e.test.ts
@@ -367,24 +367,28 @@ describe("Client E2E Tests", () => {
       expect(isValid).toBeTrue();
     });
 
-    it("should successfully send a transaction with webauthn signer and paymaster", async () => {
-      const account = await webauthClient.requestAccount();
-      const result = await webauthClient.sendCalls({
-        calls: [{ to: zeroAddress, value: "0x0" }],
-        from: account.address,
-        capabilities: {
-          // Signer is randomized, so we must sponsor the transaction
-          paymasterService: {
-            policyId: process.env.TEST_PAYMASTER_POLICY_ID!,
+    it(
+      "should successfully send a transaction with webauthn signer and paymaster",
+      async () => {
+        const account = await webauthClient.requestAccount();
+        const result = await webauthClient.sendCalls({
+          calls: [{ to: zeroAddress, value: "0x0" }],
+          from: account.address,
+          capabilities: {
+            // Signer is randomized, so we must sponsor the transaction
+            paymasterService: {
+              policyId: process.env.TEST_PAYMASTER_POLICY_ID!,
+            },
           },
-        },
-      });
+        });
 
-      const waitForResult = await webauthClient.waitForCallsStatus({
-        id: result.preparedCallIds[0],
-      });
-      expect(waitForResult.status).toBe("success");
-    });
+        const waitForResult = await webauthClient.waitForCallsStatus({
+          id: result.preparedCallIds[0],
+        });
+        expect(waitForResult.status).toBe("success");
+      },
+      { timeout: 45_000 },
+    );
   });
 
   const givenTypedData = {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refines the test case for sending a transaction using a `webauthn` signer and `paymaster`, ensuring the test is properly defined and includes a timeout setting.

### Detailed summary
- Updated the test case title for clarity.
- Reformatted the test case for better readability.
- Added a timeout of 45 seconds to the test case.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->