### PR TITLE
docs: add stateoverride preparecalls

### DIFF
--- a/docs/specs/openrpc/wallet-api/wallet-api.yaml
+++ b/docs/specs/openrpc/wallet-api/wallet-api.yaml
@@ -256,28 +256,6 @@ methods:
                       required:
                         - "sessionId"
                         - "signature"
-                stateOverride:
-                  description: |
-                    Allows changes to the state of a contract before executing the call. For example, you can modify variable values (like balances or approvals) for that call without changing the contract itself on the blockchain.
-
-                    In more technical terms, the state override set is an optional parameter that allows executing the call against a modified chain state. It is an address-to-state mapping, where each entry specifies some state to be overridden prior to executing the call.
-                  type: "object"
-                  properties:
-                    balance:
-                      type: "string"
-                      description: "Fake balance to set for the account before executing the call (<= 32 bytes)"
-                    nonce:
-                      type: "string"
-                      description: "Fake nonce to set for the account before executing the call (<= 8 bytes)."
-                    code:
-                      type: "string"
-                      description: "Fake EVM bytecode to inject into the account before executing the call."
-                    state:
-                      type: "object"
-                      description: "Fake key-value mapping to override all slots in the account storage before executing the call."
-                    stateDiff:
-                      type: "object"
-                      description: "Fake key-value mapping to override individual slots in the account storage before executing the call."
                 paymasterService:
                   allOf:
                     - anyOf:
@@ -518,6 +496,28 @@ methods:
                       pattern: "^0x(.*)$"
                   required:
                     - "nonceKey"
+                stateOverride:
+                  description: |
+                    Allows changes to the state of a contract before executing the call. For example, you can modify variable values (like balances or approvals) for that call without changing the contract itself on the blockchain.
+
+                    In more technical terms, the state override set is an optional parameter that allows executing the call against a modified chain state. It is an address-to-state mapping, where each entry specifies some state to be overridden prior to executing the call.
+                  type: "object"
+                  properties:
+                    balance:
+                      type: "string"
+                      description: "Fake balance to set for the account before executing the call (<= 32 bytes)"
+                    nonce:
+                      type: "string"
+                      description: "Fake nonce to set for the account before executing the call (<= 8 bytes)."
+                    code:
+                      type: "string"
+                      description: "Fake EVM bytecode to inject into the account before executing the call."
+                    state:
+                      type: "object"
+                      description: "Fake key-value mapping to override all slots in the account storage before executing the call."
+                    stateDiff:
+                      type: "object"
+                      description: "Fake key-value mapping to override individual slots in the account storage before executing the call."
             paymasterPermitSignature:
               anyOf:
                 - description: "Secp256k1 signature"


### PR DESCRIPTION
## Summary
- add a `stateOverride` capability to the `wallet_prepareCalls` request schema so docs match bundler overrides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_690bae7ca578832087537feb1213c625

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `stateOverride` parameter in the `wallet-api.yaml` specification, allowing users to modify the state of a contract before executing a call. This enhances the flexibility of contract interactions by enabling temporary state changes without altering the blockchain.

### Detailed summary
- Added `stateOverride` parameter with a description of its purpose.
- Defined `stateOverride` as an object with several properties:
  - `balance`: Fake balance to set for the account.
  - `nonce`: Fake nonce for the account.
  - `code`: Fake EVM bytecode to inject into the account.
  - `state`: Fake key-value mapping for account storage overrides.
  - `stateDiff`: Fake key-value mapping for individual storage slot overrides.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->