### PR TITLE
fix: fix link

### DIFF
--- a/docs/pages/resources/faqs.mdx
+++ b/docs/pages/resources/faqs.mdx
@@ -201,7 +201,7 @@ We recommend adding error handling when sending a UO to handle potential gas and
 
     Use this flow when you just need to verify user sessions created by SCAs via Smart Wallets.
 
-    1. The frontend generates a stamped request using [signer.inner.stampWhoAmI](https://www.alchemy.com/docs/wallets/reference/account-kit/signer/classes/BaseSignerClient/stampWhoami).
+    1. The frontend generates a stamped request using [signer.inner.stampWhoAmI](https://www.alchemy.com/docs/wallets/reference/account-kit/signer/classes/BaseSignerClient#stampwhoami).
     2. It sends the stamp to your backend.
     3. The backend calls Alchemy's [/signer/v1/whoami](https://www.alchemy.com/docs/node/smart-wallets/signer-api-endpoints/signer-api-endpoints/auth-user) endpoint to verify the identity.
     4. If you need to make subsequent requests, you can also avoid calling the whoami endpoint on every request. To do so, after verifying the `whoami`, the backend can issue its own session token (e.g. an HTTP-only cookie or access token). If the token is present, you can safely skip the `whoami` check.


### PR DESCRIPTION
Gensyn called out a broken link in the FAQs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a documentation file to correct a hyperlink reference related to the `stampWhoAmI` function in the `signer` class.

### Detailed summary
- Changed the hyperlink for `signer.inner.stampWhoAmI` from `#stampWhoami` to `#stampwhoami` in the `docs/pages/resources/faqs.mdx` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->