### PR TITLE
docs: update slugs to use wallets/reference path structure

### DIFF
--- a/docs/pages/bundler-api/bundler-faqs.mdx
+++ b/docs/pages/bundler-api/bundler-faqs.mdx
@@ -2,8 +2,8 @@
 title: FAQs
 description: Frequently asked questions about the Bundler
 subtitle: Frequently asked questions about the Bundler
-url: https://alchemy.com/docs/reference/bundler-faqs
-slug: reference/bundler-faqs
+url: https://alchemy.com/docs/wallets/reference/bundler-faqs
+slug: wallets/reference/bundler-faqs
 ---
 
 ## userOperation

--- a/docs/pages/bundler-api/bundler-rpc-errors.mdx
+++ b/docs/pages/bundler-api/bundler-rpc-errors.mdx
@@ -2,8 +2,8 @@
 title: Bundler RPC Errors
 description: Learn about the different Bundler error codes.
 subtitle: Learn about the different Bundler error codes.
-url: https://alchemy.com/docs/reference/bundler-rpc-errors
-slug: reference/bundler-rpc-errors
+url: https://alchemy.com/docs/wallets/reference/bundler-rpc-errors
+slug: wallets/reference/bundler-rpc-errors
 ---
 
 This document provides a list of the JSON-RPC errors that you might encounter when using the Bundler API. These are in addition to the [standard JSON-RPC error codes](/reference/error-reference#json-rpc-error-codes) returned by a bad method call.

--- a/docs/pages/bundler-api/entrypoint-revert-codes/entrypoint-v06-revert-codes.mdx
+++ b/docs/pages/bundler-api/entrypoint-revert-codes/entrypoint-v06-revert-codes.mdx
@@ -2,8 +2,8 @@
 title: EntryPoint v0.6 Revert Codes
 description: Learn about the revert codes returned by the ERC-4337 EntryPoint v0.6
 subtitle: Learn about the revert codes returned by the ERC-4337 EntryPoint v0.6
-url: https://alchemy.com/docs/reference/entrypoint-v06-revert-codes
-slug: reference/entrypoint-v06-revert-codes
+url: https://alchemy.com/docs/wallets/reference/entrypoint-v06-revert-codes
+slug: wallets/reference/entrypoint-v06-revert-codes
 ---
 
 Bundler JSON-RPC error codes are often accompanied by an additional AAxx code provided by the EntryPoint.

--- a/docs/pages/bundler-api/entrypoint-revert-codes/entrypoint-v07-revert-codes.mdx
+++ b/docs/pages/bundler-api/entrypoint-revert-codes/entrypoint-v07-revert-codes.mdx
@@ -2,8 +2,8 @@
 title: EntryPoint v0.7 Revert Codes
 description: Learn about the revert codes returned by the ERC-4337 EntryPoint v0.7
 subtitle: Learn about the revert codes returned by the ERC-4337 EntryPoint v0.7
-url: https://alchemy.com/docs/reference/entrypoint-v07-revert-codes
-slug: reference/entrypoint-v07-revert-codes
+url: https://alchemy.com/docs/wallets/reference/entrypoint-v07-revert-codes
+slug: wallets/reference/entrypoint-v07-revert-codes
 ---
 
 Bundler JSON-RPC error codes are often accompanied by an additional AAxx code provided by the EntryPoint.

--- a/docs/pages/gas-manager-admin-api/gas-manager-errors.mdx
+++ b/docs/pages/gas-manager-admin-api/gas-manager-errors.mdx
@@ -2,8 +2,8 @@
 title: Gas Manager Errors
 description: Learn about the most common Gas Manager errors.
 subtitle: Learn about the most common Gas Manager errors.
-url: https://alchemy.com/docs/reference/gas-manager-errors
-slug: reference/gas-manager-errors
+url: https://alchemy.com/docs/wallets/reference/gas-manager-errors
+slug: wallets/reference/gas-manager-errors
 ---
 
 ### Invalid Policy ID. Please ensure you're sending requests with the api key associated with the policy's app, and that the policy is active.

--- a/docs/pages/gas-manager-admin-api/gas-manager-faqs.mdx
+++ b/docs/pages/gas-manager-admin-api/gas-manager-faqs.mdx
@@ -2,8 +2,8 @@
 title: FAQs
 description: Frequently asked questions about Gas Manager
 subtitle: Frequently asked questions about Gas Manager
-url: https://alchemy.com/docs/reference/gas-manager-faqs
-slug: reference/gas-manager-faqs
+url: https://alchemy.com/docs/wallets/reference/gas-manager-faqs
+slug: wallets/reference/gas-manager-faqs
 ---
 
 ## Usage Limits

--- a/docs/pages/smart-wallets/how-to-stamp-requests.mdx
+++ b/docs/pages/smart-wallets/how-to-stamp-requests.mdx
@@ -2,8 +2,8 @@
 title: How to stamp requests
 description: Overview for how to send stamped (or verified) requests required for using Wallet APIs directly.
 subtitle: Overview for how to send stamped (or verified) requests required for using Wallet APIs directly.
-url: https://alchemy.com/docs/reference/how-to-stamp-requests
-slug: reference/how-to-stamp-requests
+url: https://alchemy.com/docs/wallets/reference/how-to-stamp-requests
+slug: wallets/reference/how-to-stamp-requests
 ---
 
 ### What is stamping?

--- a/docs/pages/smart-wallets/quickstart/index.mdx
+++ b/docs/pages/smart-wallets/quickstart/index.mdx
@@ -2,8 +2,8 @@
 title: Wallets API Quickstart
 description: How to go from zero to hero with Wallet APIs
 subtitle: Learn to interact with Wallet APIs
-url: https://alchemy.com/docs/reference/smart-wallet-quickstart
-slug: reference/smart-wallet-quickstart
+url: https://alchemy.com/docs/wallets/reference/smart-wallet-quickstart
+slug: wallets/reference/smart-wallet-quickstart
 ---
 
 This quickstart shows you how to prepare and send a User Operation (UO) in minutes.

--- a/docs/pages/smart-wallets/session-keys/api.mdx
+++ b/docs/pages/smart-wallets/session-keys/api.mdx
@@ -1,8 +1,8 @@
 ---
 title: Session Keys (API)
 subtitle: Learn how to use session keys using any RPC client
-url: https://alchemy.com/docs/reference/wallet-apis-session-keys/api
-slug: reference/wallet-apis-session-keys/api
+url: https://alchemy.com/docs/wallets/reference/wallet-apis-session-keys/api
+slug: wallets/reference/wallet-apis-session-keys/api
 ---
 
 ### 1. Request an Account for the Owner Signer

--- a/docs/pages/smart-wallets/session-keys/index.mdx
+++ b/docs/pages/smart-wallets/session-keys/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Session Keys
 subtitle: Learn how to use session keys with Wallet APIs
-url: https://alchemy.com/docs/reference/wallet-apis-session-keys
-slug: reference/wallet-apis-session-keys
+url: https://alchemy.com/docs/wallets/reference/wallet-apis-session-keys
+slug: wallets/reference/wallet-apis-session-keys
 ---
 
 Session keys are a powerful feature of the Alchemy Wallets API that allow you to create a session for a user's smart account with specific permissions. This enables secure, permissioned access to the user's wallet, allowing your app's server to perform actions on behalf of the user without needing their private key. Session keys allow another account to operate on a user's smart account with given permissions. After creating a session, you will be able to sign transactions for the generated wallet within the defined permissions using that session key. See [here for a list of permissions!](#permission-types)

--- a/docs/pages/smart-wallets/session-keys/sdk.mdx
+++ b/docs/pages/smart-wallets/session-keys/sdk.mdx
@@ -1,8 +1,8 @@
 ---
 title: Session Keys (SDK)
 subtitle: Learn how to use session keys using the Wallet Client SDK
-url: https://alchemy.com/docs/reference/wallet-apis-session-keys/sdk
-slug: reference/wallet-apis-session-keys/sdk
+url: https://alchemy.com/docs/wallets/reference/wallet-apis-session-keys/sdk
+slug: wallets/reference/wallet-apis-session-keys/sdk
 ---
 
 ### 1. Install Prerequisites


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the URLs and slugs in various documentation files related to the Bundler and Gas Manager, changing them to reflect a new structure under the `wallets` path.

### Detailed summary
- Updated URLs and slugs in `bundler-faqs.mdx` to point to `wallets/reference/bundler-faqs`
- Updated URLs and slugs in `gas-manager-faqs.mdx` to point to `wallets/reference/gas-manager-faqs`
- Updated URLs and slugs in `sdk.mdx` to point to `wallets/reference/wallet-apis-session-keys/sdk`
- Updated URLs and slugs in `api.mdx` to point to `wallets/reference/wallet-apis-session-keys/api`
- Updated URLs and slugs in `index.mdx` (quickstart) to point to `wallets/reference/smart-wallet-quickstart`
- Updated URLs and slugs in `how-to-stamp-requests.mdx` to point to `wallets/reference/how-to-stamp-requests`
- Updated URLs and slugs in `gas-manager-errors.mdx` to point to `wallets/reference/gas-manager-errors`
- Updated URLs and slugs in `entrypoint-v06-revert-codes.mdx` to point to `wallets/reference/entrypoint-v06-revert-codes`
- Updated URLs and slugs in `entrypoint-v07-revert-codes.mdx` to point to `wallets/reference/entrypoint-v07-revert-codes`
- Updated URLs and slugs in `bundler-rpc-errors.mdx` to point to `wallets/reference/bundler-rpc-errors`
- Updated URLs and slugs in `session-keys/index.mdx` to point to `wallets/reference/wallet-apis-session-keys`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->