### PR TITLE
feat(v4): track key exports for migration visibility

### DIFF
--- a/account-kit/signer/src/client/base.ts
+++ b/account-kit/signer/src/client/base.ts
@@ -1553,6 +1553,12 @@ export abstract class BaseSignerClient<
       exported?.activity.result.exportWalletAccountResult?.exportBundle;
     if (!exportBundle) throw new Error("No export bundle found");
 
+    this.request("/v1/track-key-export", {
+      orgId: organizationId,
+      accountAddress: account.address,
+      type: opts.type === "ETHEREUM" ? "ETH" : "SOL",
+    }).catch(() => {});
+
     const parsedExportBundle = JSON.parse(exportBundle);
     const signedData = JSON.parse(
       fromHex(`0x${parsedExportBundle.data}`, { to: "string" }),

--- a/account-kit/signer/src/client/types.ts
+++ b/account-kit/signer/src/client/types.ts
@@ -449,9 +449,7 @@ export type SignerEndpoints = [
       accountAddress: string;
       type: "ETH" | "SOL";
     };
-    Response: {
-      success: boolean;
-    };
+    Response: {};
   },
 ];
 

--- a/account-kit/signer/src/client/types.ts
+++ b/account-kit/signer/src/client/types.ts
@@ -442,6 +442,17 @@ export type SignerEndpoints = [
       };
     };
   },
+  {
+    Route: "/v1/track-key-export";
+    Body: {
+      orgId: string;
+      accountAddress: string;
+      type: "ETH" | "SOL";
+    };
+    Response: {
+      success: boolean;
+    };
+  },
 ];
 
 export type AuthenticatingEventMetadata = {

--- a/docs/pages/reference/account-kit/signer/src/classes/AlchemySignerWebClient.mdx
+++ b/docs/pages/reference/account-kit/signer/src/classes/AlchemySignerWebClient.mdx
@@ -896,7 +896,7 @@ This will remove members from an existing multi-sig account
 experimental_multiOwnerExportPrivateKeyEncrypted(opts): Promise<ExportPrivateKeyEncryptedResult>;
 ```
 
-Defined in: [account-kit/signer/src/client/base.ts:1610](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1610)
+Defined in: [account-kit/signer/src/client/base.ts:1616](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1616)
 
 Exports a private key for a given account in a multi-owner org
 
@@ -1031,7 +1031,7 @@ the signature over the raw hex
 exportPrivateKey(opts): Promise<string>;
 ```
 
-Defined in: [account-kit/signer/src/client/base.ts:1574](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1574)
+Defined in: [account-kit/signer/src/client/base.ts:1580](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1580)
 
 Exports a private key for a given account
 
@@ -2807,6 +2807,7 @@ Not intended to be used directly, use the specific methods instead on the client
         | `"/v1/multi-owner-sign-raw-payload"`
         | `"/v1/multi-owner-prepare-delete"`
         | `"/v1/multi-owner-delete"`
+        | `"/v1/track-key-export"`
       </td>
     </tr>
   </tbody>

--- a/docs/pages/reference/account-kit/signer/src/classes/BaseSignerClient.mdx
+++ b/docs/pages/reference/account-kit/signer/src/classes/BaseSignerClient.mdx
@@ -748,7 +748,7 @@ This will remove members from an existing multi-sig account
 experimental_multiOwnerExportPrivateKeyEncrypted(opts): Promise<ExportPrivateKeyEncryptedResult>;
 ```
 
-Defined in: [account-kit/signer/src/client/base.ts:1610](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1610)
+Defined in: [account-kit/signer/src/client/base.ts:1616](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1616)
 
 Exports a private key for a given account in a multi-owner org
 
@@ -875,7 +875,7 @@ the signature over the raw hex
 exportPrivateKey(opts): Promise<string>;
 ```
 
-Defined in: [account-kit/signer/src/client/base.ts:1574](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1574)
+Defined in: [account-kit/signer/src/client/base.ts:1580](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1580)
 
 Exports a private key for a given account
 
@@ -2320,6 +2320,7 @@ Not intended to be used directly, use the specific methods instead on the client
         | `"/v1/multi-owner-sign-raw-payload"`
         | `"/v1/multi-owner-prepare-delete"`
         | `"/v1/multi-owner-delete"`
+        | `"/v1/track-key-export"`
       </td>
     </tr>
   </tbody>

--- a/docs/pages/reference/account-kit/signer/src/classes/ServerSignerClient.mdx
+++ b/docs/pages/reference/account-kit/signer/src/classes/ServerSignerClient.mdx
@@ -910,7 +910,7 @@ This will remove members from an existing multi-sig account
 experimental_multiOwnerExportPrivateKeyEncrypted(opts): Promise<ExportPrivateKeyEncryptedResult>;
 ```
 
-Defined in: [account-kit/signer/src/client/base.ts:1610](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1610)
+Defined in: [account-kit/signer/src/client/base.ts:1616](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1616)
 
 Exports a private key for a given account in a multi-owner org
 
@@ -1045,7 +1045,7 @@ the signature over the raw hex
 exportPrivateKey(opts): Promise<string>;
 ```
 
-Defined in: [account-kit/signer/src/client/base.ts:1574](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1574)
+Defined in: [account-kit/signer/src/client/base.ts:1580](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/base.ts#L1580)
 
 Exports a private key for a given account
 
@@ -2224,6 +2224,7 @@ Not intended to be used directly, use the specific methods instead on the client
         | `"/v1/multi-owner-sign-raw-payload"`
         | `"/v1/multi-owner-prepare-delete"`
         | `"/v1/multi-owner-delete"`
+        | `"/v1/track-key-export"`
       </td>
     </tr>
   </tbody>

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AddMfaParams.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AddMfaParams.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AddMfaParams = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:521](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L521)
+Defined in: [account-kit/signer/src/client/types.ts:530](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L530)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AddMfaResult.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AddMfaResult.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AddMfaResult = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:525](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L525)
+Defined in: [account-kit/signer/src/client/types.ts:534](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L534)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AddOauthProviderParams.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AddOauthProviderParams.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AddOauthProviderParams = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:558](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L558)
+Defined in: [account-kit/signer/src/client/types.ts:567](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L567)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AlchemySignerClientEvent.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AlchemySignerClientEvent.mdx
@@ -11,4 +11,4 @@ layout: reference
 type AlchemySignerClientEvent = keyof AlchemySignerClientEvents;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:470](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L470)
+Defined in: [account-kit/signer/src/client/types.ts:479](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L479)

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AlchemySignerClientEvents.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AlchemySignerClientEvents.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AlchemySignerClientEvents = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:458](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L458)
+Defined in: [account-kit/signer/src/client/types.ts:467](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L467)
 
 ## Methods
 
@@ -21,7 +21,7 @@ Defined in: [account-kit/signer/src/client/types.ts:458](https://github.com/alch
 authenticating(data): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:461](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L461)
+Defined in: [account-kit/signer/src/client/types.ts:470](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L470)
 
 #### Parameters
 
@@ -59,7 +59,7 @@ Defined in: [account-kit/signer/src/client/types.ts:461](https://github.com/alch
 connected(user): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:459](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L459)
+Defined in: [account-kit/signer/src/client/types.ts:468](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L468)
 
 #### Parameters
 
@@ -97,7 +97,7 @@ Defined in: [account-kit/signer/src/client/types.ts:459](https://github.com/alch
 connectedEmail(user, bundle): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:462](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L462)
+Defined in: [account-kit/signer/src/client/types.ts:471](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L471)
 
 #### Parameters
 
@@ -145,7 +145,7 @@ Defined in: [account-kit/signer/src/client/types.ts:462](https://github.com/alch
 connectedJwt(user, bundle): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:466](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L466)
+Defined in: [account-kit/signer/src/client/types.ts:475](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L475)
 
 #### Parameters
 
@@ -193,7 +193,7 @@ Defined in: [account-kit/signer/src/client/types.ts:466](https://github.com/alch
 connectedOauth(user, bundle): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:464](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L464)
+Defined in: [account-kit/signer/src/client/types.ts:473](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L473)
 
 #### Parameters
 
@@ -241,7 +241,7 @@ Defined in: [account-kit/signer/src/client/types.ts:464](https://github.com/alch
 connectedOtp(user, bundle): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:465](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L465)
+Defined in: [account-kit/signer/src/client/types.ts:474](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L474)
 
 #### Parameters
 
@@ -289,7 +289,7 @@ Defined in: [account-kit/signer/src/client/types.ts:465](https://github.com/alch
 connectedPasskey(user): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:463](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L463)
+Defined in: [account-kit/signer/src/client/types.ts:472](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L472)
 
 #### Parameters
 
@@ -327,7 +327,7 @@ Defined in: [account-kit/signer/src/client/types.ts:463](https://github.com/alch
 disconnected(): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:467](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L467)
+Defined in: [account-kit/signer/src/client/types.ts:476](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L476)
 
 #### Returns
 
@@ -341,7 +341,7 @@ Defined in: [account-kit/signer/src/client/types.ts:467](https://github.com/alch
 newUserSignup(): void;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:460](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L460)
+Defined in: [account-kit/signer/src/client/types.ts:469](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L469)
 
 #### Returns
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AuthLinkingPrompt.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AuthLinkingPrompt.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AuthLinkingPrompt = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:478](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L478)
+Defined in: [account-kit/signer/src/client/types.ts:487](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L487)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AuthMethods.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AuthMethods.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AuthMethods = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:563](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L563)
+Defined in: [account-kit/signer/src/client/types.ts:572](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L572)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/AuthenticatingEventMetadata.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/AuthenticatingEventMetadata.mdx
@@ -11,7 +11,7 @@ layout: reference
 type AuthenticatingEventMetadata = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:447](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L447)
+Defined in: [account-kit/signer/src/client/types.ts:456](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L456)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/GetOauthProviderUrlArgs.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/GetOauthProviderUrlArgs.mdx
@@ -11,7 +11,7 @@ layout: reference
 type GetOauthProviderUrlArgs = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:506](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L506)
+Defined in: [account-kit/signer/src/client/types.ts:515](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L515)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/GetWebAuthnAttestationResult.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/GetWebAuthnAttestationResult.mdx
@@ -11,7 +11,7 @@ layout: reference
 type GetWebAuthnAttestationResult = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:472](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L472)
+Defined in: [account-kit/signer/src/client/types.ts:481](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L481)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/IdTokenOnly.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/IdTokenOnly.mdx
@@ -11,7 +11,7 @@ layout: reference
 type IdTokenOnly = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:488](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L488)
+Defined in: [account-kit/signer/src/client/types.ts:497](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L497)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/MfaChallenge.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/MfaChallenge.mdx
@@ -11,7 +11,7 @@ layout: reference
 type MfaChallenge = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:545](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L545)
+Defined in: [account-kit/signer/src/client/types.ts:554](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L554)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/MfaFactor.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/MfaFactor.mdx
@@ -11,7 +11,7 @@ layout: reference
 type MfaFactor = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:514](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L514)
+Defined in: [account-kit/signer/src/client/types.ts:523](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L523)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/OauthProviderInfo.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/OauthProviderInfo.mdx
@@ -11,7 +11,7 @@ layout: reference
 type OauthProviderInfo = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:570](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L570)
+Defined in: [account-kit/signer/src/client/types.ts:579](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L579)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/OauthState.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/OauthState.mdx
@@ -11,7 +11,7 @@ layout: reference
 type OauthState = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:495](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L495)
+Defined in: [account-kit/signer/src/client/types.ts:504](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L504)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/PasskeyInfo.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/PasskeyInfo.mdx
@@ -11,7 +11,7 @@ layout: reference
 type PasskeyInfo = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:577](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L577)
+Defined in: [account-kit/signer/src/client/types.ts:586](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L586)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/RemoveMfaParams.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/RemoveMfaParams.mdx
@@ -11,7 +11,7 @@ layout: reference
 type RemoveMfaParams = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:536](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L536)
+Defined in: [account-kit/signer/src/client/types.ts:545](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L545)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/SignerEndpoints.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/SignerEndpoints.mdx
@@ -265,6 +265,15 @@ type SignerEndpoints = [
     };
     Route: "/v1/multi-owner-delete";
   },
+  {
+    Body: {
+      accountAddress: string;
+      orgId: string;
+      type: "ETH" | "SOL";
+    };
+    Response: {};
+    Route: "/v1/track-key-export";
+  },
 ];
 ```
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/SubmitOtpCodeResponse.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/SubmitOtpCodeResponse.mdx
@@ -20,4 +20,4 @@ type SubmitOtpCodeResponse =
     };
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:554](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L554)
+Defined in: [account-kit/signer/src/client/types.ts:563](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L563)

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/ValidateMultiFactorsParams.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/ValidateMultiFactorsParams.mdx
@@ -11,7 +11,7 @@ layout: reference
 type ValidateMultiFactorsParams = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:540](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L540)
+Defined in: [account-kit/signer/src/client/types.ts:549](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L549)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/VerifyMfaParams.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/VerifyMfaParams.mdx
@@ -11,7 +11,7 @@ layout: reference
 type VerifyMfaParams = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:531](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L531)
+Defined in: [account-kit/signer/src/client/types.ts:540](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L540)
 
 ## Properties
 

--- a/docs/pages/reference/account-kit/signer/src/type-aliases/experimental_CreateApiKeyParams.mdx
+++ b/docs/pages/reference/account-kit/signer/src/type-aliases/experimental_CreateApiKeyParams.mdx
@@ -11,7 +11,7 @@ layout: reference
 type experimental_CreateApiKeyParams = object;
 ```
 
-Defined in: [account-kit/signer/src/client/types.ts:583](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L583)
+Defined in: [account-kit/signer/src/client/types.ts:592](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/signer/src/client/types.ts#L592)
 
 ## Properties
 


### PR DESCRIPTION
## Summary
- Adds a fire-and-forget call to `/v1/track-key-export` after a successful wallet key export in the signer client
- Sends org ID, account address, and chain type (ETH/SOL) for export tracking
- Adds the new endpoint type definition to `SignerEndpoints`

## Test plan
- [ ] Verify key export flow still works end-to-end
- [ ] Confirm tracking request is sent after successful export
- [ ] Confirm failed tracking request does not break the export flow (fire-and-forget with `.catch(() => {})`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new API endpoint for tracking key exports and updates several type definitions in the codebase. It enhances the functionality related to account management and multi-owner operations.

### Detailed summary
- Added new endpoint `"/v1/track-key-export"` with request `Body` containing `orgId`, `accountAddress`, and `type`.
- Updated type definitions for various events and parameters in `account-kit/signer/src/client/types.ts`.
- Adjusted existing documentation references to reflect updated line numbers for type definitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->