### PR TITLE
docs: clarify waitForCallsStatus in sendCalls example

### DIFF
--- a/docs/pages/reference/wallet-apis/src/exports/functions/sendCalls.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/functions/sendCalls.mdx
@@ -11,7 +11,7 @@ layout: reference
 function sendCalls(client, params): Promise<SendCallsResult>;
 ```
 
-Defined in: [packages/wallet-apis/src/actions/sendCalls.ts:56](https://github.com/alchemyplatform/aa-sdk/blob/v5.x.x/packages/wallet-apis/src/actions/sendCalls.ts#L56)
+Defined in: [packages/wallet-apis/src/actions/sendCalls.ts:59](https://github.com/alchemyplatform/aa-sdk/blob/v5.x.x/packages/wallet-apis/src/actions/sendCalls.ts#L59)
 
 Prepares, signs, and submits calls. This function internally calls `prepareCalls`, `signPreparedCalls`, and `sendPreparedCalls`.
 
@@ -35,8 +35,11 @@ const result = await client.sendCalls({
   },
 });
 
-// The result contains the call ID
-console.log(result.id);
+// Wait for the calls to be mined and confirmed.
+// Polls getCallsStatus until the bundle succeeds, fails, or times out (default 60s).
+// See: https://viem.sh/docs/actions/wallet/waitForCallsStatus
+const status = await client.waitForCallsStatus({ id: result.id });
+console.log(status.status); // "success" | "failure"
 ```
 
 \<Note>

--- a/packages/wallet-apis/src/actions/sendCalls.ts
+++ b/packages/wallet-apis/src/actions/sendCalls.ts
@@ -45,8 +45,11 @@ export type SendCallsResult = Prettify<SendPreparedCallsResult>;
  *   }
  * });
  *
- * // The result contains the call ID
- * console.log(result.id);
+ * // Wait for the calls to be mined and confirmed.
+ * // Polls getCallsStatus until the bundle succeeds, fails, or times out (default 60s).
+ * // See: https://viem.sh/docs/actions/wallet/waitForCallsStatus
+ * const status = await client.waitForCallsStatus({ id: result.id });
+ * console.log(status.status); // "success" | "failure"
  * ```
  * <Note>
  * If using this action with an ERC-20 paymaster in pre-operation mode with `autoPermit`, the contents of the permit will be hidden


### PR DESCRIPTION
## Summary
- Updated the `sendCalls` JSDoc example to show the `sendCalls` → `waitForCallsStatus` flow instead of just logging the call ID
- Added a link to viem's `waitForCallsStatus` docs (https://viem.sh/docs/actions/wallet/waitForCallsStatus)
- Clarifies that `waitForCallsStatus` polls until the bundle succeeds, fails, or times out (default 60s)

## Test plan
- [ ] Verify TypeDoc regeneration picks up the updated JSDoc
- [ ] Confirm the viem docs link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `sendCalls` functionality in the `sendCalls.ts` file by adding a mechanism to wait for the calls to be mined and confirmed. It replaces the previous logging of the call ID with a status check.

### Detailed summary
- Added comments explaining the new functionality for waiting on calls.
- Introduced `client.waitForCallsStatus({ id: result.id })` to check the status of the calls.
- Updated the console log to output the status of the calls instead of the call ID.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->