### PR TITLE
fix: disallow more permission builder selectors

### DIFF
--- a/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
+++ b/account-kit/smart-contracts/src/ma-v2/actions/deferralActions.test.ts
@@ -18,6 +18,7 @@ import {
   PermissionBuilder,
   PermissionType,
   RootPermissionOnlyError,
+  SelectorNotAllowed,
   type Permission,
 } from "@account-kit/smart-contracts/experimental";
 import {
@@ -518,6 +519,110 @@ describe("MA v2 deferral actions tests", async () => {
         }),
       );
     });
+  });
+
+  const FORBIDDEN_SELECTOR_CASES: [Hex, string][] = [
+    ["0xb61d27f6", "execute"],
+    ["0x34fcd5be", "executeBatch"],
+    ["0x5998db5c", "performCreate"],
+    ["0xf2680c0f", "executeWithRuntimeValidation"],
+    ["0x1bbf564c", "installValidation"],
+    ["0xb6b1ccfe", "uninstallValidation"],
+    ["0x1d37e7d6", "installExecution"],
+    ["0x0b7cad71", "uninstallExecution"],
+    ["0x4f1ef286", "upgradeToAndCall"],
+  ];
+
+  it.each(FORBIDDEN_SELECTOR_CASES)(
+    "PermissionBuilder: constructor rejects forbidden selector %s (%s)",
+    async (selector, _name) => {
+      const provider = await givenConnectedProvider({ signer });
+      const sessionKeyAddress = await sessionKey.getAddress();
+      expect(
+        () =>
+          new PermissionBuilder({
+            client: provider.extend(deferralActions),
+            key: { publicKey: sessionKeyAddress, type: "secp256k1" },
+            entityId: 1,
+            nonce: 0n,
+            selectors: [selector],
+            deadline: 0,
+          }),
+      ).toThrow(SelectorNotAllowed);
+    },
+  );
+
+  it.each(FORBIDDEN_SELECTOR_CASES)(
+    "PermissionBuilder: addSelector rejects forbidden selector %s (%s)",
+    async (selector, _name) => {
+      const provider = await givenConnectedProvider({ signer });
+      const sessionKeyAddress = await sessionKey.getAddress();
+      const builder = new PermissionBuilder({
+        client: provider.extend(deferralActions),
+        key: { publicKey: sessionKeyAddress, type: "secp256k1" },
+        entityId: 1,
+        nonce: 0n,
+        deadline: 0,
+      });
+      expect(() => builder.addSelector({ selector })).toThrow(
+        SelectorNotAllowed,
+      );
+    },
+  );
+
+  it.each(FORBIDDEN_SELECTOR_CASES)(
+    "PermissionBuilder: addPermission(ACCOUNT_FUNCTIONS) rejects forbidden selector %s (%s)",
+    async (selector, _name) => {
+      const provider = await givenConnectedProvider({ signer });
+      const sessionKeyAddress = await sessionKey.getAddress();
+      const builder = new PermissionBuilder({
+        client: provider.extend(deferralActions),
+        key: { publicKey: sessionKeyAddress, type: "secp256k1" },
+        entityId: 1,
+        nonce: 0n,
+        deadline: 0,
+      });
+      expect(() =>
+        builder.addPermission({
+          permission: {
+            type: PermissionType.ACCOUNT_FUNCTIONS,
+            data: { functions: [selector] },
+          },
+        }),
+      ).toThrow(SelectorNotAllowed);
+    },
+  );
+
+  it("PermissionBuilder: rejects forbidden selector with mixed-case hex", async () => {
+    const provider = await givenConnectedProvider({ signer });
+    const sessionKeyAddress = await sessionKey.getAddress();
+    const builder = new PermissionBuilder({
+      client: provider.extend(deferralActions),
+      key: { publicKey: sessionKeyAddress, type: "secp256k1" },
+      entityId: 1,
+      nonce: 0n,
+      deadline: 0,
+    });
+    expect(() => builder.addSelector({ selector: "0x4F1EF286" })).toThrow(
+      SelectorNotAllowed,
+    );
+  });
+
+  it("PermissionBuilder: accepts non-forbidden selectors", async () => {
+    const provider = await givenConnectedProvider({ signer });
+    const sessionKeyAddress = await sessionKey.getAddress();
+    const safeSelector: Hex = "0xdeadbeef";
+    expect(
+      () =>
+        new PermissionBuilder({
+          client: provider.extend(deferralActions),
+          key: { publicKey: sessionKeyAddress, type: "secp256k1" },
+          entityId: 1,
+          nonce: 0n,
+          selectors: [safeSelector],
+          deadline: 0,
+        }),
+    ).not.toThrow();
   });
 
   /* -------------------------------------------------------------------------- */

--- a/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
+++ b/account-kit/smart-contracts/src/ma-v2/permissionBuilder.ts
@@ -46,6 +46,44 @@ const ACCOUNT_EXECUTE_SELECTOR = "0xb61d27f6";
 const ACCOUNT_EXECUTEBATCH_SELECTOR = "0x34fcd5be";
 const ACCOUNT_PERFORM_CREATE_SELECTOR = "0x5998db5c";
 const ACCOUNT_EXECUTE_WITH_RUNTIME_VALIDATION_SELECTOR = "0xf2680c0f";
+const ACCOUNT_INSTALL_VALIDATION_SELECTOR = "0x1bbf564c";
+const ACCOUNT_UNINSTALL_VALIDATION_SELECTOR = "0xb6b1ccfe";
+const ACCOUNT_INSTALL_EXECUTION_SELECTOR = "0x1d37e7d6";
+const ACCOUNT_UNINSTALL_EXECUTION_SELECTOR = "0x0b7cad71";
+const ACCOUNT_UPGRADE_TO_AND_CALL_SELECTOR = "0x4f1ef286";
+// Wrapped native functions that must not be added to a session key's selector allowlist.
+const PRIVILEGED_SELECTORS: Record<string, string> = {
+  [ACCOUNT_PERFORM_CREATE_SELECTOR]: "performCreate",
+  [ACCOUNT_EXECUTE_WITH_RUNTIME_VALIDATION_SELECTOR]:
+    "executeWithRuntimeValidation",
+  [ACCOUNT_INSTALL_VALIDATION_SELECTOR]: "installValidation",
+  [ACCOUNT_UNINSTALL_VALIDATION_SELECTOR]: "uninstallValidation",
+  [ACCOUNT_INSTALL_EXECUTION_SELECTOR]: "installExecution",
+  [ACCOUNT_UNINSTALL_EXECUTION_SELECTOR]: "uninstallExecution",
+  [ACCOUNT_UPGRADE_TO_AND_CALL_SELECTOR]: "upgradeToAndCall",
+};
+
+// Auto-added by translatePermissions when a PREVAL_ALLOWLIST hook exists.
+// Blocked from manual addition to ensure they're only added with proper hook context.
+const SYSTEM_MANAGED_SELECTORS: Record<string, string> = {
+  [ACCOUNT_EXECUTE_SELECTOR]: "execute",
+  [ACCOUNT_EXECUTEBATCH_SELECTOR]: "executeBatch",
+};
+
+function assertNotForbiddenSelector(selector: Hex): void {
+  const normalized = selector.toLowerCase();
+  const match =
+    PRIVILEGED_SELECTORS[normalized] ?? SYSTEM_MANAGED_SELECTORS[normalized];
+  if (match != null) {
+    throw new SelectorNotAllowed(match);
+  }
+}
+
+function assertNoForbiddenSelectors(selectors: Hex[]): void {
+  for (const selector of selectors) {
+    assertNotForbiddenSelector(selector);
+  }
+}
 
 export enum PermissionType {
   NATIVE_TOKEN_TRANSFER = "native-token-transfer",
@@ -254,18 +292,16 @@ export class PermissionBuilder {
       signer: key.publicKey,
     });
     this.nonce = nonce;
-    if (selectors) this.selectors = selectors;
+    if (selectors) {
+      assertNoForbiddenSelectors(selectors);
+      this.selectors = selectors;
+    }
     if (hooks) this.hooks = hooks;
     if (deadline) this.deadline = deadline;
   }
 
   addSelector({ selector }: { selector: Hex }): this {
-    if (selector === ACCOUNT_PERFORM_CREATE_SELECTOR) {
-      throw new SelectorNotAllowed("performCreate");
-    }
-    if (selector === ACCOUNT_EXECUTE_WITH_RUNTIME_VALIDATION_SELECTOR) {
-      throw new SelectorNotAllowed("executeWithRuntimeValidation");
-    }
+    assertNotForbiddenSelector(selector);
     this.selectors.push(selector);
     return this;
   }
@@ -322,24 +358,7 @@ export class PermissionBuilder {
       if (permission.data.functions.length === 0) {
         throw new NoFunctionsProvidedError(permission);
       }
-      // Explicitly disallow adding execute, executeBatch, performCreate, and executeWithRuntimeValidation
-      if (permission.data.functions.includes(ACCOUNT_EXECUTE_SELECTOR)) {
-        throw new SelectorNotAllowed("execute");
-      } else if (
-        permission.data.functions.includes(ACCOUNT_EXECUTEBATCH_SELECTOR)
-      ) {
-        throw new SelectorNotAllowed("executeBatch");
-      } else if (
-        permission.data.functions.includes(ACCOUNT_PERFORM_CREATE_SELECTOR)
-      ) {
-        throw new SelectorNotAllowed("performCreate");
-      } else if (
-        permission.data.functions.includes(
-          ACCOUNT_EXECUTE_WITH_RUNTIME_VALIDATION_SELECTOR,
-        )
-      ) {
-        throw new SelectorNotAllowed("executeWithRuntimeValidation");
-      }
+      assertNoForbiddenSelectors(permission.data.functions);
       this.selectors = [...this.selectors, ...permission.data.functions];
     }
 


### PR DESCRIPTION
## Summary
- Ports v5 PR #2484 selector restrictions to v4 — blocks `installValidation`, `uninstallValidation`, `installExecution`, `uninstallExecution`, and `upgradeToAndCall` from being added to session key selector allowlists
- Refactors individual selector checks into shared `assertNotForbiddenSelector` / `assertNoForbiddenSelectors` helpers with case-insensitive matching
- Adds constructor-level validation so forbidden selectors are caught at build time, not just via `addSelector`/`addPermission`
- Adds comprehensive test coverage for all 9 forbidden selectors across all entry points

## Test plan
- [ ] Verify forbidden selector tests pass locally
- [ ] Confirm existing deferral action tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `PermissionBuilder` class by introducing new selectors and validation mechanisms to prevent the use of forbidden selectors, ensuring better security and proper management of permissions.

### Detailed summary
- Added new selectors: `ACCOUNT_INSTALL_VALIDATION_SELECTOR`, `ACCOUNT_UNINSTALL_VALIDATION_SELECTOR`, `ACCOUNT_INSTALL_EXECUTION_SELECTOR`, `ACCOUNT_UNINSTALL_EXECUTION_SELECTOR`, `ACCOUNT_UPGRADE_TO_AND_CALL_SELECTOR`.
- Introduced `PRIVILEGED_SELECTORS` and `SYSTEM_MANAGED_SELECTORS` for managing allowed selectors.
- Implemented `assertNotForbiddenSelector` and `assertNoForbiddenSelectors` functions to validate selectors.
- Updated the `PermissionBuilder` constructor to check for forbidden selectors when initializing.
- Modified `addSelector` method to use the new validation functions.
- Replaced explicit selector checks in `addPermission` with `assertNoForbiddenSelectors`.
- Added tests for forbidden selectors in `deferralActions.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->