### PR TITLE
fix(v5): pin wallet-api-types

### DIFF
--- a/packages/wallet-apis/package.json
+++ b/packages/wallet-apis/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@alchemy/common": "workspace:*",
-    "@alchemy/wallet-api-types": "^0.1.0-alpha.27",
+    "@alchemy/wallet-api-types": "0.1.0-alpha.27",
     "deep-equal": "^2.2.3",
     "ox": "^0.11.1",
     "typebox": "^1.0.81"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,7 +248,7 @@ importers:
         specifier: workspace:*
         version: link:../common
       "@alchemy/wallet-api-types":
-        specifier: ^0.1.0-alpha.27
+        specifier: 0.1.0-alpha.27
         version: 0.1.0-alpha.27(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       deep-equal:
         specifier: ^2.2.3


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version specification for the `@alchemy/wallet-api-types` dependency in both `package.json` and `pnpm-lock.yaml` files from a caret version (`^0.1.0-alpha.27`) to a fixed version (`0.1.0-alpha.27`).

### Detailed summary
- In `packages/wallet-apis/package.json`:
  - Changed `@alchemy/wallet-api-types` from `"^0.1.0-alpha.27"` to `"0.1.0-alpha.27"`.
  
- In `pnpm-lock.yaml`:
  - Updated `specifier` for `@alchemy/wallet-api-types` from `^0.1.0-alpha.27` to `0.1.0-alpha.27`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->