### PR TITLE
fix(wallet-apis): improve codec error messages for union schemas

### DIFF
--- a/packages/wallet-apis/src/utils/schema.test.ts
+++ b/packages/wallet-apis/src/utils/schema.test.ts
@@ -50,6 +50,63 @@ describe("encode", () => {
     );
   });
 
+  // ─── Union branch selection (EVM vs Solana) ───
+  // formatCodecError should pick the union branch with the fewest issues
+  // (closest match) rather than always the first branch.
+
+  it("picks the Solana branch when input is Solana-shaped", () => {
+    expect(() =>
+      encode(prepareCallsSchema.request, {
+        from: "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV",
+        chainId: "solana:mainnet",
+        calls: [{ programId: 12345 as any, data: "0xabcdef" }],
+      } as any),
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining("/calls/0/programId"),
+      }),
+    );
+  });
+
+  it("picks the EVM branch when input is EVM-shaped", () => {
+    expect(() =>
+      encode(prepareCallsSchema.request, {
+        ...validPrepareCallsParams,
+        calls: [
+          {
+            to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567" as const,
+            value: "0x1" as any,
+          },
+        ],
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining("/calls/0/value: Expected bigint"),
+      }),
+    );
+  });
+
+  // ─── Path accumulation across nested unions ───
+  // Paths from intermediate union levels must be preserved when drilling
+  // into nested unions (e.g. capabilities → paymasterService variants).
+
+  it("includes the full path for errors inside nested unions", () => {
+    expect(() =>
+      encode(prepareCallsSchema.request, {
+        ...validPrepareCallsParams,
+        capabilities: {
+          paymasterService: { policyId: 12345 as any },
+        },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "/capabilities/paymasterService/policyId",
+        ),
+      }),
+    );
+  });
+
   // ─── Runtime-only validations that TypeScript cannot catch ───
   // These all compile fine because TS sees `string` or `number`,
   // but the schema enforces stricter constraints at runtime.

--- a/packages/wallet-apis/src/utils/schema.ts
+++ b/packages/wallet-apis/src/utils/schema.ts
@@ -61,9 +61,7 @@ function formatCodecError(error: z.ZodError): string {
 
   const fullPath = [...pathPrefix, ...issue.path];
   const path =
-    fullPath.length > 0
-      ? "/" + fullPath.map(String).join("/") + ": "
-      : "";
+    fullPath.length > 0 ? "/" + fullPath.map(String).join("/") + ": " : "";
 
   return `Invalid params: ${path}${issue.message}`;
 }

--- a/packages/wallet-apis/src/utils/schema.ts
+++ b/packages/wallet-apis/src/utils/schema.ts
@@ -51,9 +51,9 @@ function formatCodecError(error: z.ZodError): string {
   }
 
   const fullPath = [...pathPrefix, ...issue.path];
-  const path = fullPath.length > 0 ? "/" + fullPath.join("/") : "(root)";
+  const path = fullPath.length > 0 ? "/" + fullPath.join("/") + ": " : "";
 
-  return `Invalid params: ${path}: ${issue.message}`;
+  return `Invalid params: ${path}${issue.message}`;
 }
 
 export function encode<const T extends z.ZodType>(

--- a/packages/wallet-apis/src/utils/schema.ts
+++ b/packages/wallet-apis/src/utils/schema.ts
@@ -39,15 +39,19 @@ function formatCodecError(error: z.ZodError): string {
   let issue: z.core.$ZodIssue | undefined = error.issues[0];
   if (!issue) return "Invalid params";
 
-  // For union errors, drill into the first branch for the most specific error.
-  while (
-    issue.code === "invalid_union" &&
-    (issue as z.core.$ZodIssueInvalidUnion).errors?.[0]?.[0]
-  ) {
-    issue = (issue as z.core.$ZodIssueInvalidUnion).errors[0][0];
+  // For union errors, drill into the branch with the fewest issues (closest match).
+  // Accumulate paths as we drill — each union level carries a partial path.
+  const pathPrefix: (string | number)[] = [];
+  while (issue.code === "invalid_union") {
+    pathPrefix.push(...(issue.path as (string | number)[]));
+    const { errors: branches } = issue as z.core.$ZodIssueInvalidUnion;
+    const best = branches.reduce((a, b) => (b.length < a.length ? b : a));
+    if (!best[0]) break;
+    issue = best[0];
   }
 
-  const path = issue.path.length > 0 ? "/" + issue.path.join("/") : "(root)";
+  const fullPath = [...pathPrefix, ...issue.path];
+  const path = fullPath.length > 0 ? "/" + fullPath.join("/") : "(root)";
 
   return `Invalid params: ${path}: ${issue.message}`;
 }

--- a/packages/wallet-apis/src/utils/schema.ts
+++ b/packages/wallet-apis/src/utils/schema.ts
@@ -35,23 +35,35 @@ export type MethodResponse<T extends RpcMethodSchema> = z.output<
   T["shape"]["ReturnType"]
 >;
 
+function isUnionIssue(
+  issue: z.core.$ZodIssue,
+): issue is z.core.$ZodIssueInvalidUnion {
+  return issue.code === "invalid_union";
+}
+
 function formatCodecError(error: z.ZodError): string {
   let issue: z.core.$ZodIssue | undefined = error.issues[0];
   if (!issue) return "Invalid params";
 
   // For union errors, drill into the branch with the fewest issues (closest match).
   // Accumulate paths as we drill — each union level carries a partial path.
-  const pathPrefix: (string | number)[] = [];
-  while (issue.code === "invalid_union") {
-    pathPrefix.push(...(issue.path as (string | number)[]));
-    const { errors: branches } = issue as z.core.$ZodIssueInvalidUnion;
-    const best = branches.reduce((a, b) => (b.length < a.length ? b : a));
-    if (!best[0]) break;
-    issue = best[0];
+  const pathPrefix: PropertyKey[] = [];
+  while (isUnionIssue(issue)) {
+    pathPrefix.push(...issue.path);
+    let best: z.core.$ZodIssue[] | undefined;
+    for (const branch of issue.errors) {
+      if (!best || branch.length < best.length) best = branch;
+    }
+    const next = best?.[0];
+    if (!next) break;
+    issue = next;
   }
 
   const fullPath = [...pathPrefix, ...issue.path];
-  const path = fullPath.length > 0 ? "/" + fullPath.join("/") + ": " : "";
+  const path =
+    fullPath.length > 0
+      ? "/" + fullPath.map(String).join("/") + ": "
+      : "";
 
   return `Invalid params: ${path}${issue.message}`;
 }


### PR DESCRIPTION
## Summary
- Pick the closest-matching union branch (fewest errors) instead of always the first, so Solana-shaped inputs get Solana-relevant errors instead of misleading EVM errors
- Accumulate paths across nested union levels so intermediate path segments (e.g. `/capabilities/paymasterService/`) aren't lost when drilling through nested unions
- Add regression tests for branch selection and path accumulation

## Test plan
- [x] Unit tests added for Solana branch selection, EVM branch selection, and nested union path accumulation
- [x] All 10 tests in `schema.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `formatCodecError` function to improve error handling for union types in Zod schemas. It introduces a new function to identify union issues and modifies the error formatting to provide more informative paths for errors, particularly in nested unions.

### Detailed summary
- Added `isUnionIssue` function to identify union errors.
- Modified `formatCodecError` to accumulate paths when drilling into union errors.
- Changed logic to select the branch with the fewest issues for better specificity.
- Added tests to verify correct branch selection for EVM and Solana inputs.
- Ensured full path for errors in nested unions is preserved.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->