### PR TITLE
fix(smart-accounts): make PermissionBuilder hook state non-mutating

### DIFF
--- a/packages/smart-accounts/src/ma-v2/permissionBuilder.ts
+++ b/packages/smart-accounts/src/ma-v2/permissionBuilder.ts
@@ -427,6 +427,8 @@ export class PermissionBuilder {
     typedData: DeferredActionTypedData;
     fullPreSignatureDeferredActionPayload: Hex;
   }> {
+    const extraHooks: Hook[] = [];
+
     // Add time range module hook via expiry
     if (this.deadline !== 0) {
       if (this.deadline < Date.now() / 1000) {
@@ -436,7 +438,7 @@ export class PermissionBuilder {
         throw new DeadlineOverLimitError(this.deadline);
       }
 
-      this.hooks.push(
+      extraHooks.push(
         TimeRangeModule.buildHook(
           {
             entityId: this.validationConfig.entityId,
@@ -448,7 +450,8 @@ export class PermissionBuilder {
       );
     }
 
-    const installValidationCall = await this.compileRaw();
+    const installValidationCall =
+      await this.encodeInstallValidationCall(extraHooks);
 
     const { typedData } = await deferralActions(
       this.client,
@@ -481,32 +484,14 @@ export class PermissionBuilder {
    * @returns {Promise<Hex>} The raw install arguments.
    */
   async compileRaw(): Promise<Hex> {
-    const account = this.client.account;
-    if (!account || !isModularAccountV2(account)) {
-      throw new AccountNotFoundError();
-    }
-
-    // Translate all permissions into raw hooks if >0
-    if (this.permissions.length > 0) {
-      const rawHooks = this.translatePermissions(
-        this.validationConfig.entityId,
-      );
-      // Add the translated permissions as hooks
-      this.addHooks(rawHooks);
-    }
-    this.validateConfiguration();
-
-    return await installValidationActions(this.client).encodeInstallValidation({
-      validationConfig: this.validationConfig,
-      selectors: this.selectors,
-      installData: this.installData,
-      hooks: this.hooks,
-      account,
-    });
+    return await this.encodeInstallValidationCall();
   }
 
   /**
-   * Compiles the install arguments for the installValidation function.
+   * Compiles the install arguments for the installValidation function. Translates
+   * any permissions added via {@link addPermission}/{@link addPermissions} into
+   * hooks before returning, so the returned `hooks` array reflects the full
+   * configured permission set.
    *
    * @returns {Promise<InstallValidationParams>} The install arguments.
    */
@@ -516,15 +501,53 @@ export class PermissionBuilder {
       throw new AccountNotFoundError();
     }
 
+    const hooks = this.buildHooks();
     this.validateConfiguration();
 
     return {
       validationConfig: this.validationConfig,
       selectors: this.selectors,
       installData: this.installData,
-      hooks: this.hooks,
+      hooks,
       account,
     };
+  }
+
+  // Shared encoder for compileRaw / compileDeferred. extraHooks lets the deferred
+  // path inject its TimeRange hook without mutating this.hooks.
+  private async encodeInstallValidationCall(
+    extraHooks: Hook[] = [],
+  ): Promise<Hex> {
+    const account = this.client.account;
+    if (!account || !isModularAccountV2(account)) {
+      throw new AccountNotFoundError();
+    }
+
+    const hooks = this.buildHooks(extraHooks);
+    this.validateConfiguration();
+
+    return await installValidationActions(this.client).encodeInstallValidation({
+      validationConfig: this.validationConfig,
+      selectors: this.selectors,
+      installData: this.installData,
+      hooks,
+      account,
+    });
+  }
+
+  // Assembles the final hook array fresh on every call: constructor-provided
+  // hooks, plus any extras the caller wants injected, plus encoded hooks from
+  // pending permissions. Does not mutate this.hooks — callers may invoke any
+  // compile method any number of times without duplication.
+  private buildHooks(extraHooks: Hook[] = []): Hook[] {
+    const result: Hook[] = [...this.hooks, ...extraHooks];
+    if (this.permissions.length > 0) {
+      const rawHooks = this.translatePermissions(
+        this.validationConfig.entityId,
+      );
+      result.push(...this.encodeRawHooks(rawHooks));
+    }
+    return result;
   }
 
   private validateConfiguration(): void {
@@ -762,10 +785,14 @@ export class PermissionBuilder {
     return rawHooks;
   }
 
-  private addHooks(rawHooks: RawHooks) {
+  // Encodes translated RawHooks into the on-the-wire Hook[] form. Returns a
+  // fresh array; does not mutate this.hooks.
+  private encodeRawHooks(rawHooks: RawHooks): Hook[] {
+    const result: Hook[] = [];
+
     const ntt = rawHooks[HookIdentifier.NATIVE_TOKEN_TRANSFER];
     if (ntt) {
-      this.hooks.push({
+      result.push({
         hookConfig: ntt.hookConfig,
         initData: NativeTokenLimitModule.encodeOnInstallData(ntt.initData),
       });
@@ -773,7 +800,7 @@ export class PermissionBuilder {
 
     const erc20 = rawHooks[HookIdentifier.ERC20_TOKEN_TRANSFER];
     if (erc20) {
-      this.hooks.push({
+      result.push({
         hookConfig: erc20.hookConfig,
         initData: AllowlistModule.encodeOnInstallData(erc20.initData),
       });
@@ -781,7 +808,7 @@ export class PermissionBuilder {
 
     const gl = rawHooks[HookIdentifier.GAS_LIMIT];
     if (gl) {
-      this.hooks.push({
+      result.push({
         hookConfig: gl.hookConfig,
         initData: NativeTokenLimitModule.encodeOnInstallData(gl.initData),
       });
@@ -789,10 +816,12 @@ export class PermissionBuilder {
 
     const allowlist = rawHooks[HookIdentifier.PREVAL_ALLOWLIST];
     if (allowlist) {
-      this.hooks.push({
+      result.push({
         hookConfig: allowlist.hookConfig,
         initData: AllowlistModule.encodeOnInstallData(allowlist.initData),
       });
     }
+
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- \`compileInstallArgs\` silently dropped permissions because it never called \`translatePermissions\`. Any caller adding permissions and then invoking \`compileInstallArgs\` got an empty \`hooks\` array — a security-relevant footgun for session-key flows.
- \`compileRaw\` and \`compileDeferred\` translated correctly but mutated \`this.hooks\`, so repeated or interleaved compile calls duplicated hooks.
- Refactored to treat \`this.hooks\` as immutable after construction. All three compile methods now build the final hook array fresh per call via a shared private \`buildHooks(extraHooks?)\` helper.

## Test plan
- [ ] Verify \`compileInstallArgs\` after \`addPermission\` returns hooks matching \`compileRaw\` output
- [ ] Verify calling any compile method multiple times produces identical hook arrays (no duplication)
- [ ] Verify \`compileDeferred\` still injects the TimeRange hook when deadline is set
- [ ] Verify constructor-provided \`hooks\` still pass through to all compile outputs
- [ ] Run existing \`deferralActions.test.ts\` suite end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `PermissionBuilder` class in `permissionBuilder.ts` to improve the handling of hooks, particularly in relation to time range modules and install validation. It introduces new methods for compiling install arguments and encoding hooks, enhancing modularity and maintainability.

### Detailed summary
- Introduced `extraHooks` array for managing additional hooks.
- Updated hook handling logic to use `extraHooks` instead of directly modifying `this.hooks`.
- Created `compileInstallArgs` method to compile install arguments with hooks.
- Added `encodeInstallValidationCall` method for shared encoding logic.
- Implemented `buildHooks` method to assemble hooks without mutating existing hooks.
- Added `encodeRawHooks` method to encode raw hooks into the final hook format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->