### PR TITLE
chore: bump wallet-api-types to 0.2.0-alpha.2

### DIFF
--- a/docs/pages/reference/wallet-apis/src/exports/experimental/type-aliases/RequestQuoteV0Params.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/experimental/type-aliases/RequestQuoteV0Params.mdx
@@ -83,6 +83,7 @@ type RequestQuoteV0Params =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -222,6 +223,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -268,6 +270,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -366,6 +369,7 @@ type RequestQuoteV0Params =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -505,6 +509,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -551,6 +556,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -649,6 +655,7 @@ type RequestQuoteV0Params =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -788,6 +795,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -834,6 +842,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -932,6 +941,7 @@ type RequestQuoteV0Params =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -1071,6 +1081,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;
@@ -1117,6 +1128,7 @@ type RequestQuoteV0Params =
                                 amount: bigint;
                               }
                             | undefined;
+                          balanceCheck?: false | undefined;
                         };
                         tokenAddress: `0x${string}`;
                         maxTokenAmount?: bigint | undefined;

--- a/docs/pages/reference/wallet-apis/src/exports/experimental/type-aliases/RequestQuoteV0Result.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/experimental/type-aliases/RequestQuoteV0Result.mdx
@@ -458,6 +458,7 @@ type RequestQuoteV0Result =
                                     amount: bigint;
                                   }
                                 | undefined;
+                              balanceCheck?: false | undefined;
                             };
                             tokenAddress: `0x${string}`;
                             maxTokenAmount?: bigint | undefined;
@@ -749,6 +750,7 @@ type RequestQuoteV0Result =
                                     amount: bigint;
                                   }
                                 | undefined;
+                              balanceCheck?: false | undefined;
                             };
                             tokenAddress: `0x${string}`;
                             maxTokenAmount?: bigint | undefined;
@@ -888,6 +890,7 @@ type RequestQuoteV0Result =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -934,6 +937,7 @@ type RequestQuoteV0Result =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;

--- a/docs/pages/reference/wallet-apis/src/exports/type-aliases/PrepareCallsParams.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/type-aliases/PrepareCallsParams.mdx
@@ -103,6 +103,7 @@ type PrepareCallsParams = {
                               amount: bigint;
                             }
                           | undefined;
+                        balanceCheck?: false | undefined;
                       };
                       tokenAddress: `0x${string}`;
                       maxTokenAmount?: bigint | undefined;
@@ -242,6 +243,7 @@ type PrepareCallsParams = {
                             amount: bigint;
                           }
                         | undefined;
+                      balanceCheck?: false | undefined;
                     };
                     tokenAddress: `0x${string}`;
                     maxTokenAmount?: bigint | undefined;
@@ -288,6 +290,7 @@ type PrepareCallsParams = {
                             amount: bigint;
                           }
                         | undefined;
+                      balanceCheck?: false | undefined;
                     };
                     tokenAddress: `0x${string}`;
                     maxTokenAmount?: bigint | undefined;

--- a/docs/pages/reference/wallet-apis/src/exports/type-aliases/PrepareCallsResult.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/type-aliases/PrepareCallsResult.mdx
@@ -391,6 +391,7 @@ type PrepareCallsResult =
                                     amount: bigint;
                                   }
                                 | undefined;
+                              balanceCheck?: false | undefined;
                             };
                             tokenAddress: `0x${string}`;
                             maxTokenAmount?: bigint | undefined;
@@ -682,6 +683,7 @@ type PrepareCallsResult =
                                     amount: bigint;
                                   }
                                 | undefined;
+                              balanceCheck?: false | undefined;
                             };
                             tokenAddress: `0x${string}`;
                             maxTokenAmount?: bigint | undefined;
@@ -821,6 +823,7 @@ type PrepareCallsResult =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -867,6 +870,7 @@ type PrepareCallsResult =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;

--- a/docs/pages/reference/wallet-apis/src/exports/type-aliases/SendCallsParams.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/type-aliases/SendCallsParams.mdx
@@ -63,6 +63,7 @@ type SendCallsParams = {
                               amount: bigint;
                             }
                           | undefined;
+                        balanceCheck?: false | undefined;
                       };
                       tokenAddress: `0x${string}`;
                       maxTokenAmount?: bigint | undefined;
@@ -202,6 +203,7 @@ type SendCallsParams = {
                             amount: bigint;
                           }
                         | undefined;
+                      balanceCheck?: false | undefined;
                     };
                     tokenAddress: `0x${string}`;
                     maxTokenAmount?: bigint | undefined;
@@ -248,6 +250,7 @@ type SendCallsParams = {
                             amount: bigint;
                           }
                         | undefined;
+                      balanceCheck?: false | undefined;
                     };
                     tokenAddress: `0x${string}`;
                     maxTokenAmount?: bigint | undefined;

--- a/docs/pages/reference/wallet-apis/src/exports/type-aliases/SignPreparedCallsParams.mdx
+++ b/docs/pages/reference/wallet-apis/src/exports/type-aliases/SignPreparedCallsParams.mdx
@@ -476,6 +476,7 @@ type SignPreparedCallsParams =
                                     amount: bigint;
                                   }
                                 | undefined;
+                              balanceCheck?: false | undefined;
                             };
                             tokenAddress: `0x${string}`;
                             maxTokenAmount?: bigint | undefined;
@@ -615,6 +616,7 @@ type SignPreparedCallsParams =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;
@@ -661,6 +663,7 @@ type SignPreparedCallsParams =
                                   amount: bigint;
                                 }
                               | undefined;
+                            balanceCheck?: false | undefined;
                           };
                           tokenAddress: `0x${string}`;
                           maxTokenAmount?: bigint | undefined;

--- a/packages/wallet-apis/package.json
+++ b/packages/wallet-apis/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@alchemy/common": "workspace:*",
-    "@alchemy/wallet-api-types": "0.2.0-alpha.1",
+    "@alchemy/wallet-api-types": "0.2.0-alpha.2",
     "deep-equal": "^2.2.3",
     "ox": "^0.11.1",
     "zod": "^4.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,8 +249,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@alchemy/wallet-api-types':
-        specifier: 0.2.0-alpha.1
-        version: 0.2.0-alpha.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: 0.2.0-alpha.2
+        version: 0.2.0-alpha.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       deep-equal:
         specifier: ^2.2.3
         version: 2.2.3
@@ -326,8 +326,8 @@ packages:
     peerDependencies:
       viem: ^2.45.0
 
-  '@alchemy/wallet-api-types@0.2.0-alpha.1':
-    resolution: {integrity: sha512-Yd40U7SFXb5oAprRmt7PwHzNm+vrdE2YCr6+SuvcIMfLLg5g/3/NWTDWDV+JAenH8daSe2onkML/PXieHVSAvA==}
+  '@alchemy/wallet-api-types@0.2.0-alpha.2':
+    resolution: {integrity: sha512-ug9zINrUyzPMiqG3ifx1p4yoKGx1pfaWOghdz7rXfeIdGCW0bx69xA88Xh1B2Mf7Blz4nY0tmnzgsJ2tbdR6Nw==}
     peerDependencies:
       typescript: ^5.8.2
 
@@ -8182,7 +8182,7 @@ snapshots:
       viem: 2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       zod: 3.25.76
 
-  '@alchemy/wallet-api-types@0.2.0-alpha.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@alchemy/wallet-api-types@0.2.0-alpha.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@alchemy/common': 5.0.0-beta.24(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3))
       deep-equal: 2.2.3


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `site` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint:check`) and fix any issues? (`yarn lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@alchemy/wallet-api-types` package and introduces a new optional property `balanceCheck` across various type definitions in the documentation files.

### Detailed summary
- Updated `@alchemy/wallet-api-types` dependency from `0.2.0-alpha.1` to `0.2.0-alpha.2`.
- Added optional property `balanceCheck?: false | undefined;` to the following types:
  - `SendCallsParams`
  - `PrepareCallsParams`
  - `SignPreparedCallsParams`
  - `PrepareCallsResult`
  - `RequestQuoteV0Result`
  - `RequestQuoteV0Params`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->