### PR TITLE
fix(release): include generated versions in publish commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,7 @@
     "packages/smart-accounts",
     "packages/wallet-apis"
   ],
+  "granularPathspec": false,
   "command": {
     "version": {
       "message": "chore(release): publish %s [skip ci]",


### PR DESCRIPTION
## Summary
- Set Lerna `granularPathspec` to `false` so publish release commits include generated tracked files like `packages/*/src/version.ts` after the version lifecycle runs.

## Test plan
- [x] `node -e 'JSON.parse(require("fs").readFileSync("lerna.json", "utf8")); console.log("lerna.json OK")'`

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`pnpm test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`pnpm run lint:check`) and fix any issues? (`pnpm run lint:write`)
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

Generated with Codex.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `lerna.json` configuration for a project, specifically adjusting the `granularPathspec` setting and modifying the version command message for releases.

### Detailed summary
- Added `"granularPathspec": false` to the `lerna.json` file.
- Updated the `version` command message to `"chore(release): publish %s [skip ci]"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->