### PR TITLE
fix(eslint): lazily construct OpenAI client in jsdoc worker

### DIFF
--- a/templates/eslint/src/fixers/openai-worker.ts
+++ b/templates/eslint/src/fixers/openai-worker.ts
@@ -179,8 +179,8 @@ const sampleResponseThree = `
 `;
 
 runAsWorker(async (codeToComment: string): Promise<string | null> => {
-  const completion = await getClient().chat.completions
-    .create({
+  const completion = await getClient()
+    .chat.completions.create({
       // 2 shot approach to "train" the model. We should consider training the model on a larger dataset so we can refine it further.
       messages: [
         { role: "system", content: systemPrompt },

--- a/templates/eslint/src/fixers/openai-worker.ts
+++ b/templates/eslint/src/fixers/openai-worker.ts
@@ -1,7 +1,13 @@
 import OpenAI from "openai";
 import { runAsWorker } from "synckit";
 
-const openai = new OpenAI();
+// Lazily instantiate the client. Constructing OpenAI at module load throws when
+// OPENAI_API_KEY is unset, which crashes any process that merely loads this
+// worker (e.g. the lerna release commit's pre-commit lint-staged run). The
+// re-export fixer guards on OPENAI_API_KEY before ever calling into the worker,
+// so deferring construction keeps that guard effective.
+let client: OpenAI | undefined;
+const getClient = () => (client ??= new OpenAI());
 
 const systemPrompt = `
 Given sample code, you generate jsdocs for that code. You only return the jsdoc comment.
@@ -173,7 +179,7 @@ const sampleResponseThree = `
 `;
 
 runAsWorker(async (codeToComment: string): Promise<string | null> => {
-  const completion = await openai.chat.completions
+  const completion = await getClient().chat.completions
     .create({
       // 2 shot approach to "train" the model. We should consider training the model on a larger dataset so we can refine it further.
       messages: [


### PR DESCRIPTION
The publish GHA was failing with `OPENAI_API_KEY environment variable is missing` because `openai-worker.ts` constructed `new OpenAI()` at module load — so the worker crashed the moment ESLint loaded the rule during lerna's release commit pre-commit hook (which has no key), before the existing `OPENAI_API_KEY` guard in `re-export-fixer.ts` could short-circuit. This change defers client construction to first use (`getClient()`), so the worker boots harmlessly and only instantiates OpenAI when the AI JSDoc fixer is actually invoked with a key present. This surfaced now because #2531 (`granularPathspec: false`) started staging generated `version.ts` files into the release commit, which lint-staged then ran `eslint --fix` over.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`pnpm test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md))
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`pnpm run lint:check`) and fix any issues? (`pnpm run lint:write`)
- [ ] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on lazily instantiating the `OpenAI` client to prevent crashes when the `OPENAI_API_KEY` is unset, ensuring that the worker can load without issues during linting processes.

### Detailed summary
- Added a comment explaining the lazy instantiation of the `OpenAI` client.
- Introduced a `client` variable to hold the `OpenAI` instance.
- Created a `getClient` function to manage the instantiation of the `OpenAI` client.
- Updated the code to use `getClient()` instead of directly instantiating `OpenAI`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->