### PR TITLE
fix(common): support default alchemy chain rpc urls

### DIFF
--- a/docs/pages/reference/common/src/functions/alchemyTransport.mdx
+++ b/docs/pages/reference/common/src/functions/alchemyTransport.mdx
@@ -11,7 +11,7 @@ layout: reference
 function alchemyTransport<rpcSchema>(config): AlchemyTransport<rpcSchema>;
 ```
 
-Defined in: [packages/common/src/transport/alchemy.ts:146](https://github.com/alchemyplatform/aa-sdk/blob/main/packages/common/src/transport/alchemy.ts#L146)
+Defined in: [packages/common/src/transport/alchemy.ts:174](https://github.com/alchemyplatform/aa-sdk/blob/main/packages/common/src/transport/alchemy.ts#L174)
 
 Creates an Alchemy HTTP transport for connecting to Alchemy's services.
 

--- a/packages/common/src/transport/alchemy.ts
+++ b/packages/common/src/transport/alchemy.ts
@@ -68,16 +68,20 @@ export function isAlchemyTransport(
 
 function isAlchemyRpcUrl(url: string): boolean {
   try {
-    const { hostname } = new URL(url);
-    return hostname === "alchemy.com" || hostname.endsWith(".alchemy.com");
+    const { hostname, pathname } = new URL(url);
+    return (
+      hostname.endsWith(".alchemy.com") &&
+      (pathname === "/v2" || pathname.startsWith("/v2/"))
+    );
   } catch {
     return false;
   }
 }
 
 function getAlchemyRpcUrlFromChainDefinition(chain: Chain): string | undefined {
-  if (chain.rpcUrls?.alchemy?.http?.[0]) {
-    return chain.rpcUrls.alchemy.http[0];
+  const legacyAlchemyUrl = chain.rpcUrls?.alchemy?.http?.[0];
+  if (legacyAlchemyUrl && isAlchemyRpcUrl(legacyAlchemyUrl)) {
+    return legacyAlchemyUrl;
   }
 
   for (const rpcUrls of Object.values(chain.rpcUrls ?? {})) {

--- a/packages/common/src/transport/alchemy.ts
+++ b/packages/common/src/transport/alchemy.ts
@@ -66,6 +66,30 @@ export function isAlchemyTransport(
   return transport({ chain }).config.type === "alchemyHttp";
 }
 
+function isAlchemyRpcUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "alchemy.com" || hostname.endsWith(".alchemy.com");
+  } catch {
+    return false;
+  }
+}
+
+function getAlchemyRpcUrlFromChainDefinition(chain: Chain): string | undefined {
+  if (chain.rpcUrls?.alchemy?.http?.[0]) {
+    return chain.rpcUrls.alchemy.http[0];
+  }
+
+  for (const rpcUrls of Object.values(chain.rpcUrls ?? {})) {
+    const alchemyUrl = rpcUrls.http.find(isAlchemyRpcUrl);
+    if (alchemyUrl) {
+      return alchemyUrl;
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Creates an Alchemy HTTP transport for connecting to Alchemy's services.
  *
@@ -184,9 +208,10 @@ export function alchemyTransport<
         return alchemyUrl;
       }
 
-      // Fallback: check for legacy alchemy RPC URLs in chain definition
-      if (chain.rpcUrls?.alchemy?.http?.[0]) {
-        return chain.rpcUrls.alchemy.http[0];
+      const chainDefinitionAlchemyUrl =
+        getAlchemyRpcUrlFromChainDefinition(chain);
+      if (chainDefinitionAlchemyUrl) {
+        return chainDefinitionAlchemyUrl;
       }
 
       throw new BaseError(

--- a/packages/common/tests/transport/registryIntegration.test.ts
+++ b/packages/common/tests/transport/registryIntegration.test.ts
@@ -77,6 +77,28 @@ describe("Registry Integration Tests", () => {
       );
     });
 
+    it("should fallback to Alchemy URLs in default chain RPC URLs", () => {
+      const transport = alchemyTransport({ apiKey: "test-key" });
+
+      const defaultAlchemyChain = defineChain({
+        id: 999998, // Not in registry
+        name: "Default Alchemy Chain",
+        nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+        rpcUrls: {
+          default: {
+            http: ["https://default-alchemy-chain.g.alchemy.com/v2"],
+          },
+        },
+      });
+
+      const defaultAlchemyTransport = transport({
+        chain: defaultAlchemyChain,
+      });
+      expect(defaultAlchemyTransport.value?.alchemyRpcUrl).toBe(
+        "https://default-alchemy-chain.g.alchemy.com/v2",
+      );
+    });
+
     it("should prioritize explicit URL over registry", () => {
       const explicitUrl = "https://explicit.alchemy.com/v2/custom-key";
       const transport = alchemyTransport({

--- a/packages/common/tests/transport/registryIntegration.test.ts
+++ b/packages/common/tests/transport/registryIntegration.test.ts
@@ -99,6 +99,68 @@ describe("Registry Integration Tests", () => {
       );
     });
 
+    it("should reject Alchemy domain URLs that are not RPC endpoints", () => {
+      const transport = alchemyTransport({ apiKey: "test-key" });
+
+      const explorerChain = defineChain({
+        id: 999997, // Not in registry
+        name: "Explorer Chain",
+        nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+        rpcUrls: {
+          default: {
+            http: ["https://explorer.alchemy.com"],
+          },
+        },
+      });
+
+      expect(() => transport({ chain: explorerChain })).toThrowError(
+        `Chain ${explorerChain.id} (${explorerChain.name}) is not supported by Alchemy`,
+      );
+    });
+
+    it("should reject root alchemy.com URLs in chain RPC URLs", () => {
+      const transport = alchemyTransport({ apiKey: "test-key" });
+
+      const rootAlchemyChain = defineChain({
+        id: 999996, // Not in registry
+        name: "Root Alchemy Chain",
+        nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+        rpcUrls: {
+          default: {
+            http: ["https://alchemy.com/v2"],
+          },
+        },
+      });
+
+      expect(() => transport({ chain: rootAlchemyChain })).toThrowError(
+        `Chain ${rootAlchemyChain.id} (${rootAlchemyChain.name}) is not supported by Alchemy`,
+      );
+    });
+
+    it("should reject legacy alchemy RPC URLs without the v2 path", () => {
+      const transport = alchemyTransport({ apiKey: "test-key" });
+
+      const invalidLegacyAlchemyChain = defineChain({
+        id: 999995, // Not in registry
+        name: "Invalid Legacy Alchemy Chain",
+        nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+        rpcUrls: {
+          default: {
+            http: ["https://default.rpc.com"],
+          },
+          alchemy: {
+            http: ["https://invalid-legacy.g.alchemy.com"],
+          },
+        },
+      });
+
+      expect(() =>
+        transport({ chain: invalidLegacyAlchemyChain }),
+      ).toThrowError(
+        `Chain ${invalidLegacyAlchemyChain.id} (${invalidLegacyAlchemyChain.name}) is not supported by Alchemy`,
+      );
+    });
+
     it("should prioritize explicit URL over registry", () => {
       const explicitUrl = "https://explicit.alchemy.com/v2/custom-key";
       const transport = alchemyTransport({


### PR DESCRIPTION
## Summary
- Allow `alchemyTransport` to use Alchemy-hosted `/v2` RPC URLs from chain definitions when registry lookup misses.
- Preserve unsupported-chain errors for non-Alchemy URLs, root `alchemy.com` URLs, and Alchemy-domain URLs without the `/v2` RPC path.
- Add regression coverage for default RPC URL fallback and invalid Alchemy-domain chain URLs.

## Test plan
- [x] `fnm exec --using=22.20.0 pnpm --filter @alchemy/common build`
- [x] `fnm exec --using=22.20.0 pnpm vitest run --project=alchemy/common packages/common/tests/transport/registryIntegration.test.ts`
- [x] `fnm exec --using=22.20.0 pnpm eslint packages/common/src/transport/alchemy.ts packages/common/tests/transport/registryIntegration.test.ts`
- [x] `fnm exec --using=22.20.0 pnpm prettier --check packages/common/src/transport/alchemy.ts packages/common/tests/transport/registryIntegration.test.ts`

# Pull Request Checklist

- [x] Did you add new tests and confirm existing tests pass? (`pnpm test`) Targeted Vitest run listed above.
- [x] Did you update relevant docs? No docs changes needed.
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? No breaking change.
- [x] Did you run lint (`pnpm run lint:check`) and fix any issues? (`pnpm run lint:write`) Targeted lint and format checks listed above.
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `alchemyTransport` functionality by implementing URL validation for Alchemy RPC endpoints and adding tests to ensure proper behavior when handling various chain definitions.

### Detailed summary
- Updated the definition location of `alchemyTransport` in the documentation.
- Introduced `isAlchemyRpcUrl` function to validate Alchemy RPC URLs.
- Added `getAlchemyRpcUrlFromChainDefinition` function for fetching valid URLs from chain definitions.
- Updated `alchemyTransport` to utilize the new URL validation logic.
- Added tests for fallback behavior to Alchemy URLs in default chain RPC URLs.
- Implemented tests to reject invalid Alchemy domain URLs and legacy URLs without the v2 path.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->