### PR TITLE
chore: bump tar

### DIFF
--- a/.vitest/package.json
+++ b/.vitest/package.json
@@ -11,7 +11,7 @@
     "is-ci": "^3.0.1",
     "node-fetch": "^3.3.1",
     "prool": "^0.0.15",
-    "tar": "^7.5.15",
+    "tar": "^7.5.16",
     "typescript-template": "workspace:*",
     "viem": "^2.45.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
         specifier: ^0.0.15
         version: 0.0.15
       tar:
-        specifier: ^7.5.15
-        version: 7.5.15
+        specifier: ^7.5.16
+        version: 7.5.16
       typescript-template:
         specifier: workspace:*
         version: link:../templates/typescript
@@ -7153,8 +7153,8 @@ packages:
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   temp-dir@1.0.0:
@@ -17460,7 +17460,7 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  tar@7.5.15:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Summary
- chore: bump tar

## Test plan
- [x] `fnm exec --using=22.20.0 pnpm install --frozen-lockfile --lockfile-only`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `tar` package from `7.5.15` to `7.5.16` in both the `.vitest/package.json` and `pnpm-lock.yaml` files to address security vulnerabilities present in older versions.

### Detailed summary
- Updated `tar` version in `.vitest/package.json` from `7.5.15` to `7.5.16`.
- Updated `tar` specifier and version in `pnpm-lock.yaml` from `7.5.15` to `7.5.16`.
- Changed integrity hash for `tar@7.5.16` in `pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->