### PR TITLE
[codex] Add viem-free common core entrypoint

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -13,7 +13,7 @@ npm install @alchemy/common viem
 - **`alchemyTransport`** - viem-compatible HTTP transport for Alchemy APIs (supports API key, JWT, or direct URL auth)
 - **Chain registry** - `getAlchemyRpcUrl`, `isChainSupported`, `getSupportedChainIds`
 - **Custom chain definitions** (via `@alchemy/common/chains`) - chains not yet in viem
-- **`AlchemyRestClient`** - typed REST client for non-JSON-RPC Alchemy APIs
+- **Core infrastructure** (via `@alchemy/common/core`) - viem-free REST/JSON-RPC clients, normalized API errors, retry/timeout helpers, and network resolution
 - **Error classes** - `BaseError`, `ChainNotFoundError`, `AccountNotFoundError`, `ConnectionConfigError`, etc.
 - **Logging** - `createLogger`, `setGlobalLoggerConfig`, `LogLevel`
 - **Utilities** - `bigIntMultiply`, `bigIntMax`, `lowerAddress`, `assertNever`

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/esm/index.js",
       "default": "./dist/esm/index.js"
     },
+    "./core": {
+      "types": "./dist/types/core.d.ts",
+      "import": "./dist/esm/core.js",
+      "default": "./dist/esm/core.js"
+    },
     "./chains": {
       "types": "./dist/types/chains.d.ts",
       "import": "./dist/esm/chains.js",
@@ -70,5 +75,10 @@
   "bugs": {
     "url": "https://github.com/alchemyplatform/aa-sdk/issues"
   },
-  "homepage": "https://github.com/alchemyplatform/aa-sdk#readme"
+  "homepage": "https://github.com/alchemyplatform/aa-sdk#readme",
+  "peerDependenciesMeta": {
+    "viem": {
+      "optional": true
+    }
+  }
 }

--- a/packages/common/src/core.ts
+++ b/packages/common/src/core.ts
@@ -1,0 +1,46 @@
+// The viem-free entry point ("@alchemy/common/core"): everything here is
+// importable without viem installed. The root barrel ("@alchemy/common")
+// additionally exposes the viem-based transport, chains, and BaseError for
+// wallet-facing packages. Chain-library-free consumers (the Data APIs core)
+// import from this entry only; adding a viem-dependent export here breaks
+// their install, and the data-apis no-viem proof will catch it.
+
+// errors (AlchemyError-rooted family — no viem)
+export { AlchemyError } from "./errors/AlchemyError.js";
+export type { AlchemyApiErrorDetails } from "./errors/AlchemyApiError.js";
+export { AlchemyApiError } from "./errors/AlchemyApiError.js";
+export { AlchemyFetchError } from "./errors/AlchemyFetchError.js";
+export { AlchemyServerError } from "./errors/AlchemyServerError.js";
+
+// REST + JSON-RPC runtime
+export type * from "./rest/restClient.js";
+export type * from "./rest/types.js";
+export { AlchemyRestClient } from "./rest/restClient.js";
+export type {
+  AlchemyJsonRpcClientParams,
+  JsonRpcRequestFn,
+  JsonRpcSchema,
+} from "./rest/jsonRpcClient.js";
+export { AlchemyJsonRpcClient } from "./rest/jsonRpcClient.js";
+
+// network identity (slug / CAIP-2 resolution; chain ID bridge for adapters)
+export type {
+  AlchemyNetwork,
+  KnownAlchemyNetwork,
+  ResolvedNetwork,
+} from "./networks/networkRegistry.js";
+export {
+  resolveNetwork,
+  resolveNetworkByChainId,
+} from "./networks/networkRegistry.js";
+
+// chain registry data (generated; no viem)
+export {
+  getAlchemyRpcUrl,
+  getSupportedChainIds,
+  isChainSupported,
+} from "./transport/chainRegistry.js";
+
+// utils
+export { composeSignals, sleep } from "./utils/signals.js";
+export { redactUrlCredentials } from "./utils/redact.js";

--- a/packages/common/src/errors/AlchemyApiError.ts
+++ b/packages/common/src/errors/AlchemyApiError.ts
@@ -1,0 +1,72 @@
+import { AlchemyError } from "./AlchemyError.js";
+
+/** Normalized failure metadata shared across REST and JSON-RPC channels. */
+export type AlchemyApiErrorDetails = {
+  /** HTTP status code, when the failure was an HTTP response. */
+  status?: number;
+  /** Provider error code: JSON-RPC `error.code` or a REST error-body code. */
+  code?: number | string;
+  /** The client-generated X-Alchemy-Client-Request-Id sent with the request. */
+  requestId?: string;
+  /** Parsed Retry-After hint in milliseconds, when the server provided one. */
+  retryAfter?: number;
+};
+
+/**
+ * The normalized error family for Alchemy API failures. Both the REST channel
+ * (AlchemyRestClient → AlchemyServerError/AlchemyFetchError, which extend
+ * this class) and SDK JSON-RPC actions surface failures as AlchemyApiError, so
+ * consumers can handle status/code/requestId/retryAfter uniformly:
+ *
+ * ```ts
+ * try { ... } catch (e) {
+ *   if (e instanceof AlchemyApiError && e.status === 429) {
+ *     await sleep(e.retryAfter ?? 1_000);
+ *   }
+ * }
+ * ```
+ */
+export class AlchemyApiError extends AlchemyError {
+  override name = "AlchemyApiError";
+
+  /** HTTP status code, when the failure was an HTTP response. */
+  readonly status?: number;
+  /** Provider error code: JSON-RPC `error.code` or a REST error-body code. */
+  readonly code?: number | string;
+  /** The client-generated X-Alchemy-Client-Request-Id sent with the request. */
+  readonly requestId?: string;
+  /** Parsed Retry-After hint in milliseconds, when the server provided one. */
+  readonly retryAfter?: number;
+
+  /**
+   * Creates a normalized API error.
+   *
+   * @param {string} shortMessage The headline error message
+   * @param {AlchemyApiErrorDetails & { cause?: Error; details?: string; metaMessages?: string[] }} [args] Failure metadata plus AlchemyError options
+   */
+  constructor(
+    shortMessage: string,
+    args: AlchemyApiErrorDetails & {
+      cause?: Error;
+      details?: string;
+      metaMessages?: string[];
+    } = {},
+  ) {
+    const { status, code, requestId, retryAfter, ...baseArgs } = args;
+    const metaMessages = [
+      ...(baseArgs.metaMessages ?? []),
+      ...(requestId ? [`Request ID: ${requestId}`] : []),
+    ];
+    // AlchemyError takes cause XOR details; forward whichever was provided.
+    super(
+      shortMessage,
+      baseArgs.cause
+        ? { cause: baseArgs.cause, metaMessages }
+        : { details: baseArgs.details, metaMessages },
+    );
+    this.status = status;
+    this.code = code;
+    this.requestId = requestId;
+    this.retryAfter = retryAfter;
+  }
+}

--- a/packages/common/src/errors/AlchemyError.ts
+++ b/packages/common/src/errors/AlchemyError.ts
@@ -1,0 +1,95 @@
+import { VERSION } from "../version.js";
+
+type AlchemyErrorParameters = {
+  docsPath?: string;
+  docsSlug?: string;
+  metaMessages?: string[];
+} & (
+  | {
+      cause?: never;
+      details?: string;
+    }
+  | {
+      cause: Error;
+      details?: never;
+    }
+);
+
+/**
+ * Dependency-free error root for SDK surfaces that must not pull in viem at
+ * runtime (the Data APIs core and the shared REST/JSON-RPC runtime). Message
+ * shape matches {@link BaseError} (short message, meta messages, docs link,
+ * details, version line), and `walk()` provides viem-compatible cause-chain
+ * traversal — but the class extends plain `Error`.
+ *
+ * Wallet-facing errors keep extending {@link BaseError} (viem-based); this
+ * root exists so `AlchemyApiError` and friends stay viem-free.
+ */
+export class AlchemyError extends Error {
+  override name = "AlchemyError";
+  readonly version = VERSION;
+  readonly shortMessage: string;
+  readonly details?: string;
+  readonly docsPath?: string;
+  readonly metaMessages?: string[];
+
+  /**
+   * Creates an error with the SDK's standard message formatting.
+   *
+   * @param {string} shortMessage The headline error message
+   * @param {AlchemyErrorParameters} args Docs pointers, meta messages, and cause XOR details
+   */
+  constructor(shortMessage: string, args: AlchemyErrorParameters = {}) {
+    const details =
+      args.cause instanceof AlchemyError
+        ? args.cause.details
+        : args.cause?.message
+          ? args.cause.message
+          : args.details;
+    const docsPath =
+      args.cause instanceof AlchemyError
+        ? args.cause.docsPath || args.docsPath
+        : args.docsPath;
+
+    super(
+      [
+        shortMessage || "An error occurred.",
+        "",
+        ...(args.metaMessages ? [...args.metaMessages, ""] : []),
+        ...(docsPath
+          ? [
+              `Docs: https://www.alchemy.com/docs/wallets${docsPath}${
+                args.docsSlug ? `#${args.docsSlug}` : ""
+              }`,
+            ]
+          : []),
+        ...(details ? [`Details: ${details}`] : []),
+        `Version: ${VERSION}`,
+      ].join("\n"),
+      args.cause ? { cause: args.cause } : undefined,
+    );
+
+    this.shortMessage = shortMessage;
+    this.details = details;
+    this.docsPath = docsPath;
+    this.metaMessages = args.metaMessages;
+  }
+
+  /**
+   * Walks the cause chain: with no predicate, returns the deepest error;
+   * with a predicate, returns the first matching error or null (viem
+   * BaseError-compatible semantics).
+   *
+   * @param {Function} [fn] Optional predicate over each error in the chain
+   * @returns {Error | null} The deepest error, the first match, or null
+   */
+  walk(fn?: (err: unknown) => boolean): Error | null {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let err: Error = this;
+    while (true) {
+      if (fn?.(err)) return err;
+      if (!(err.cause instanceof Error)) return fn ? null : err;
+      err = err.cause;
+    }
+  }
+}

--- a/packages/common/src/errors/AlchemyFetchError.ts
+++ b/packages/common/src/errors/AlchemyFetchError.ts
@@ -1,0 +1,31 @@
+import {
+  AlchemyApiError,
+  type AlchemyApiErrorDetails,
+} from "./AlchemyApiError.js";
+
+/**
+ * Viem-free fetch failure for the shared REST/JSON-RPC runtime.
+ */
+export class AlchemyFetchError extends AlchemyApiError {
+  override name = "AlchemyFetchError";
+
+  /**
+   * Initializes a new fetch error for a request that failed before a response.
+   *
+   * @param {string} route - The route that failed to fetch.
+   * @param {string} method - The HTTP method that was used.
+   * @param {Error} cause - The cause of the error.
+   * @param {AlchemyApiErrorDetails} apiDetails - Normalized failure metadata.
+   */
+  constructor(
+    route: string,
+    method: string,
+    cause?: Error,
+    apiDetails?: AlchemyApiErrorDetails,
+  ) {
+    super(`[${method}] ${route} failed to fetch`, {
+      cause,
+      ...apiDetails,
+    });
+  }
+}

--- a/packages/common/src/errors/AlchemyServerError.ts
+++ b/packages/common/src/errors/AlchemyServerError.ts
@@ -1,0 +1,32 @@
+import {
+  AlchemyApiError,
+  type AlchemyApiErrorDetails,
+} from "./AlchemyApiError.js";
+
+/**
+ * Viem-free HTTP response failure for the shared REST/JSON-RPC runtime.
+ */
+export class AlchemyServerError extends AlchemyApiError {
+  override name = "AlchemyServerError";
+
+  /**
+   * Initializes a new server error for a failed HTTP response.
+   *
+   * @param {string} message - The error message.
+   * @param {number} status - The HTTP status code of the error.
+   * @param {Error} cause - The cause of the error.
+   * @param {AlchemyApiErrorDetails} apiDetails - Normalized failure metadata.
+   */
+  constructor(
+    message: string,
+    status: number,
+    cause?: Error,
+    apiDetails?: AlchemyApiErrorDetails,
+  ) {
+    super(`HTTP request failed with status ${status}: ${message}`, {
+      cause,
+      ...apiDetails,
+      status,
+    });
+  }
+}

--- a/packages/common/src/errors/FetchError.ts
+++ b/packages/common/src/errors/FetchError.ts
@@ -7,7 +7,7 @@ export class FetchError extends BaseError {
   override name = "FetchError";
 
   /**
-   * Initializes a new instance of the error message with a default message indicating that no chain was supplied to the client.
+   * Initializes a fetch error for a request that failed before a response.
    *
    * @param {string} route - The route that failed to fetch.
    * @param {string} method - The HTTP method that was used.

--- a/packages/common/src/errors/ServerError.ts
+++ b/packages/common/src/errors/ServerError.ts
@@ -7,7 +7,7 @@ export class ServerError extends BaseError {
   override name = "ServerError";
 
   /**
-   * Initializes a new instance of the error message with a default message indicating that no chain was supplied to the client.
+   * Initializes a server error for a failed HTTP response.
    *
    * @param {string} message - The error message.
    * @param {number} status - The HTTP status code of the error.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,11 +2,6 @@
 export type * from "./transport/alchemy.js";
 export { alchemyTransport, isAlchemyTransport } from "./transport/alchemy.js";
 
-// http -- Revisit exporting this once it has a use case.
-// export type * from "./rest/restClient.js";
-// export type * from "./rest/types.js";
-// export { AlchemyRestClient } from "./rest/restClient.js";
-
 // chain registry utilities
 export {
   getAlchemyRpcUrl,

--- a/packages/common/src/networks/networkRegistry.ts
+++ b/packages/common/src/networks/networkRegistry.ts
@@ -1,0 +1,138 @@
+import { AlchemyError } from "../errors/AlchemyError.js";
+import { ALCHEMY_RPC_MAPPING } from "../transport/chainRegistry.js";
+
+/**
+ * Known Alchemy network slugs for autocomplete.
+ *
+ * TODO(data-sdk): generate this union from daikon via the ws-tools CLI in the
+ * same pass that generates ALCHEMY_RPC_MAPPING, so it is never hand-maintained.
+ * This subset exists to prove the MVP only.
+ */
+export type KnownAlchemyNetwork =
+  | "eth-mainnet"
+  | "eth-sepolia"
+  | "base-mainnet"
+  | "base-sepolia"
+  | "polygon-mainnet"
+  | "polygon-amoy"
+  | "arb-mainnet"
+  | "arb-sepolia"
+  | "opt-mainnet"
+  | "opt-sepolia"
+  | "solana-mainnet"
+  | "solana-devnet";
+
+/**
+ * An Alchemy network identifier. Known slugs get autocomplete; arbitrary
+ * strings are accepted as an escape hatch so new networks work without an
+ * SDK release.
+ */
+export type AlchemyNetwork = KnownAlchemyNetwork | (string & {});
+
+/**
+ * A resolved network: the Alchemy slug used for URL construction and REST
+ * payloads, plus the numeric chain ID when one exists (EVM only).
+ */
+export type ResolvedNetwork = {
+  slug: string;
+  chainId?: number;
+};
+
+// Solana networks have no numeric chain ID; CAIP-2 aliases match the
+// identifiers wallet-apis already uses.
+const SOLANA_SLUG_BY_CAIP2: Record<string, string> = {
+  "solana:mainnet": "solana-mainnet",
+  "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": "solana-mainnet",
+  "solana:devnet": "solana-devnet",
+  "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "solana-devnet",
+};
+
+const SOLANA_SLUGS = new Set(Object.values(SOLANA_SLUG_BY_CAIP2));
+
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+// The slug is already present in every daikon-generated registry URL
+// (https://{slug}.g.alchemy.com/v2); derive the slug<->chainId maps from it
+// rather than maintaining a second copy. Once ws-tools emits structured
+// entries ({ slug, chainId, caip2 }), these derivations go away.
+const slugByChainId = new Map<number, string>();
+const chainIdBySlug = new Map<string, number>();
+for (const [chainId, url] of Object.entries(ALCHEMY_RPC_MAPPING)) {
+  const slug = new URL(url).hostname.split(".")[0];
+  if (slug) {
+    slugByChainId.set(Number(chainId), slug);
+    chainIdBySlug.set(slug, Number(chainId));
+  }
+}
+
+/**
+ * Resolves a chain ID to the Alchemy network slug.
+ *
+ * @example
+ * ```ts
+ * resolveNetworkByChainId(1); // { slug: "eth-mainnet", chainId: 1 }
+ * ```
+ *
+ * @param {number} chainId The EVM chain ID to resolve
+ * @returns {ResolvedNetwork} The resolved slug and optional chain ID
+ */
+export function resolveNetworkByChainId(chainId: number): ResolvedNetwork {
+  const slug = slugByChainId.get(chainId);
+  if (!Number.isInteger(chainId) || !slug) {
+    throw new AlchemyError(
+      `Chain ID ${chainId} is not in the Alchemy network registry.`,
+    );
+  }
+  return { slug, chainId };
+}
+
+/**
+ * Resolves an Alchemy network slug or CAIP-2 identifier to the Alchemy network
+ * slug (and chain ID when one exists). Both forms resolve against the same
+ * daikon-generated registry.
+ *
+ * @example
+ * ```ts
+ * resolveNetwork("eth-mainnet"); // { slug: "eth-mainnet", chainId: 1 }
+ * resolveNetwork("eip155:1"); // { slug: "eth-mainnet", chainId: 1 }
+ * resolveNetwork("solana:mainnet"); // { slug: "solana-mainnet" }
+ * ```
+ *
+ * @param {AlchemyNetwork} input The network to resolve
+ * @returns {ResolvedNetwork} The resolved slug and optional chain ID
+ */
+export function resolveNetwork(input: AlchemyNetwork): ResolvedNetwork {
+  if (input.startsWith("eip155:")) {
+    const chainId = Number(input.slice("eip155:".length));
+    try {
+      return resolveNetworkByChainId(chainId);
+    } catch {
+      throw new AlchemyError(
+        `CAIP-2 identifier "${input}" is not in the Alchemy network registry.`,
+      );
+    }
+  }
+
+  if (input.startsWith("solana:")) {
+    const slug = SOLANA_SLUG_BY_CAIP2[input];
+    if (!slug) {
+      throw new AlchemyError(
+        `CAIP-2 identifier "${input}" is not a known Solana network.`,
+      );
+    }
+    return { slug };
+  }
+
+  if (!SLUG_PATTERN.test(input)) {
+    throw new AlchemyError(
+      `"${input}" is not a valid Alchemy network slug (expected lowercase letters, digits, and hyphens).`,
+    );
+  }
+
+  // Known slugs resolve a chain ID; unknown slugs are the escape hatch for
+  // networks newer than the shipped registry (URL is composed directly).
+  if (SOLANA_SLUGS.has(input)) {
+    return { slug: input };
+  }
+  return { slug: input, chainId: chainIdBySlug.get(input) };
+}

--- a/packages/common/src/rest/httpEngine.ts
+++ b/packages/common/src/rest/httpEngine.ts
@@ -1,0 +1,117 @@
+import { AlchemyFetchError } from "../errors/AlchemyFetchError.js";
+import { composeSignals, sleep } from "../utils/signals.js";
+
+// Internal request engine shared by AlchemyRestClient and
+// AlchemyJsonRpcClient. Not exported from the package.
+
+/** Parameters for one logical request (spanning retries). */
+export type HttpSendParams = {
+  url: string;
+  method: string;
+  /** Final headers, including auth and X-Alchemy-Client-Request-Id. */
+  headers: Headers;
+  body?: string;
+  /** Label used in AlchemyFetchError messages — a route or RPC method, never a URL. */
+  errorLabel: string;
+  requestId: string;
+  signal?: AbortSignal;
+  retryCount: number;
+  retryDelay: number;
+  timeout: number;
+};
+
+/**
+ * Parses a Retry-After response header into milliseconds (integer seconds or
+ * HTTP-date forms).
+ *
+ * @param {Response} response The HTTP response
+ * @returns {number | undefined} Milliseconds to wait, or undefined when absent/unparseable
+ */
+export function parseRetryAfter(response: Response): number | undefined {
+  const header = response.headers.get("Retry-After");
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return undefined;
+}
+
+/**
+ * Best-effort extraction of an error code from a JSON error body.
+ *
+ * @param {string} bodyText The raw response body
+ * @returns {number | string | undefined} The error code, when present
+ */
+export function parseErrorCode(bodyText: string): number | string | undefined {
+  try {
+    const parsed = JSON.parse(bodyText);
+    const code = parsed?.error?.code ?? parsed?.code;
+    return typeof code === "number" || typeof code === "string"
+      ? code
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Sends a request with the SDK's standard retry policy: 429/5xx/network
+ * failures retried with exponential backoff (honoring Retry-After), a
+ * per-attempt timeout merged with the caller's signal, and caller-initiated
+ * aborts rethrown immediately without retrying. Resolves with the final
+ * Response — ok, or non-ok once the policy is exhausted or the status is
+ * non-retryable — leaving error mapping to the typed frontends. Throws
+ * AlchemyFetchError when network/timeout failures exhaust the retries.
+ *
+ * @param {HttpSendParams} params The request and retry configuration
+ * @returns {Promise<{ response: Response; retryAfter?: number }>} The final response and any Retry-After hint
+ */
+export async function sendWithRetry({
+  url,
+  method,
+  headers,
+  body,
+  errorLabel,
+  requestId,
+  signal: callerSignal,
+  retryCount,
+  retryDelay,
+  timeout,
+}: HttpSendParams): Promise<{ response: Response; retryAfter?: number }> {
+  for (let attempt = 0; ; attempt++) {
+    // Per-attempt timeout; the caller's signal spans all attempts.
+    const signal = composeSignals(callerSignal, AbortSignal.timeout(timeout));
+
+    let response: Response;
+    try {
+      response = await fetch(url, { method, body, headers, signal });
+    } catch (error) {
+      // A caller-initiated abort propagates as-is, immediately.
+      if (callerSignal?.aborted) throw callerSignal.reason;
+      // Timeout or network failure: retryable.
+      if (attempt < retryCount) {
+        await sleep((1 << attempt) * retryDelay, callerSignal);
+        continue;
+      }
+      throw new AlchemyFetchError(
+        errorLabel,
+        method,
+        error instanceof Error ? error : undefined,
+        { requestId },
+      );
+    }
+
+    if (response.ok) {
+      return { response };
+    }
+
+    const retryAfter = parseRetryAfter(response);
+    const retryable = response.status === 429 || response.status >= 500;
+    if (retryable && attempt < retryCount) {
+      await sleep(retryAfter ?? (1 << attempt) * retryDelay, callerSignal);
+      continue;
+    }
+    return { response, retryAfter };
+  }
+}

--- a/packages/common/src/rest/jsonRpcClient.ts
+++ b/packages/common/src/rest/jsonRpcClient.ts
@@ -1,0 +1,136 @@
+import { AlchemyApiError } from "../errors/AlchemyApiError.js";
+import { AlchemyServerError } from "../errors/AlchemyServerError.js";
+import { withAlchemyHeaders } from "../utils/headers.js";
+import { redactUrlCredentials } from "../utils/redact.js";
+import { parseErrorCode, sendWithRetry } from "./httpEngine.js";
+import {
+  DEFAULT_RETRY_COUNT,
+  DEFAULT_RETRY_DELAY_MS,
+  DEFAULT_TIMEOUT_MS,
+  type AlchemyRestClientParams,
+} from "./restClient.js";
+import type { RestRequestOptions } from "./types.js";
+
+/**
+ * A typed JSON-RPC schema: a tuple of method entries. Structurally compatible
+ * with viem's RpcSchema shape, but defined here so consumers need no viem
+ * dependency.
+ */
+export type JsonRpcSchema = readonly {
+  Method: string;
+  Parameters?: unknown;
+  ReturnType: unknown;
+}[];
+
+export type JsonRpcRequestFn<Schema extends JsonRpcSchema> = <
+  method extends Schema[number]["Method"],
+>(
+  args: {
+    method: method;
+    params: Extract<Schema[number], { Method: method }>["Parameters"];
+  },
+  options?: RestRequestOptions,
+) => Promise<Extract<Schema[number], { Method: method }>["ReturnType"]>;
+
+/** Parameters for creating an AlchemyJsonRpcClient (URL is required: JSON-RPC is always endpoint-scoped). */
+export type AlchemyJsonRpcClientParams = AlchemyRestClientParams & {
+  url: string;
+};
+
+/**
+ * A typed JSON-RPC client over the same HTTP engine as
+ * {@link AlchemyRestClient}: bounded retries on 429/5xx/network failures
+ * (honoring Retry-After), per-attempt timeouts, abort support, and a
+ * per-request X-Alchemy-Client-Request-Id surfaced on thrown errors.
+ * JSON-RPC-level errors (an `error` object on HTTP 200) are deterministic and
+ * are never retried; they throw {@link AlchemyApiError} carrying the RPC
+ * error code.
+ */
+export class AlchemyJsonRpcClient<Schema extends JsonRpcSchema> {
+  private readonly url: string;
+  private readonly headers: Headers;
+  private readonly retryCount: number;
+  private readonly retryDelay: number;
+  private readonly timeout: number;
+  private nextId = 1;
+
+  /**
+   * Creates a new instance of AlchemyJsonRpcClient.
+   *
+   * @param {AlchemyJsonRpcClientParams} params - Endpoint URL plus auth, headers, and retry/timeout defaults.
+   */
+  constructor({
+    apiKey,
+    jwt,
+    url,
+    headers,
+    retryCount,
+    retryDelay,
+    timeout,
+  }: AlchemyJsonRpcClientParams) {
+    this.url = url;
+    this.headers = new Headers(withAlchemyHeaders({ headers, apiKey, jwt }));
+    this.headers.set("Content-Type", "application/json");
+    this.retryCount = retryCount ?? DEFAULT_RETRY_COUNT;
+    this.retryDelay = retryDelay ?? DEFAULT_RETRY_DELAY_MS;
+    this.timeout = timeout ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   * Sends a JSON-RPC request and returns its result.
+   *
+   * @param {object} args - The request to send
+   * @param {string} args.method - The JSON-RPC method name
+   * @param {unknown} args.params - The positional params for the method
+   * @param {RestRequestOptions} [options] - Per-request signal and retry/timeout overrides
+   * @returns {Promise<unknown>} The JSON-RPC result
+   */
+  public request: JsonRpcRequestFn<Schema> = async (
+    { method, params },
+    options,
+  ) => {
+    const requestId = crypto.randomUUID();
+    const headers = new Headers(this.headers);
+    headers.set("X-Alchemy-Client-Request-Id", requestId);
+
+    const { response, retryAfter } = await sendWithRetry({
+      url: this.url,
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method,
+        params,
+      }),
+      errorLabel: method,
+      requestId,
+      signal: options?.signal,
+      retryCount: options?.retryCount ?? this.retryCount,
+      retryDelay: options?.retryDelay ?? this.retryDelay,
+      timeout: options?.timeout ?? this.timeout,
+    });
+
+    if (!response.ok) {
+      const bodyText = await response.text();
+      throw new AlchemyServerError(
+        redactUrlCredentials(bodyText),
+        response.status,
+        new Error(response.statusText),
+        { requestId, retryAfter, code: parseErrorCode(bodyText) },
+      );
+    }
+
+    const body = await response.json();
+    if (body?.error != null) {
+      throw new AlchemyApiError(
+        redactUrlCredentials(body.error.message ?? "JSON-RPC error"),
+        { code: body.error.code, requestId },
+      );
+    }
+    if (!("result" in (body ?? {}))) {
+      throw new AlchemyApiError("Malformed JSON-RPC response", { requestId });
+    }
+    return body.result;
+  };
+}

--- a/packages/common/src/rest/restClient.ts
+++ b/packages/common/src/rest/restClient.ts
@@ -1,9 +1,13 @@
-import { FetchError } from "../errors/FetchError.js";
-import { ServerError } from "../errors/ServerError.js";
+import { AlchemyServerError } from "../errors/AlchemyServerError.js";
 import { withAlchemyHeaders } from "../utils/headers.js";
-import type { RestRequestFn, RestRequestSchema } from "./types.js";
+import { parseErrorCode, sendWithRetry } from "./httpEngine.js";
+import type { QueryParams, RestRequestFn, RestRequestSchema } from "./types.js";
 
 const ALCHEMY_API_URL = "https://api.g.alchemy.com";
+
+export const DEFAULT_RETRY_COUNT = 3;
+export const DEFAULT_RETRY_DELAY_MS = 150;
+export const DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
  * Parameters for creating an AlchemyRestClient instance.
@@ -17,48 +21,116 @@ export type AlchemyRestClientParams = {
   url?: string;
   /** Custom headers to be sent with requests */
   headers?: HeadersInit;
+  /** Max retry attempts after the initial request (default 3; retries 429/5xx/network only) */
+  retryCount?: number;
+  /** Base backoff delay in ms, doubled per attempt (default 150) */
+  retryDelay?: number;
+  /** Per-attempt timeout in ms (default 10000) */
+  timeout?: number;
 };
 
 /**
- * A client for making requests to Alchemy's non-JSON-RPC endpoints.
+ * Serializes a query object to a URL search string. Skips null/undefined
+ * values; array values append the key repeatedly (wire keys that need the
+ * bracketed form, e.g. "contractAddresses[]", carry the brackets in the key
+ * itself).
+ *
+ * @param {QueryParams | undefined} query The query object
+ * @returns {string} A "?key=value..." string, or "" when there is nothing to send
+ */
+function serializeQuery(query: QueryParams | undefined): string {
+  if (!query) return "";
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (entry != null) search.append(key, String(entry));
+      }
+    } else {
+      search.append(key, String(value));
+    }
+  }
+  const serialized = search.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+/**
+ * A client for making requests to Alchemy's non-JSON-RPC endpoints, with
+ * typed routes/bodies/queries (via a RestRequestSchema), bounded retries with
+ * exponential backoff (429/5xx/network only, honoring Retry-After),
+ * per-attempt timeouts, abort support, and a per-request idempotency id sent
+ * as X-Alchemy-Client-Request-Id and surfaced on thrown errors.
  */
 export class AlchemyRestClient<Schema extends RestRequestSchema> {
   private readonly url: string;
   private readonly headers: Headers;
+  private readonly retryCount: number;
+  private readonly retryDelay: number;
+  private readonly timeout: number;
 
   /**
    * Creates a new instance of AlchemyRestClient.
    *
-   * @param {AlchemyRestClientParams} params - The parameters for configuring the client, including API key, JWT, custom URL, and headers.
+   * @param {AlchemyRestClientParams} params - The parameters for configuring the client, including API key, JWT, custom URL, headers, and retry/timeout defaults.
    */
-  constructor({ apiKey, jwt, url, headers }: AlchemyRestClientParams) {
+  constructor({
+    apiKey,
+    jwt,
+    url,
+    headers,
+    retryCount,
+    retryDelay,
+    timeout,
+  }: AlchemyRestClientParams) {
     this.url = url ?? ALCHEMY_API_URL;
     this.headers = new Headers(withAlchemyHeaders({ headers, apiKey, jwt }));
+    this.retryCount = retryCount ?? DEFAULT_RETRY_COUNT;
+    this.retryDelay = retryDelay ?? DEFAULT_RETRY_DELAY_MS;
+    this.timeout = timeout ?? DEFAULT_TIMEOUT_MS;
   }
 
   /**
-   * Makes an HTTP request to an Alchemy non-JSON-RPC endpoint.
+   * Makes an HTTP request to an Alchemy non-JSON-RPC endpoint. Retries
+   * 429/5xx/network failures with exponential backoff (honoring Retry-After);
+   * other statuses throw immediately. A caller-initiated abort is never
+   * retried.
    *
    * @param {RestRequestFn<Schema>} params - The parameters for the request
    * @returns {Promise<unknown>} The response from the request
    */
   public request: RestRequestFn<Schema> = async (params) => {
-    const response = await fetch(`${this.url}/${params.route}`, {
+    const requestId = crypto.randomUUID();
+    const headers = new Headers(this.headers);
+    headers.set("X-Alchemy-Client-Request-Id", requestId);
+
+    const url = `${this.url}/${params.route}${serializeQuery(
+      params.query as QueryParams | undefined,
+    )}`;
+
+    const { response, retryAfter } = await sendWithRetry({
+      url,
       method: params.method,
+      headers,
       body: params.body ? JSON.stringify(params.body) : undefined,
-      headers: this.headers,
-    }).catch((error) => {
-      throw new FetchError(params.route, params.method, error);
+      errorLabel: params.route,
+      requestId,
+      signal: params.signal,
+      retryCount: params.retryCount ?? this.retryCount,
+      retryDelay: params.retryDelay ?? this.retryDelay,
+      timeout: params.timeout ?? this.timeout,
     });
 
-    if (!response.ok) {
-      throw new ServerError(
-        await response.text(),
-        response.status,
-        new Error(response.statusText),
-      );
+    if (response.ok) {
+      return response.json();
     }
 
-    return response.json();
+    const bodyText = await response.text();
+    throw new AlchemyServerError(
+      bodyText,
+      response.status,
+      new Error(response.statusText),
+      { requestId, retryAfter, code: parseErrorCode(bodyText) },
+    );
   };
 }

--- a/packages/common/src/rest/types.ts
+++ b/packages/common/src/rest/types.ts
@@ -1,11 +1,39 @@
-import type { Prettify } from "viem";
+/** Flattens an intersection for readable hover types (viem-equivalent, local to stay viem-free). */
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+/** Values the query serializer accepts (null/undefined entries are skipped). */
+export type QueryValue = string | number | boolean | null | undefined;
+
+/** A query-params object; array values serialize as repeated keys. */
+export type QueryParams = Record<string, QueryValue | readonly QueryValue[]>;
 
 export type RestRequestSchema = readonly {
   Route: string;
   Method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD";
   Body?: unknown | undefined;
+  Query?: unknown | undefined;
   Response: unknown;
 }[];
+
+/** Per-request runtime options; values override the client-level defaults. */
+export type RestRequestOptions = {
+  /** Abort the request (and any pending retries). */
+  signal?: AbortSignal;
+  /** Max retry attempts after the initial request (client default applies when omitted). */
+  retryCount?: number;
+  /** Base backoff delay in ms (client default applies when omitted). */
+  retryDelay?: number;
+  /** Per-attempt timeout in ms (client default applies when omitted). */
+  timeout?: number;
+};
+
+/**
+ * Reads a schema entry's Query member without indexed access, so legacy
+ * entries that never declared Query resolve to undefined instead of erroring.
+ */
+type EntryQuery<Entry> = "Query" extends keyof Entry
+  ? Entry["Query"]
+  : undefined;
 
 export type RestRequestParams<
   Schema extends RestRequestSchema | undefined = undefined,
@@ -21,14 +49,23 @@ export type RestRequestParams<
           ? Schema[K]["Body"] extends undefined
             ? { body?: undefined }
             : { body: Schema[K]["Body"] }
-          : never)
+          : never) &
+          (Schema[K] extends Schema[number]
+            ? EntryQuery<Schema[K]> extends undefined
+              ? { query?: undefined }
+              : undefined extends EntryQuery<Schema[K]>
+                ? { query?: EntryQuery<Schema[K]> }
+                : { query: EntryQuery<Schema[K]> }
+            : never) &
+          RestRequestOptions
       >;
     }[number]
   : {
       route: string;
       method: RestRequestSchema[number]["Method"];
       body?: unknown | undefined;
-    };
+      query?: QueryParams | undefined;
+    } & RestRequestOptions;
 
 export type RestRequestFn<
   Schema extends RestRequestSchema | undefined = undefined,

--- a/packages/common/src/utils/redact.ts
+++ b/packages/common/src/utils/redact.ts
@@ -1,0 +1,14 @@
+/**
+ * Redacts credentials that can appear in URLs: keys embedded in `/v2/{key}` paths
+ * RPC paths (when a caller configured a key-bearing url) and apiKey query
+ * params. The header-auth paths never put keys in URLs; this protects
+ * configured-url escape hatches and any server-echoed text.
+ *
+ * @param {string} text Any error text that may embed a URL
+ * @returns {string} The text with credentials replaced by "[redacted]"
+ */
+export function redactUrlCredentials(text: string): string {
+  return text
+    .replace(/(\/v2\/)[A-Za-z0-9_-]+/g, "$1[redacted]")
+    .replace(/([?&]apiKey=)[^&\s]+/gi, "$1[redacted]");
+}

--- a/packages/common/src/utils/signals.ts
+++ b/packages/common/src/utils/signals.ts
@@ -1,0 +1,55 @@
+/**
+ * Combines multiple abort signals into one that aborts when any input aborts.
+ * Uses AbortSignal.any where available, with an addEventListener fallback.
+ *
+ * @param {...(AbortSignal | undefined)} signals Signals to combine (undefined entries are skipped)
+ * @returns {AbortSignal | undefined} The combined signal, or undefined if none were provided
+ */
+export function composeSignals(
+  ...signals: Array<AbortSignal | undefined>
+): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => s != null);
+  if (present.length === 0) return undefined;
+  if (present.length === 1) return present[0];
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(present);
+  }
+  const controller = new AbortController();
+  for (const signal of present) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener("abort", () => controller.abort(signal.reason), {
+      once: true,
+      signal: controller.signal,
+    });
+  }
+  return controller.signal;
+}
+
+/**
+ * Waits for a duration, rejecting immediately with the signal's reason if the
+ * signal aborts first.
+ *
+ * @param {number} ms Milliseconds to wait
+ * @param {AbortSignal} [signal] Optional abort signal
+ * @returns {Promise<void>} Resolves after the delay
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/common/tests/errors/alchemyError.test.ts
+++ b/packages/common/tests/errors/alchemyError.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { AlchemyError } from "../../src/errors/AlchemyError.js";
+import { AlchemyApiError } from "../../src/errors/AlchemyApiError.js";
+import { AlchemyServerError } from "../../src/errors/AlchemyServerError.js";
+import { AlchemyFetchError } from "../../src/errors/AlchemyFetchError.js";
+import { ServerError } from "../../src/errors/ServerError.js";
+import { FetchError } from "../../src/errors/FetchError.js";
+import { BaseError } from "../../src/errors/BaseError.js";
+import { VERSION } from "../../src/version.js";
+
+describe("AlchemyError", () => {
+  it("formats messages like BaseError (short message, meta, details, version)", () => {
+    const error = new AlchemyError("Something failed", {
+      metaMessages: ["Request ID: abc"],
+      details: "boom",
+    });
+    expect(error.message).toBe(
+      [
+        "Something failed",
+        "",
+        "Request ID: abc",
+        "",
+        "Details: boom",
+        `Version: ${VERSION}`,
+      ].join("\n"),
+    );
+    expect(error.shortMessage).toBe("Something failed");
+  });
+
+  it("derives details and docs path from an AlchemyError cause", () => {
+    const cause = new AlchemyError("inner", {
+      details: "inner-details",
+      docsPath: "/path",
+    });
+    const outer = new AlchemyError("outer", { cause });
+    expect(outer.details).toBe("inner-details");
+    expect(outer.docsPath).toBe("/path");
+    expect(outer.message).toContain("Docs: https://www.alchemy.com");
+  });
+
+  it("walk() returns the deepest cause without a predicate and first match with one", () => {
+    const root = new Error("root");
+    const mid = new AlchemyError("mid", { cause: root });
+    const top = new AlchemyError("top", { cause: mid });
+    expect(top.walk()).toBe(root);
+    expect(
+      top.walk((e) => e instanceof AlchemyError && e.shortMessage === "mid"),
+    ).toBe(mid);
+    expect(top.walk(() => false)).toBeNull();
+  });
+
+  it("the API error family is viem-free: not instanceof BaseError", () => {
+    const server = new AlchemyServerError("body", 500);
+    const fetchErr = new AlchemyFetchError("route", "GET");
+    for (const error of [server, fetchErr]) {
+      expect(error).toBeInstanceOf(AlchemyApiError);
+      expect(error).toBeInstanceOf(AlchemyError);
+      expect(error).toBeInstanceOf(Error);
+      // deliberately NOT instanceof the viem-extending BaseError
+      expect(error).not.toBeInstanceOf(BaseError);
+    }
+  });
+
+  it("legacy root FetchError and ServerError remain BaseError-based", () => {
+    const server = new ServerError("body", 500);
+    const fetchErr = new FetchError("route", "GET");
+    for (const error of [server, fetchErr]) {
+      expect(error).toBeInstanceOf(BaseError);
+      expect(error).not.toBeInstanceOf(AlchemyApiError);
+      expect(error).not.toBeInstanceOf(AlchemyError);
+    }
+  });
+
+  it("wallet-facing BaseError is untouched (still its own hierarchy)", () => {
+    const base = new BaseError("wallet error");
+    expect(base).toBeInstanceOf(Error);
+    expect(base).not.toBeInstanceOf(AlchemyError);
+  });
+});

--- a/packages/common/tests/logging/createLogger.test.ts
+++ b/packages/common/tests/logging/createLogger.test.ts
@@ -339,7 +339,9 @@ describe("createLogger", () => {
       );
 
       const entry = mockSink.mock.calls[0][0] as LogEntry;
-      expect(entry.data?.executionTimeMs).toBeGreaterThanOrEqual(10);
+      // setTimeout(10) can measure as 9ms due to millisecond truncation at
+      // both timing endpoints — allow 1ms of tolerance to deflake CI.
+      expect(entry.data?.executionTimeMs).toBeGreaterThanOrEqual(9);
     });
 
     it("should track failed profiled functions", async () => {

--- a/packages/common/tests/networks/networkRegistry.test.ts
+++ b/packages/common/tests/networks/networkRegistry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveNetwork,
+  resolveNetworkByChainId,
+} from "../../src/networks/networkRegistry.js";
+
+describe("resolveNetwork", () => {
+  it("resolves a chain id via the adapter bridge", () => {
+    expect(resolveNetworkByChainId(1)).toEqual({
+      slug: "eth-mainnet",
+      chainId: 1,
+    });
+    expect(resolveNetworkByChainId(421614)).toEqual({
+      slug: "arb-sepolia",
+      chainId: 421614,
+    });
+  });
+
+  it("resolves a known slug to the same entry as the chain id", () => {
+    expect(resolveNetwork("eth-mainnet")).toEqual(resolveNetworkByChainId(1));
+  });
+
+  it("resolves CAIP-2 identifiers", () => {
+    expect(resolveNetwork("eip155:1")).toEqual({
+      slug: "eth-mainnet",
+      chainId: 1,
+    });
+    expect(resolveNetwork("solana:mainnet")).toEqual({
+      slug: "solana-mainnet",
+    });
+    expect(resolveNetwork("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")).toEqual({
+      slug: "solana-mainnet",
+    });
+  });
+
+  it("passes through unknown slugs as the escape hatch", () => {
+    expect(resolveNetwork("some-new-chain")).toEqual({
+      slug: "some-new-chain",
+      chainId: undefined,
+    });
+  });
+
+  it("rejects inputs that are not valid hostname labels", () => {
+    expect(() => resolveNetwork("Not A Slug!")).toThrow();
+    expect(() => resolveNetwork("eth-mainnet/../evil")).toThrow();
+  });
+
+  it("rejects chain ids and CAIP-2 ids missing from the registry", () => {
+    expect(() => resolveNetworkByChainId(999999001)).toThrow();
+    expect(() => resolveNetwork("eip155:999999001")).toThrow();
+    expect(() => resolveNetwork("solana:unknownref")).toThrow();
+  });
+});

--- a/packages/common/tests/rest/jsonRpcClient.test.ts
+++ b/packages/common/tests/rest/jsonRpcClient.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AlchemyJsonRpcClient } from "../../src/rest/jsonRpcClient.js";
+import { AlchemyApiError } from "../../src/errors/AlchemyApiError.js";
+import { AlchemyServerError } from "../../src/errors/AlchemyServerError.js";
+
+type TestSchema = readonly [
+  {
+    Method: "alchemy_getThings";
+    Parameters: [{ owner: string }];
+    ReturnType: { things: string[] };
+  },
+];
+
+const fetchMock = vi.fn();
+
+const rpcResponse = (body: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+const makeClient = () =>
+  new AlchemyJsonRpcClient<TestSchema>({
+    apiKey: "test-key",
+    url: "https://eth-mainnet.example.test/v2",
+    retryDelay: 1,
+  });
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AlchemyJsonRpcClient", () => {
+  it("posts the JSON-RPC envelope with monotonic ids and auth headers", async () => {
+    fetchMock.mockImplementation(async () =>
+      rpcResponse({ jsonrpc: "2.0", id: 1, result: { things: [] } }),
+    );
+    const client = makeClient();
+    await client.request({
+      method: "alchemy_getThings",
+      params: [{ owner: "0xa" }],
+    });
+    await client.request({
+      method: "alchemy_getThings",
+      params: [{ owner: "0xb" }],
+    });
+
+    const body1 = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    const body2 = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body1).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "alchemy_getThings",
+      params: [{ owner: "0xa" }],
+    });
+    expect(body2.id).toBe(2);
+
+    const headers = fetchMock.mock.calls[0]![1].headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer test-key");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("X-Alchemy-Client-Request-Id")).toMatch(
+      /^[0-9a-f-]{36}$/,
+    );
+  });
+
+  it("retries 429 honoring Retry-After, then succeeds", async () => {
+    fetchMock
+      .mockImplementationOnce(
+        async () =>
+          new Response("{}", { status: 429, headers: { "Retry-After": "0" } }),
+      )
+      .mockImplementationOnce(async () =>
+        rpcResponse({ jsonrpc: "2.0", id: 1, result: { things: ["x"] } }),
+      );
+    const result = await makeClient().request({
+      method: "alchemy_getThings",
+      params: [{ owner: "0xa" }],
+    });
+    expect(result).toEqual({ things: ["x"] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry JSON-RPC-level errors and maps them to AlchemyApiError", async () => {
+    fetchMock.mockImplementation(async () =>
+      rpcResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32602, message: "invalid params" },
+      }),
+    );
+    const error = await makeClient()
+      .request({ method: "alchemy_getThings", params: [{ owner: "0xa" }] })
+      .catch((e) => e);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(error).toBeInstanceOf(AlchemyApiError);
+    expect(error.code).toBe(-32602);
+    expect(error.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("redacts credentials echoed in rpc error messages", async () => {
+    fetchMock.mockImplementation(async () =>
+      rpcResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32000, message: "bad key at /v2/supersecret123" },
+      }),
+    );
+    const error = await makeClient()
+      .request({ method: "alchemy_getThings", params: [{ owner: "0xa" }] })
+      .catch((e) => e);
+    expect(error.message).not.toContain("supersecret123");
+    expect(error.message).toContain("/v2/[redacted]");
+  });
+
+  it("maps non-ok HTTP responses to AlchemyServerError with status and requestId", async () => {
+    fetchMock.mockImplementation(async () =>
+      rpcResponse({ message: "nope" }, { status: 403 }),
+    );
+    const error = await makeClient()
+      .request({ method: "alchemy_getThings", params: [{ owner: "0xa" }] })
+      .catch((e) => e);
+    expect(error).toBeInstanceOf(AlchemyServerError);
+    expect(error.status).toBe(403);
+    expect(error.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("throws on malformed responses missing result and error", async () => {
+    fetchMock.mockImplementation(async () =>
+      rpcResponse({ jsonrpc: "2.0", id: 1 }),
+    );
+    await expect(
+      makeClient().request({
+        method: "alchemy_getThings",
+        params: [{ owner: "0xa" }],
+      }),
+    ).rejects.toThrow(/Malformed JSON-RPC response/);
+  });
+
+  it("propagates caller aborts immediately", async () => {
+    const controller = new AbortController();
+    fetchMock.mockImplementation(async (_url, init: RequestInit) => {
+      controller.abort(new Error("user-cancelled"));
+      throw (init.signal as AbortSignal).reason;
+    });
+    const error = await makeClient()
+      .request(
+        { method: "alchemy_getThings", params: [{ owner: "0xa" }] },
+        { signal: controller.signal },
+      )
+      .catch((e) => e);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(error.message).toBe("user-cancelled");
+  });
+});

--- a/packages/common/tests/rest/restClient.test.ts
+++ b/packages/common/tests/rest/restClient.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AlchemyRestClient } from "../../src/rest/restClient.js";
+import { AlchemyApiError } from "../../src/errors/AlchemyApiError.js";
+import { AlchemyServerError } from "../../src/errors/AlchemyServerError.js";
+import { AlchemyFetchError } from "../../src/errors/AlchemyFetchError.js";
+
+type TestSchema = readonly [
+  {
+    Route: "things";
+    Method: "GET";
+    Body?: undefined;
+    Query?: { owner?: string; "tags[]"?: string[]; limit?: number } | undefined;
+    Response: { ok: boolean };
+  },
+  {
+    Route: "things/create";
+    Method: "POST";
+    Body: { name: string };
+    Response: { id: string };
+  },
+];
+
+const fetchMock = vi.fn();
+
+const jsonResponse = (body: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+const makeClient = (
+  overrides?: ConstructorParameters<typeof AlchemyRestClient>[0],
+) =>
+  new AlchemyRestClient<TestSchema>({
+    apiKey: "test-key",
+    url: "https://example.test/api",
+    retryDelay: 1, // keep retry tests fast
+    ...overrides,
+  });
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AlchemyRestClient query serialization", () => {
+  it("serializes scalars, repeats array keys, and skips nullish values", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({ ok: true }));
+    const client = makeClient();
+    await client.request({
+      route: "things",
+      method: "GET",
+      query: { owner: "0xabc", "tags[]": ["a", "b"], limit: undefined },
+    });
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toBe(
+      "https://example.test/api/things?owner=0xabc&tags%5B%5D=a&tags%5B%5D=b",
+    );
+  });
+
+  it("sends no query string when the query object is empty", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({ ok: true }));
+    await makeClient().request({ route: "things", method: "GET", query: {} });
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      "https://example.test/api/things",
+    );
+  });
+});
+
+describe("AlchemyRestClient request id", () => {
+  it("sends X-Alchemy-Client-Request-Id and keeps it stable across retries", async () => {
+    fetchMock
+      .mockImplementationOnce(async () => jsonResponse({}, { status: 500 }))
+      .mockImplementationOnce(async () => jsonResponse({ ok: true }));
+    await makeClient().request({ route: "things", method: "GET" });
+
+    const ids = fetchMock.mock.calls.map((call) =>
+      (call[1].headers as Headers).get("X-Alchemy-Client-Request-Id"),
+    );
+    expect(ids[0]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(ids[1]).toBe(ids[0]);
+  });
+
+  it("surfaces the request id on thrown AlchemyServerError", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({}, { status: 400 }));
+    const error = await makeClient()
+      .request({ route: "things", method: "GET" })
+      .catch((e) => e);
+    expect(error).toBeInstanceOf(AlchemyServerError);
+    expect(error).toBeInstanceOf(AlchemyApiError);
+    expect(error.requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(error.status).toBe(400);
+  });
+});
+
+describe("AlchemyRestClient retries", () => {
+  it("retries 429 and 5xx up to retryCount, then succeeds", async () => {
+    fetchMock
+      .mockImplementationOnce(async () => jsonResponse({}, { status: 429 }))
+      .mockImplementationOnce(async () => jsonResponse({}, { status: 503 }))
+      .mockImplementationOnce(async () => jsonResponse({ ok: true }));
+    const result = await makeClient().request({
+      route: "things",
+      method: "GET",
+    });
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-429 4xx", async () => {
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({ error: { code: "bad-owner" } }, { status: 400 }),
+    );
+    const error = await makeClient()
+      .request({ route: "things", method: "GET" })
+      .catch((e) => e);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(error.code).toBe("bad-owner");
+  });
+
+  it("honors Retry-After seconds and exposes retryAfter on the final error", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response("{}", {
+          status: 429,
+          headers: { "Retry-After": "0" },
+        }),
+    );
+    const error = await makeClient({ retryCount: 1, retryDelay: 1 })
+      .request({ route: "things", method: "GET" })
+      .catch((e) => e);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(error.status).toBe(429);
+    expect(error.retryAfter).toBe(0);
+  });
+
+  it("retries network errors and throws AlchemyFetchError with requestId when exhausted", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new TypeError("fetch failed");
+    });
+    const error = await makeClient({ retryCount: 2 })
+      .request({ route: "things", method: "GET" })
+      .catch((e) => e);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(error).toBeInstanceOf(AlchemyFetchError);
+    expect(error.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("respects per-request retryCount override of 0", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({}, { status: 500 }));
+    await makeClient()
+      .request({ route: "things", method: "GET", retryCount: 0 })
+      .catch(() => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AlchemyRestClient abort", () => {
+  it("propagates a caller abort immediately without retrying", async () => {
+    const controller = new AbortController();
+    fetchMock.mockImplementation(async (_url, init: RequestInit) => {
+      controller.abort(new Error("user-cancelled"));
+      throw (init.signal as AbortSignal).reason;
+    });
+    const error = await makeClient()
+      .request({ route: "things", method: "GET", signal: controller.signal })
+      .catch((e) => e);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(error.message).toBe("user-cancelled");
+  });
+});
+
+describe("AlchemyRestClient bodies", () => {
+  it("posts JSON bodies as before", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({ id: "1" }));
+    const result = await makeClient().request({
+      route: "things/create",
+      method: "POST",
+      body: { name: "x" },
+    });
+    expect(result).toEqual({ id: "1" });
+    expect(fetchMock.mock.calls[0]![1].body).toBe(
+      JSON.stringify({ name: "x" }),
+    );
+  });
+});

--- a/packages/common/tests/utils/redact.test.ts
+++ b/packages/common/tests/utils/redact.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { redactUrlCredentials } from "../../src/utils/redact.js";
+
+describe("redactUrlCredentials", () => {
+  it("redacts /v2/<key> path segments and apiKey query params", () => {
+    expect(
+      redactUrlCredentials(
+        "https://eth-mainnet.g.alchemy.com/v2/supersecret123 and https://x.test/?apiKey=supersecret123&y=1",
+      ),
+    ).toBe(
+      "https://eth-mainnet.g.alchemy.com/v2/[redacted] and https://x.test/?apiKey=[redacted]&y=1",
+    );
+  });
+
+  it("leaves credential-free text untouched", () => {
+    expect(redactUrlCredentials("plain message")).toBe("plain message");
+  });
+});


### PR DESCRIPTION
## Description

Add a viem-free `@alchemy/common/core` entrypoint for shared Alchemy SDK infrastructure. This lets packages such as Data APIs reuse REST/JSON-RPC transport, normalized API errors, retries/timeouts/abort handling, request IDs, redaction, and network resolution without depending on viem or wallet-client types.

The root `@alchemy/common` barrel stays wallet-facing: existing viem transport utilities and `BaseError`-based errors remain available there, while chain-library-free consumers can import only from the new `/core` subpath.

## Summary

- Add `@alchemy/common/core` package export and core barrel.
- Add viem-free `AlchemyError` / `AlchemyApiError` family plus fetch/server subclasses for shared HTTP clients.
- Add shared HTTP engine support for query params, retries, timeouts, abort signals, request IDs, retry-after parsing, and credential redaction.
- Add typed REST and JSON-RPC clients over the shared HTTP engine.
- Add network slug / CAIP-2 resolution helpers and a chain ID bridge for adapters.
- Keep root `@alchemy/common` focused on wallet/viem-facing exports and mark viem as an optional peer.
- Add tests for error shape, redaction, network resolution, REST/JSON-RPC retry/error behavior, and a small logger timing deflake.

## Test Plan

- [x] `pnpm --filter @alchemy/common test:run`
- [x] `pnpm --filter @alchemy/common build`
- [x] `pnpm --filter @alchemy/wallet-apis build`
- [x] `pnpm --filter @alchemy/smart-accounts exec tsc --project tsconfig.build.json --noEmit`
- [x] `pnpm --filter @alchemy/aa-infra exec tsc --project tsconfig.build.json --noEmit`
- [x] no-viem temp consumer proof importing `@alchemy/common/core`
- [x] `git diff --check`

## Breaking Changes

None expected. Existing root `@alchemy/common` wallet-facing exports remain available; the new core entrypoint is additive.

## Deployment Notes

No service deployment or migration required. This is a package surface addition for downstream SDK work.

LINEAR TASK: N/A - Data SDK Foundation follow-up; no Linear issue provided.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing error handling, introducing new error classes, and refining the `AlchemyRestClient` for better request management. It also adds utility functions for redacting sensitive information in URLs and improves query serialization.

### Detailed summary
- Updated documentation for `ServerError` and `FetchError`.
- Added `AlchemyFetchError` and `AlchemyServerError` classes for better error handling.
- Introduced `redactUrlCredentials` function to mask sensitive data in URLs.
- Enhanced `AlchemyRestClient` with request ID and improved retry logic.
- Implemented query serialization in `AlchemyRestClient`.
- Added tests for error handling and request functionality in both `AlchemyRestClient` and `AlchemyJsonRpcClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->