### PR TITLE
chore: include brg8 in code review ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8 @brgonzalez
+*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8
+*    @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8
+*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8 @brgonzalez

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe
+*    @0xfourzerofour @dancoombs @niveda-krish @pavelm @jakehobbs @florrdv @Richard-Dang @clinder777 @avarobinson @blakecduncan @thebrianchen @SahilAujla @CodesMcCabe @brg8


### PR DESCRIPTION
Summary: Adds `@brg8` to the global `CODEOWNERS` rule so they are included as a code owner across the repository.

Test plan: Not run; this is a CODEOWNERS metadata-only change.

# Pull Request Checklist

- [ ] Did you add new tests and confirm existing tests pass? (`pnpm test`) Not run; not applicable for CODEOWNERS-only metadata.
- [ ] Did you update relevant docs? (docs are found in the `docs` folder, and guidelines for updating/adding docs can be found in the [contribution guide](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)) Not applicable.
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? No breaking change.
- [ ] Did you run lint (`pnpm run lint:check`) and fix any issues? (`pnpm run lint:write`) Not run; not applicable for CODEOWNERS-only metadata.
- [x] Did you follow the [contribution guidelines](https://github.com/alchemyplatform/aa-sdk/blob/main/CONTRIBUTING.md)?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `CODEOWNERS` file to include additional contributors who will be responsible for code reviews and ownership.

### Detailed summary
- Added the following users to the `CODEOWNERS` file:
  - `@dancoombs`
  - `@niveda-krish`
  - `@pavelm`
  - `@jakehobbs`
  - `@florrdv`
  - `@Richard-Dang`
  - `@avarobinson`
  - `@blakecduncan`
  - `@thebrianchen`
  - `@SahilAujla`
  - `@CodesMcCabe`
  - `@brg8`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->