### PR TITLE
fix(deps): drop tar override that broke the publish pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
       "@noble/curves": "^1.4.0",
       "eslint-plugin-react-hooks": "4.6.0",
       "js-yaml@<3.15.0": "3.15.0",
-      "js-yaml@>=4 <4.3.0": "4.3.0",
-      "tar@<7.5.18": "7.5.21"
+      "js-yaml@>=4 <4.3.0": "4.3.0"
     }
   },
   "workspaces": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,6 @@ overrides:
   eslint-plugin-react-hooks: 4.6.0
   js-yaml@<3.15.0: 3.15.0
   js-yaml@>=4 <4.3.0: 4.3.0
-  tar@<7.5.18: 7.5.21
 
 importers:
 
@@ -3384,6 +3383,10 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -4443,6 +4446,10 @@ packages:
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
 
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
@@ -5832,6 +5839,10 @@ packages:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
 
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5851,6 +5862,16 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   modify-values@1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
@@ -7119,6 +7140,16 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.2.0:
+    resolution: {integrity: sha512-hctwP0Nb4AB60bj8WQgRYaMOuJYRAPMGiQUAotms5igN8ppfQM+IvjQ5HcKu1MaZh2Wy2KWVTe563Yj8dfc14w==}
+    engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.21:
     resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
@@ -9534,7 +9565,7 @@ snapshots:
       slash: 3.0.0
       ssri: 10.0.6
       string-width: 4.2.3
-      tar: 7.5.21
+      tar: 6.2.1
       temp-dir: 1.0.0
       through: 2.3.8
       tinyglobby: 0.2.12
@@ -12438,7 +12469,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 4.0.0
       ssri: 10.0.6
-      tar: 7.5.21
+      tar: 6.2.1
       unique-filename: 3.0.0
 
   call-bind-apply-helpers@1.0.2:
@@ -12518,6 +12549,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@2.0.0: {}
 
   chownr@3.0.0: {}
 
@@ -13840,6 +13873,10 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fs-minipass@3.0.3:
     dependencies:
       minipass: 7.1.3
@@ -14756,7 +14793,7 @@ snapshots:
       slash: 3.0.0
       ssri: 10.0.6
       string-width: 4.2.3
-      tar: 7.5.21
+      tar: 6.2.1
       temp-dir: 1.0.0
       through: 2.3.8
       tinyglobby: 0.2.12
@@ -15863,6 +15900,8 @@ snapshots:
 
   minipass@4.2.8: {}
 
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
 
   minizlib@2.1.2:
@@ -15877,6 +15916,10 @@ snapshots:
   mipd@0.0.7(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   modify-values@1.0.1: {}
 
@@ -15957,7 +16000,7 @@ snapshots:
       nopt: 7.2.1
       proc-log: 4.2.0
       semver: 7.7.4
-      tar: 7.5.21
+      tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -16405,7 +16448,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 2.3.1
       ssri: 10.0.6
-      tar: 7.5.21
+      tar: 6.2.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -16621,7 +16664,7 @@ snapshots:
       execa: 9.6.1
       get-port: 7.1.0
       http-proxy: 1.18.1
-      tar: 7.5.21
+      tar: 7.2.0
     transitivePeerDependencies:
       - debug
 
@@ -17392,6 +17435,24 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  tar@7.2.0:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      mkdirp: 3.0.1
+      yallist: 5.0.0
 
   tar@7.5.21:
     dependencies:


### PR DESCRIPTION
## What

Removes the `tar@<7.5.18` pnpm override added in #2549. That override forced `lerna@8.2.4` onto `tar@7`, whose API is incompatible with lerna's `packDirectory`:

```
lerna ERR! TypeError: Cannot read properties of undefined (reading 'create')
lerna ERR!     at packDirectory (.../node_modules/lerna/dist/index.js:6231:39)
```

`lerna publish` bumps versions, commits, and tags **before** packing/publishing, so the v5.0.8 version bump + git tags landed on `main`, but the actual `npm publish` never ran — leaving npm on 5.0.7 with a dangling 5.0.8 tag.

## Change

- Drop `tar@<7.5.18`. `tar` reverts to its prior resolution (6.2.1 / 7.2.0 / 7.5.21) — the same set that shipped 5.0.7 successfully.
- The `js-yaml` overrides (`3.15.0` / `4.3.0`) are **retained** — they were not implicated in the failure (the CI build steps passed; only lerna's pack step crashed on tar).

`node-tar` shipped no 6.x-compatible patch for the range lerna needs, so there is no `tar` bump that both satisfies the dependency-hygiene goal and keeps lerna 8 working. Moving lerna's `tar` forward would require a lerna v9 major upgrade, which should be evaluated on its own rather than bundled into a lockfile change.

## Verification

- `pnpm install --frozen-lockfile` passes on Node 22.20.0.
- `tar` back to the resolution that published 5.0.7; `js-yaml` remains on 3.15.0 / 4.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the package dependencies in `package.json` and `pnpm-lock.yaml`, particularly the `tar` package and its versions, while also adding new entries for several packages with their respective resolutions and engine requirements.

### Detailed summary
- Updated `tar` package versions from `7.5.21` to `6.2.1` and `7.2.0`.
- Added new packages: 
  - `chownr@2.0.0` and `fs-minipass@2.1.0`.
  - `minipass@5.0.0` and `mkdirp@1.0.4`.
- Specified engine requirements for several packages.
- Included deprecation warnings for older `tar` versions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->