### PR TITLE
feat(smart-accounts): let 7702 accounts pick a custom delegation address

### DIFF
--- a/docs/pages/reference/smart-accounts/src/functions/toModularAccountV2.mdx
+++ b/docs/pages/reference/smart-accounts/src/functions/toModularAccountV2.mdx
@@ -11,52 +11,9 @@ layout: reference
 function toModularAccountV2<TMode>(param0): Promise<ModularAccountV2>;
 ```
 
-Defined in: [packages/smart-accounts/src/ma-v2/accounts/account.ts:108](https://github.com/alchemyplatform/aa-sdk/blob/main/packages/smart-accounts/src/ma-v2/accounts/account.ts#L108)
+Defined in: [packages/smart-accounts/src/ma-v2/accounts/account.ts:128](https://github.com/alchemyplatform/aa-sdk/blob/main/packages/smart-accounts/src/ma-v2/accounts/account.ts#L128)
 
 Creates a MAv2 account.
-
-## Example
-
-```ts
-import { createPublicClient } from "viem";
-import {
-  createBundlerClient,
-  createPaymasterClient,
-} from "viem/account-abstraction";
-import { sepolia } from "viem/chains";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-import { alchemyTransport } from "@alchemy/common";
-import { estimateFeesPerGas } from "@alchemy/aa-infra";
-import { toModularAccountV2 } from "@alchemy/smart-accounts";
-
-const transport = alchemyTransport({ apiKey: "YOUR_API_KEY" });
-
-// 1. Create a MAv2 smart account
-const account = await toModularAccountV2({
-  client: createPublicClient({ chain: sepolia, transport }),
-  owner: privateKeyToAccount(generatePrivateKey()),
-});
-
-// 2. Create a bundler client with the account
-const bundlerClient = createBundlerClient({
-  account,
-  chain: sepolia,
-  transport,
-  userOperation: {
-    estimateFeesPerGas,
-  },
-  // Optional: sponsor gas with a paymaster
-  paymaster: createPaymasterClient({ transport }),
-  paymasterContext: { policyId: "YOUR_POLICY_ID" },
-});
-
-// 3. Send a user operation
-const hash = await bundlerClient.sendUserOperation({
-  calls: [{ to: "0x...", value: 0n, data: "0x" }],
-});
-
-const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
-```
 
 ## Type Parameters
 
@@ -116,3 +73,59 @@ const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
 `Promise`\<[`ModularAccountV2`](../type-aliases/ModularAccountV2)>
 
 A MAv2 account.
+
+## Examples
+
+```ts
+import { createPublicClient } from "viem";
+import {
+  createBundlerClient,
+  createPaymasterClient,
+} from "viem/account-abstraction";
+import { sepolia } from "viem/chains";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { alchemyTransport } from "@alchemy/common";
+import { estimateFeesPerGas } from "@alchemy/aa-infra";
+import { toModularAccountV2 } from "@alchemy/smart-accounts";
+
+const transport = alchemyTransport({ apiKey: "YOUR_API_KEY" });
+
+// 1. Create a MAv2 smart account
+const account = await toModularAccountV2({
+  client: createPublicClient({ chain: sepolia, transport }),
+  owner: privateKeyToAccount(generatePrivateKey()),
+});
+
+// 2. Create a bundler client with the account
+const bundlerClient = createBundlerClient({
+  account,
+  chain: sepolia,
+  transport,
+  userOperation: {
+    estimateFeesPerGas,
+  },
+  // Optional: sponsor gas with a paymaster
+  paymaster: createPaymasterClient({ transport }),
+  paymasterContext: { policyId: "YOUR_POLICY_ID" },
+});
+
+// 3. Send a user operation
+const hash = await bundlerClient.sendUserOperation({
+  calls: [{ to: "0x...", value: 0n, data: "0x" }],
+});
+
+const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
+```
+
+In `7702` mode the account delegates to `DefaultAddress.SMAV2_7702` by
+default. Pass `delegationAddress` to delegate to a different
+`SemiModularAccount7702` deployment instead.
+
+```ts
+const account = await toModularAccountV2({
+  client,
+  owner: privateKeyToAccount(generatePrivateKey()),
+  mode: "7702",
+  delegationAddress: "0x...",
+});
+```

--- a/packages/smart-accounts/src/ma-v2/accounts/account.test.ts
+++ b/packages/smart-accounts/src/ma-v2/accounts/account.test.ts
@@ -40,7 +40,11 @@ import { toLightAccount } from "../../light-account/accounts/account.js";
 import { deferralActions } from "../decorators/deferralActions.js";
 import { installValidationActions } from "../decorators/installValidation.js";
 import { HookType, SignaturePrefix } from "../types.js";
-import { buildFullNonceKey, DefaultModuleAddress } from "../utils/account.js";
+import {
+  buildFullNonceKey,
+  DefaultAddress,
+  DefaultModuleAddress,
+} from "../utils/account.js";
 import { semiModularAccountBytecodeAbi } from "../abis/semiModularAccountBytecodeAbi.js";
 import { SingleSignerValidationModule } from "../modules/single-signer-validation/module.js";
 import { PermissionBuilder, PermissionType } from "../permissionBuilder.js";
@@ -2188,6 +2192,38 @@ describe("MA v2 Account Tests", async () => {
       expect(success2).toEqual(true);
     },
   );
+
+  describe("7702 delegationAddress", () => {
+    // Construction-only: neither delegation has to exist on the fork.
+    const client7702 = () =>
+      createPublicClient({
+        transport: custom(localInstance.getClient()),
+        chain: localInstance.chain,
+      });
+
+    it("defaults to DefaultAddress.SMAV2_7702", async () => {
+      const account = await toModularAccountV2({
+        client: client7702(),
+        owner,
+        mode: "7702",
+      });
+
+      expect(account.authorization?.address).toBe(DefaultAddress.SMAV2_7702);
+    });
+
+    it("authorizes an explicit delegationAddress instead", async () => {
+      const delegationAddress = "0x1234567890AbcdEF1234567890aBcdef12345678";
+
+      const account = await toModularAccountV2({
+        client: client7702(),
+        owner,
+        mode: "7702",
+        delegationAddress,
+      });
+
+      expect(account.authorization?.address).toBe(delegationAddress);
+    });
+  });
 
   const givenConnectedProvider = async ({
     signer,

--- a/packages/smart-accounts/src/ma-v2/accounts/account.ts
+++ b/packages/smart-accounts/src/ma-v2/accounts/account.ts
@@ -45,8 +45,15 @@ export type ToModularAccountV2Params<
       factory?: never;
       factoryData?: never;
       implementationAddress?: never;
+      /**
+       * The `SemiModularAccount7702` deployment to delegate to. Defaults to
+       * {@link DefaultAddress}`.SMAV2_7702`. Use this to delegate to a
+       * deployment the SDK doesn't have an address for.
+       */
+      delegationAddress?: Address;
     }
   : {
+      delegationAddress?: never;
       factory?: Address;
       implementationAddress?: Address;
     } & (
@@ -104,6 +111,19 @@ export type ToModularAccountV2Params<
  *
  * const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
  * ```
+ *
+ * @example
+ * In `7702` mode the account delegates to `DefaultAddress.SMAV2_7702` by
+ * default. Pass `delegationAddress` to delegate to a different
+ * `SemiModularAccount7702` deployment instead.
+ * ```ts
+ * const account = await toModularAccountV2({
+ *   client,
+ *   owner: privateKeyToAccount(generatePrivateKey()),
+ *   mode: "7702",
+ *   delegationAddress: "0x...",
+ * });
+ * ```
  */
 export async function toModularAccountV2<TMode extends Mode = Mode>({
   client,
@@ -115,6 +135,7 @@ export async function toModularAccountV2<TMode extends Mode = Mode>({
   factory,
   factoryData: factoryData_,
   implementationAddress: implementationAddress_,
+  delegationAddress: delegationAddress_,
   mode,
 }: ToModularAccountV2Params<TMode>): Promise<ModularAccountV2> {
   const is7702 = mode === "7702";
@@ -124,15 +145,18 @@ export async function toModularAccountV2<TMode extends Mode = Mode>({
     mode,
     hasDeferredAction: !!deferredAction,
     hasAccountAddress: !!accountAddress_,
+    ...(is7702 ? { hasDelegationAddress: !!delegationAddress_ } : {}),
   });
 
   const entityId = signerEntity?.entityId ?? DEFAULT_OWNER_ENTITY_ID;
 
   const factoryAddress = factory ?? DefaultAddress.MAV2_FACTORY;
 
+  const delegationAddress = delegationAddress_ ?? DefaultAddress.SMAV2_7702;
+
   const implementationAddress =
     implementationAddress_ ??
-    (is7702 ? DefaultAddress.SMAV2_7702 : DefaultAddress.SMAV2_BYTECODE);
+    (is7702 ? delegationAddress : DefaultAddress.SMAV2_BYTECODE);
 
   const getFactoryArgs = async () => {
     if (is7702) {
@@ -216,7 +240,7 @@ export async function toModularAccountV2<TMode extends Mode = Mode>({
       // on a `PrivateKeyAccount`, but this seems safe as long as the
       // owner is able to `signAuthorization`.
       account: owner as PrivateKeyAccount,
-      address: DefaultAddress.SMAV2_7702,
+      address: delegationAddress,
     };
   }
 


### PR DESCRIPTION
## What

`toModularAccountV2` hardcoded `DefaultAddress.SMAV2_7702` as the 7702
delegation, so there was no way to point an account at a different
`SemiModularAccount7702` deployment. This adds an optional
`delegationAddress`, available in `mode: "7702"` only (typed `never`
otherwise).

```ts
const account = await toModularAccountV2({
  client,
  owner,
  mode: "7702",
  delegationAddress: "0x…", // defaults to DefaultAddress.SMAV2_7702
});
```

## Why the authorization line changed

The authorization re-read `DefaultAddress.SMAV2_7702` instead of the
`implementationAddress` resolved ~100 lines earlier. Invisible while both were
the same constant, but it had to change or `delegationAddress` would have had no
effect on the authorization — only on the implementation address, which 7702
mode doesn't use.

## Compatibility

No casing normalization. The default path still yields the checksummed
`DefaultAddress.SMAV2_7702` byte-for-byte, and a caller-supplied address passes
through as given, so `account.authorization.address` is unchanged for every
existing caller. No exports added or removed.

## Testing

Two construction-only tests (default delegation, explicit `delegationAddress`) —
neither needs the delegation to exist on the fork. `account.test.ts`: 27 passed.
Typecheck and eslint clean over `packages/smart-accounts/src`. Reference docs
regenerated.

## Not in scope

A version registry for selecting named `SemiModularAccount7702` versions
(`version: "v1.0.0"`, `ModularAccountV2VersionRegistry`) is a separate,
larger change — parked in #2557.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
