### PR TITLE
fix(wallet-client): preserve -32521 instead of ox/custom rewrite+retry

### DIFF
--- a/account-kit/wallet-client/src/client/createSmartWalletClient.test.ts
+++ b/account-kit/wallet-client/src/client/createSmartWalletClient.test.ts
@@ -1,0 +1,150 @@
+import { LocalAccountSigner } from "@aa-sdk/core";
+import type { AlchemyTransport } from "@account-kit/infra";
+import { describe, expect, it } from "vitest";
+import {
+  createTransport,
+  defineChain,
+  RpcRequestError,
+  type Hex,
+  type Transport,
+} from "viem";
+import { generatePrivateKey } from "viem/accounts";
+import { createSmartWalletClient } from "./index.js";
+
+const chain = defineChain({
+  id: 25,
+  name: "cronos",
+  nativeCurrency: { name: "CRO", symbol: "CRO", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["http://127.0.0.1:9"] },
+    alchemy: { http: ["http://127.0.0.1:9"] },
+  },
+});
+
+// Fake AlchemyTransport that counts requests and throws a wire-shaped RpcRequestError.
+function createCountingAlchemyTransport(error: {
+  code: number;
+  message: string;
+  data?: unknown;
+}): { transport: AlchemyTransport; getRequestCount: () => number } {
+  let requestCount = 0;
+
+  const base: Transport = () =>
+    createTransport({
+      key: "alchemy",
+      name: "Alchemy Transport",
+      type: "alchemy",
+      retryCount: 0,
+      request: async ({ method }) => {
+        if (method !== "wallet_prepareCalls") {
+          throw new Error(`unexpected method ${method}`);
+        }
+        requestCount += 1;
+        throw new RpcRequestError({
+          body: { method },
+          error: {
+            code: error.code,
+            message: error.message,
+            data: error.data,
+          },
+          url: "http://127.0.0.1:9",
+        });
+      },
+    });
+
+  const transport = Object.assign(base, {
+    updateHeaders() {},
+    config: { apiKey: "test" },
+    dynamicFetchOptions: {},
+  }) as AlchemyTransport;
+
+  return {
+    transport,
+    getRequestCount: () => requestCount,
+  };
+}
+
+describe("createSmartWalletClient error fidelity", () => {
+  it("does not retry -32521 and preserves code + revertData", async () => {
+    const { transport, getRequestCount } = createCountingAlchemyTransport({
+      code: -32521,
+      message:
+        "An error occurred while executing user operation: execution reverted",
+      data: { revertData: "0x" as Hex },
+    });
+
+    const client = createSmartWalletClient({
+      transport,
+      chain,
+      signer:
+        LocalAccountSigner.privateKeyToAccountSigner(generatePrivateKey()),
+      account: "0x0000000000000000000000000000000000000001",
+    });
+
+    let thrown: unknown;
+    try {
+      await client.request({
+        method: "wallet_prepareCalls",
+        params: [
+          {
+            from: "0x0000000000000000000000000000000000000001",
+            chainId: "0x19",
+            calls: [
+              {
+                to: "0x0000000000000000000000000000000000000002",
+                data: "0x",
+              },
+            ],
+          },
+        ],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(getRequestCount()).toBe(1);
+    expect(thrown).toMatchObject({
+      code: -32521,
+      data: { revertData: "0x" },
+    });
+  });
+
+  it("does not rewrite or amplify a real -32603 when alchemy retryCount is 0", async () => {
+    const { transport, getRequestCount } = createCountingAlchemyTransport({
+      code: -32603,
+      message: "Internal JSON-RPC error.",
+    });
+
+    const client = createSmartWalletClient({
+      transport,
+      chain,
+      signer:
+        LocalAccountSigner.privateKeyToAccountSigner(generatePrivateKey()),
+      account: "0x0000000000000000000000000000000000000001",
+    });
+
+    let thrown: unknown;
+    try {
+      await client.request({
+        method: "wallet_prepareCalls",
+        params: [
+          {
+            from: "0x0000000000000000000000000000000000000001",
+            chainId: "0x19",
+            calls: [
+              {
+                to: "0x0000000000000000000000000000000000000002",
+                data: "0x",
+              },
+            ],
+          },
+        ],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(getRequestCount()).toBe(1);
+    expect(thrown).toMatchObject({ code: -32603 });
+  });
+});

--- a/account-kit/wallet-client/src/client/index.ts
+++ b/account-kit/wallet-client/src/client/index.ts
@@ -81,12 +81,6 @@ export function createSmartWalletClient(
       ? params.policyIds
       : undefined;
 
-  // Pass the Alchemy transport through directly. Do not wrap with
-  // `custom(Provider.from(...))`: ox `parseError` rewrites AA codes like
-  // `-32521` to `-32603`, and the outer `custom()` then retries them with
-  // viem's default `retryCount=3` (4 identical wallet_prepareCalls).
-  // Typing for `client.request` comes from `WalletServerViemRpcSchema`.
-  // Retries stay on `alchemy({ retryCount })` (default 0).
   const innerClient = createClient<
     Transport,
     Chain,

--- a/account-kit/wallet-client/src/client/index.ts
+++ b/account-kit/wallet-client/src/client/index.ts
@@ -6,7 +6,6 @@ import {
   type Prettify,
   type Transport,
   createClient,
-  custom,
   type JsonRpcAccount,
 } from "viem";
 import type { InnerWalletApiClientBase } from "../types.ts";
@@ -14,11 +13,7 @@ import {
   smartWalletClientActions,
   type SmartWalletActions,
 } from "./decorator.js";
-import { Provider, RpcSchema } from "ox";
-import type {
-  WalletServerRpcSchemaType,
-  WalletServerViemRpcSchema,
-} from "@alchemy/wallet-api-types/rpc";
+import type { WalletServerViemRpcSchema } from "@alchemy/wallet-api-types/rpc";
 import { internalStateDecorator } from "../internal/decorator.js";
 import { metrics } from "../metrics.js";
 
@@ -86,18 +81,19 @@ export function createSmartWalletClient(
       ? params.policyIds
       : undefined;
 
+  // Pass the Alchemy transport through directly. Do not wrap with
+  // `custom(Provider.from(...))`: ox `parseError` rewrites AA codes like
+  // `-32521` to `-32603`, and the outer `custom()` then retries them with
+  // viem's default `retryCount=3` (4 identical wallet_prepareCalls).
+  // Typing for `client.request` comes from `WalletServerViemRpcSchema`.
+  // Retries stay on `alchemy({ retryCount })` (default 0).
   const innerClient = createClient<
     Transport,
     Chain,
     JsonRpcAccount<Address> | undefined,
     WalletServerViemRpcSchema
   >({
-    transport: (opts) =>
-      custom(
-        Provider.from(transport(opts), {
-          schema: RpcSchema.from<WalletServerRpcSchemaType>(),
-        }),
-      )(opts),
+    transport,
     chain,
     account,
   }).extend(() => ({

--- a/account-kit/wallet-client/vitest.config.ts
+++ b/account-kit/wallet-client/vitest.config.ts
@@ -1,12 +1,14 @@
-import { defineProject } from "vitest/config";
+import { configDefaults, defineProject } from "vitest/config";
 
 // Stub unit tests only (e2e lives in *.e2e.test.ts and runs via bun).
-// Intentionally skip sharedConfig so we do not pull in anvil/rundler setup.
+// Intentionally skip sharedConfig so we do not pull in anvil/rundler setup,
+// but keep Vitest's default excludes (node_modules, dist, etc.).
 export default defineProject({
   test: {
     name: "account-kit/wallet-client",
     globals: true,
     exclude: [
+      ...configDefaults.exclude,
       "**/e2e-tests/**/*.test.ts",
       "**/*.test.e2e.ts",
       "**/*.e2e.test.ts",

--- a/account-kit/wallet-client/vitest.config.ts
+++ b/account-kit/wallet-client/vitest.config.ts
@@ -1,12 +1,15 @@
-import { defineProject, mergeConfig } from "vitest/config";
-import { sharedConfig } from "../../.vitest/vitest.shared";
+import { defineProject } from "vitest/config";
 
-export default mergeConfig(
-  // @ts-ignore this does work
-  sharedConfig,
-  defineProject({
-    test: {
-      name: "account-kit/wallet-client",
-    },
-  }),
-);
+// Stub unit tests only (e2e lives in *.e2e.test.ts and runs via bun).
+// Intentionally skip sharedConfig so we do not pull in anvil/rundler setup.
+export default defineProject({
+  test: {
+    name: "account-kit/wallet-client",
+    globals: true,
+    exclude: [
+      "**/e2e-tests/**/*.test.ts",
+      "**/*.test.e2e.ts",
+      "**/*.e2e.test.ts",
+    ],
+  },
+});

--- a/docs/pages/reference/account-kit/wallet-client/src/exports/functions/createSmartWalletClient.mdx
+++ b/docs/pages/reference/account-kit/wallet-client/src/exports/functions/createSmartWalletClient.mdx
@@ -11,7 +11,7 @@ layout: reference
 function createSmartWalletClient<TAccount>(params): SmartWalletClient<TAccount>;
 ```
 
-Defined in: [account-kit/wallet-client/src/client/index.ts:74](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/wallet-client/src/client/index.ts#L74)
+Defined in: [account-kit/wallet-client/src/client/index.ts:69](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/wallet-client/src/client/index.ts#L69)
 
 Creates a smart wallet client that can be used to interact with a smart account.
 

--- a/docs/pages/reference/account-kit/wallet-client/src/exports/type-aliases/SmartWalletClient.mdx
+++ b/docs/pages/reference/account-kit/wallet-client/src/exports/type-aliases/SmartWalletClient.mdx
@@ -13,7 +13,7 @@ type SmartWalletClient<TAccount> = InnerWalletApiClientBase<
 >;
 ```
 
-Defined in: [account-kit/wallet-client/src/client/index.ts:41](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/wallet-client/src/client/index.ts#L41)
+Defined in: [account-kit/wallet-client/src/client/index.ts:36](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/wallet-client/src/client/index.ts#L36)
 
 ## Type Parameters
 

--- a/docs/pages/reference/account-kit/wallet-client/src/exports/type-aliases/SmartWalletClientParams.mdx
+++ b/docs/pages/reference/account-kit/wallet-client/src/exports/type-aliases/SmartWalletClientParams.mdx
@@ -19,7 +19,7 @@ type SmartWalletClientParams<TAccount> = Prettify<object &
 }>;
 ```
 
-Defined in: [account-kit/wallet-client/src/client/index.ts:27](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/wallet-client/src/client/index.ts#L27)
+Defined in: [account-kit/wallet-client/src/client/index.ts:22](https://github.com/alchemyplatform/aa-sdk/blob/main/account-kit/wallet-client/src/client/index.ts#L22)
 
 ## Type Parameters
 


### PR DESCRIPTION
## Summary

On v4 `createSmartWalletClient`, wrapping the Alchemy transport in `custom(Provider.from(...))` rewrote AA execution-revert codes like `-32521` to `-32603` (ox `parseError` fallthrough) and then retried them with viem's default outer `retryCount=3`. One failed `wallet_prepareCalls` became four identical requests and the app lost `revertData`. This PR removes that sandwich so the Alchemy transport is passed straight to `createClient`, matching the v5 `@alchemy/wallet-apis` shape.

## Key Changes

- Pass `transport` directly into `createClient` in `account-kit/wallet-client/src/client/index.ts` (drop `custom` / ox `Provider.from`)
- Keep request typing via `WalletServerViemRpcSchema`
- Add a stub unit test that throws `RpcRequestError` with `code: -32521` + `data.revertData` and asserts one request plus preserved code/data
- Point wallet-client vitest at stub-only setup (no anvil/rundler), while keeping `...configDefaults.exclude` plus the e2e exclude patterns
- Refresh typedoc `Defined in` line numbers for the wallet-client exports touched by the import cleanup

## Technical Details

- Retries remain on `alchemy({ retryCount })` (default `0`). The bug was a second `withRetry` from the outer `custom()` layer, not Alchemy's transport
- `Provider.from({ schema })` was type glue only. Runtime typing for `client.request` still comes from `WalletServerViemRpcSchema`
- Not a breaking API change for callers of `createSmartWalletClient`
- v5 / `@alchemy/wallet-apis` already omits this wrapper and is unaffected

## Acceptance Criteria

- [x] `createSmartWalletClient` does not wrap the Alchemy transport in `custom(Provider.from(...))`
- [x] A `-32521` with `revertData` is returned to the caller without rewrite to `-32603`
- [x] A single failing `wallet_prepareCalls` does not become four identical requests when Alchemy `retryCount` is `0`
- [x] Stub unit test covers request count + error fidelity for `-32521` (and a real `-32603` does not get amplified)

## Testing

### How to re-run

```bash
cd account-kit/wallet-client
../../node_modules/.bin/vitest run --config ./vitest.config.ts src/client/createSmartWalletClient.test.ts
```

### Local validation

- [x] `createSmartWalletClient` does not wrap the Alchemy transport in `custom(Provider.from(...))`
- [x] A `-32521` with `revertData` is returned to the caller without rewrite to `-32603`
- [x] A single failing `wallet_prepareCalls` does not become four identical requests when Alchemy `retryCount` is `0`
- [x] Stub unit test covers request count + error fidelity for `-32521` (and a real `-32603` does not get amplified)

```text
$ ../../node_modules/.bin/vitest run --config ./vitest.config.ts src/client/createSmartWalletClient.test.ts

 ✓ |account-kit/wallet-client| src/client/createSmartWalletClient.test.ts (2 tests) 15ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

No live Cronos / wallet-server smoke in this PR. The AC surface is SDK error fidelity, covered by the counting stub transport (same fingerprint Athanor saw as a 4-burst on team 220).

## Linear Task
[ENG-86](https://linear.app/alchemyapi/issue/ENG-86/medcryptocom-retry-count-handling-in-viem-with-alchemy-sdk)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating type definitions and improving the configuration for the `createSmartWalletClient` functionality, alongside adding tests to ensure error fidelity when interacting with the smart wallet client.

### Detailed summary
- Updated definitions in documentation for `SmartWalletClient` and `SmartWalletClientParams` to reflect changes in `index.ts`.
- Revised `createSmartWalletClient` to simplify transport handling.
- Removed the use of `sharedConfig` in `vitest.config.ts` and added custom test exclusions.
- Added unit tests for `createSmartWalletClient` to verify error handling and request counting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->